### PR TITLE
Resolve flatpak linting errors

### DIFF
--- a/data/com.barebaric.rayforge.metainfo.xml
+++ b/data/com.barebaric.rayforge.metainfo.xml
@@ -39,7 +39,8 @@
     <display_length compare="ge">768</display_length>
   </recommends>
 
-  <icon type="local">com.barebaric.rayforge.svg</icon>
+  <icon type="remote">https://raw.githubusercontent.com/barebaric/rayforge/refs/heads/main/data/com.barebaric.rayforge.svg</icon>
+
 
   <branding>
     <color type="primary" scheme_preference="light">#efb0a1</color>

--- a/data/com.barebaric.rayforge.metainfo.xml
+++ b/data/com.barebaric.rayforge.metainfo.xml
@@ -39,9 +39,6 @@
     <display_length compare="ge">768</display_length>
   </recommends>
 
-  <icon type="remote">https://raw.githubusercontent.com/barebaric/rayforge/refs/heads/main/data/com.barebaric.rayforge.svg</icon>
-
-
   <branding>
     <color type="primary" scheme_preference="light">#efb0a1</color>
     <color type="primary" scheme_preference="dark">#373f43</color>
@@ -50,7 +47,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main window of Rayforge.</caption>
-      <image type="source" width="1462" height="1209">https://raw.githubusercontent.com/barebaric/rayforge/main/docs/ss-main.png</image>
+      <image width="1462" height="1209">https://raw.githubusercontent.com/barebaric/rayforge/main/docs/ss-main.png</image>
     </screenshot>
   </screenshots>
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -3,12 +3,12 @@ This is Flathub package of [Rayforge](https://github.com/barebaric/rayforge).
 
 ## Building
 This package can be built locally by running
-´´´
-flatpak run org.flatpak.Builder --force-clean --sandbox --user --ccache --install-deps-from=flathub --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo builddir com.barebaric.rayforge.yml
+```
+flatpak run org.flatpak.Builder --force-clean --sandbox --user --ccache --install-deps-from=flathub --repo=repo builddir com.barebaric.rayforge.yml
 flatpak build-bundle repo rayforge.flatpak com.barebaric.rayforge
-´´´
+```
 
 ## Installation
-´´´
+```
 flatpak --user install repo rayforge.flatpak
-´´´
+```

--- a/flatpak/com.barebaric.rayforge.yml
+++ b/flatpak/com.barebaric.rayforge.yml
@@ -26,6 +26,9 @@ modules:
   - name: rayforge
     buildsystem: simple
     build-commands:
+      - install -Dm644 data/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 data/${FLATPAK_ID}.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 data/${FLATPAK_ID}.metainfo.xml /app/share/appdata/${FLATPAK_ID}.metainfo.xml
       - pip3 install --prefix=/app --no-deps --no-build-isolation .
     sources:
       - type: git 

--- a/flatpak/com.barebaric.rayforge.yml
+++ b/flatpak/com.barebaric.rayforge.yml
@@ -26,11 +26,11 @@ modules:
   - name: rayforge
     buildsystem: simple
     build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation .
+    post-install:
       - install -Dm644 data/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 data/${FLATPAK_ID}.desktop /app/share/applications/${FLATPAK_ID}.desktop
-      - install -Dm644 data/${FLATPAK_ID}.metainfo.xml /app/share/appdata/${FLATPAK_ID}.metainfo.xml
-      - pip3 install --prefix=/app --no-deps --no-build-isolation .
     sources:
       - type: git 
         url: https://github.com/barebaric/rayforge.git
-        tag: "0.22"
+        branch: main

--- a/flatpak/com.barebaric.rayforge.yml
+++ b/flatpak/com.barebaric.rayforge.yml
@@ -11,7 +11,6 @@ finish-args:
   - --device=all
   - --env=DISPLAY=:0
   - --share=network
-  - --talk-name=org.freedesktop.DBus
 
 modules:
   - python3-meson-python.yml   # This is a numpy/scipy requirement

--- a/flatpak/python3-pypotrace.yml
+++ b/flatpak/python3-pypotrace.yml
@@ -18,7 +18,7 @@ modules:
         sources:
           - type: archive
             url: https://potrace.sourceforge.net/download/1.16/potrace-1.16.tar.gz
-            sha1: 256b4fb858c66bc38117afde7c722016d2e265f3
+            sha256: be8248a17dedd6ccbaab2fcc45835bb0502d062e40fbded3bc56028ce5eb7acc
       - name: agg
         buildsystem: cmake-ninja
         builddir: true

--- a/flatpak/python3-requirements.yml
+++ b/flatpak/python3-requirements.yml
@@ -330,3 +330,11 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/5d/29/1c93c94a2289675ba2ff898612f9c9a03f46d69f253bdf4da0dfc08a599d/svgelements-1.9.6.tar.gz
         sha256: 7c02ad6404cd3d1771fd50e40fbfc0550b0893933466f86a6eb815f3ba3f37f7
+  - name: python3-pyclipper
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pyclipper~=1.3.0.post6" --no-build-isolation --use-deprecated=legacy-resolver
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/4a/b2/550fe500e49c464d73fabcb8cb04d47e4885d6ca4cfc1f5b0a125a95b19a/pyclipper-1.3.0.post6.tar.gz
+        sha256: 42bff0102fa7a7f2abdd795a2594654d62b786d0c6cd67b72d469114fdeb608c


### PR DESCRIPTION
**Remove Icon from appstream:**
There doesn't seem to be a way to set icon in the appstream without the linter complaining, removing it and instead adding a "post-install" phase seems to work.

**Change branch to build from main:**
There's a bit of causality problem, the appstream is currently broken so in order to get a working appstream when building the image the branch needs to point to main.. which will be this commit once it merges. Once a new release tag is available we can move to tracking that.

**Add pyclipper dependency**

**Minor cleanups**