### PR TITLE
Update serial.py to include higher baud rates

### DIFF
--- a/rayforge/machine/transport/serial.py
+++ b/rayforge/machine/transport/serial.py
@@ -143,6 +143,9 @@ class SerialTransport(Transport):
             115200,
             230400,
             460800,
+            921600,
+            1000000,
+            1843200
         ]
 
     def __init__(self, port: str, baudrate: int):


### PR DESCRIPTION
Update serial.py to include higher baud rates. Specifically, the baud rate of 1,000,000 for Monport Mega 70w laser which uses this baud rate.