### PR TITLE
Replace mimetype with provides/mediatype tags

### DIFF
--- a/data/org.rayforge.rayforge.metainfo.xml
+++ b/data/org.rayforge.rayforge.metainfo.xml
@@ -34,16 +34,16 @@
   
   <launchable type="desktop-id">org.rayforge.rayforge.desktop</launchable>
 
-  <mimetypes>
-    <mimetype>application/x-rayforge-project</mimetype>
-    <mimetype>application/x-rayforge-sketch</mimetype>
-    <mimetype>application/x-ruida</mimetype>
-    <mimetype>image/png</mimetype>
-    <mimetype>image/bmp</mimetype>
-    <mimetype>image/jpeg</mimetype>
-    <mimetype>image/svg+xml</mimetype>
-    <mimetype>image/vnd.dxf</mimetype>
-  </mimetypes>
+  <provides>
+    <mediatype>application/x-rayforge-project</mediatype>
+    <mediatype>application/x-rayforge-sketch</mediatype>
+    <mediatype>application/x-ruida</mediatype>
+    <mediatype>image/png</mediatype>
+    <mediatype>image/bmp</mediatype>
+    <mediatype>image/jpeg</mediatype>
+    <mediatype>image/svg+xml</mediatype>
+    <mediatype>image/vnd.dxf</mediatype>
+  </provides>
 
   <recommends>
     <control>keyboard</control>


### PR DESCRIPTION
Flathub fails validation, despite it being described as deprecated. :shrug: 

``Appstream: 'E:org.rayforge.rayforge.metainfo.xml:mimetypes-tag-deprecated:37 The toplevel `mimetypes` tag is deprecated. Please use `mediatype` tags in a `provides` block instead to indicate that your software provides a media handler for the given types.'``