### PR TITLE
Improve motion when engraving small vectors over serial

### DIFF
--- a/rayforge/machine/driver/grbl_serial.py
+++ b/rayforge/machine/driver/grbl_serial.py
@@ -276,9 +276,6 @@ class GrblSerialDriver(Driver):
                             )
                             self._job_running = False
 
-                # Release lock briefly to allow status polling
-                await asyncio.sleep(0.1)
-
             except asyncio.CancelledError:
                 logger.info("Command queue processing cancelled.")
                 break


### PR DESCRIPTION
Noticed the engraver would start shaking when engraving small vectors. It turned out that the engraved is starved of commands if the time taken to process was lower than ~0.1.

Not a 100% sure about this but is seems to work fine when testing. Happy to provide logs if needed.

Why I think this works: Both the command processing and connection monitoring call `async with _lock` which should cause them to wait for the lock to become available. As soon as one has finished it will yield when trying to reacquire the lock
https://github.com/barebaric/rayforge/blob/6a2111ac48213f5fbcb8cc09d0a723e55c6c318b/rayforge/machine/driver/grbl_serial.py#L177-L179

https://github.com/barebaric/rayforge/blob/6a2111ac48213f5fbcb8cc09d0a723e55c6c318b/rayforge/machine/driver/grbl_serial.py#L229-L231

Alternatively having a lower sleep time will also help
