### PR TITLE
Update appdata for Flathub linting

### DIFF
--- a/data/com.barebaric.rayforge.metainfo.xml
+++ b/data/com.barebaric.rayforge.metainfo.xml
@@ -39,7 +39,7 @@
     <display_length compare="ge">768</display_length>
   </recommends>
 
-  <icon type="local">com.barebaric.rayforge.svg</icon>
+  <icon type="remote">https://raw.githubusercontent.com/barebaric/rayforge/refs/heads/main/data/com.barebaric.rayforge.svg</icon>
 
   <branding>
     <color type="primary" scheme_preference="light">#efb0a1</color>
@@ -49,7 +49,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main window of Rayforge.</caption>
-      <image type="source" width="1462" height="1209">https://raw.githubusercontent.com/barebaric/rayforge/main/docs/ss-main.png</image>
+      <image type="source" width="1462" height="1209">https://raw.githubusercontent.com/barebaric/rayforge/main/website/content/docs/images/ss-main.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Sorry for labouring this for too long. There's been a problem with screenshot and icon mirroring at flathub but resolved with a changes to the build command

From what I can test this fixes all linting errors but I'm not sure if this works with Snap.

Further on after this is merged I we should be able to run the pipeline and then commit the updated manifest