### PR TITLE
normalize frame power to 0.0-1.0 range in frame job operation

### DIFF
--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -57,8 +57,10 @@ class MachineCmd:
                     self._editor.ops_generator,
                     context,
                 )
+                # Normalize frame_power (0-1000 scale) to 0.0-1.0 range
+                normalized_power = head.frame_power / head.max_power
                 frame = ops.get_frame(
-                    power=head.frame_power,
+                    power=normalized_power,
                     speed=machine.max_travel_speed,
                 )
                 # The frame op is a single pass; repeat it for visibility.

--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -63,6 +63,12 @@ class MachineCmd:
                     power=normalized_power,
                     speed=machine.max_travel_speed,
                 )
+                # Prepend the laser selection command at the beginning
+                from ..core.ops import Ops
+                frame_with_laser = Ops()
+                frame_with_laser.set_laser(head.uid)
+                frame_with_laser += frame
+                frame = frame_with_laser
                 # The frame op is a single pass; repeat it for visibility.
                 frame *= 20
                 await machine.driver.run(frame, machine, self._editor.doc)


### PR DESCRIPTION
Fix for this issue: https://github.com/barebaric/rayforge/issues/45

The frame job was failing because:
Power out of range: head.frame_power is stored as an integer (0-1000 for GRBL), but SetPowerCommand expects a normalized value (0.0-1.0). Fixed by dividing by head.max_power before passing to get_frame().
No active laser head: The encoder requires an active laser to be set before processing line commands. Fixed by creating a new Ops object with set_laser(head.uid) first, then appending the frame operations to it. This ensures the SetLaserCommand appears before the movement commands in the operation sequence.
The changes were made in [rayforge/machine/cmd.py:60-71]


TODO:
[  ] - Add a test that fails before this change and passes after. 
