### PR TITLE
Improve scaling behavior

### DIFF
--- a/rayforge/doceditor/editor.py
+++ b/rayforge/doceditor/editor.py
@@ -83,6 +83,9 @@ class DocEditor:
             self._on_processing_state_changed
         )
 
+        # Global preference for maintaining aspect ratio during transforms.
+        self.aspect_ratio_locked: bool = True
+
         # Instantiate and link command handlers, passing dependencies.
         self.asset = AssetCmd(self)
         self.edit = EditCmd(self)

--- a/rayforge/doceditor/ui/item_properties.py
+++ b/rayforge/doceditor/ui/item_properties.py
@@ -99,7 +99,7 @@ class DocItemPropertiesWidget(Expander):
 
         # Fixed Ratio Switch
         self.fixed_ratio_switch = Adw.SwitchRow(
-            title=_("Fixed Ratio"), active=True
+            title=_("Fixed Ratio"), active=self.editor.aspect_ratio_locked
         )
         self.fixed_ratio_switch.connect(
             "notify::active", self._on_fixed_ratio_toggled
@@ -415,7 +415,10 @@ class DocItemPropertiesWidget(Expander):
             self._in_update = False
 
     def _on_fixed_ratio_toggled(self, switch_row, GParamSpec):
+        if self._in_update:
+            return
         logger.debug(f"Fixed ratio toggled: {switch_row.get_active()}")
+        self.editor.aspect_ratio_locked = switch_row.get_active()
         # Check if the primary selected item is a workpiece or stock item
         is_ratio_lockable = self.items and isinstance(
             self.items[0], (WorkPiece, StockItem, Group)
@@ -704,6 +707,10 @@ class DocItemPropertiesWidget(Expander):
         is_single_item_with_size = (
             is_single_workpiece or is_single_stockitem or is_single_group
         )
+
+        self._in_update = True
+        self.fixed_ratio_switch.set_active(self.editor.aspect_ratio_locked)
+        self._in_update = False
 
         self.source_file_row.set_visible(is_single_workpiece)
         self.fixed_ratio_switch.set_sensitive(

--- a/rayforge/workbench/canvas/multiselect.py
+++ b/rayforge/workbench/canvas/multiselect.py
@@ -246,7 +246,7 @@ class MultiSelectionGroup:
         offset_y: float,
         active_origin: Tuple[float, float, float, float],
         ctrl_pressed: bool,
-        shift_pressed: bool,
+        constrain_aspect: bool,
     ):
         """
         Calculates and applies the new group bounding box by calling the
@@ -267,7 +267,7 @@ class MultiSelectionGroup:
             active_region=active_region,
             drag_delta=(offset_x, offset_y),
             is_flipped=self.canvas.view_transform.is_flipped(),
-            constrain_aspect=shift_pressed,
+            constrain_aspect=constrain_aspect,
             from_center=ctrl_pressed,
             min_size=min_size_world,
         )

--- a/rayforge/workbench/canvas/transform.py
+++ b/rayforge/workbench/canvas/transform.py
@@ -129,7 +129,7 @@ def resize_element(
     initial_world_transform: Matrix,
     active_region: ElementRegion,
     view_transform: Matrix,
-    shift_pressed: bool,
+    constrain_aspect: bool,
     ctrl_pressed: bool,
 ):
     """
@@ -156,7 +156,7 @@ def resize_element(
         active_region=active_region,
         drag_delta=local_delta,
         is_flipped=view_transform.is_flipped(),  # Pass the flag
-        constrain_aspect=shift_pressed,
+        constrain_aspect=constrain_aspect,
         from_center=ctrl_pressed,
         min_size=min_size_local,
     )

--- a/rayforge/workbench/surface.py
+++ b/rayforge/workbench/surface.py
@@ -91,6 +91,11 @@ class WorkSurface(WorldSurface):
         self.edit_sketch_requested = Signal()
         self.edit_stock_item_requested = Signal()
 
+        # Aspect-ratio lock preference shared with the properties panel.
+        self.editor.aspect_ratio_locked = (
+            getattr(self.editor, "aspect_ratio_locked", True) is True
+        )
+
         # Connect to generic signals from the base Canvas class
         self.move_begin.connect(self._on_any_transform_begin)
         self.resize_begin.connect(self._on_resize_begin)
@@ -119,6 +124,17 @@ class WorkSurface(WorldSurface):
     def show_travel_moves(self) -> bool:
         """Returns True if travel moves should be rendered."""
         return self._show_travel_moves
+
+    def _get_ratio_lock_default(self) -> bool:
+        """
+        Returns the current aspect-ratio lock preference shared with the
+        properties panel. Defaults to True for workpieces.
+        """
+        return bool(getattr(self.editor, "aspect_ratio_locked", True))
+
+    def set_aspect_ratio_locked(self, locked: bool) -> None:
+        """Synchronizes the lock state with the editor."""
+        self.editor.aspect_ratio_locked = locked
 
     def set_laser_dot_visible(self, visible: bool = True) -> None:
         self._laser_dot.set_visible(visible)


### PR DESCRIPTION
While working on the [macOS support ](https://github.com/barebaric/rayforge/issues/70) I feel like the scaling behavior is not natural so this is what I did:

- Corner handles honor the “Fixed Ratio” preference by default; holding `Shift` inverts that preference (locked → freeform, freeform → locked).
- Edge (side) handles always do non-proportional scaling, regardless of `Shift` or the "Fixed Ratio" toggle.
- The "Fixed Ratio" toggle in the properties panel now shares its state with the 2D canvas so both UI and drag interactions stay consistent.

Try it and let me know if you like it 😄