### PR TITLE
Update metainfo

### DIFF
--- a/data/org.rayforge.rayforge.metainfo.xml
+++ b/data/org.rayforge.rayforge.metainfo.xml
@@ -5,8 +5,9 @@
     <name translate="no">Samuel Abels</name>
   </developer>
   <content_rating type="oars-1.1" />
-  <url type="homepage">https://github.com/barebaric/rayforge</url>
+  <url type="homepage">https://rayforge.org</url>
   <url type="bugtracker">https://github.com/barebaric/rayforge/issues</url>
+  <url type="vcs-browser">https://github.com/barebaric/rayforge</url>
   
   <name>Rayforge</name>
   <summary>A desktop application for laser cutting and engraving</summary>


### PR DESCRIPTION
Flathub has started [requesting](https://github.com/flathub/org.rayforge.rayforge/pull/8#issuecomment-3736095563) a `vcs-browser` tag to link to source repository. So far just a warning but could become an error in the future.

Also updated the homepage