### PR TITLE
Flexible toolbar layout

### DIFF
--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -186,6 +186,9 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             self.set_default_size(1100, 800)
 
+        # Callback on window width change
+        self.connect("notify::default-width", self._on_width_changed)
+
         # HeaderBar with left-aligned menu and centered title
         self.header_bar = Adw.HeaderBar()
         vbox.append(self.header_bar)
@@ -532,6 +535,9 @@ class MainWindow(Adw.ApplicationWindow):
 
         # Trigger startup tasks when window is shown
         self.connect("map", self._trigger_startup_tasks)
+
+    def _on_width_changed(self, widget, param):
+        self.toolbar._on_width_changed(widget, param)
 
     def _trigger_startup_tasks(self, widget):
         """


### PR DESCRIPTION
Discussed in #135, the toolbar currently sets the minimum width of the application. I'm not convinced this is the best way to solve but I wanted to give Gemini CLI a go (it didn't do that well), anyhow

This collapses the machine controls when the UI is narrowed down.

From 
<img width="1031" height="104" alt="image" src="https://github.com/user-attachments/assets/8de284c7-8f67-49c7-8805-0c8e0db3fa2c" />

To

<img width="1060" height="433" alt="image" src="https://github.com/user-attachments/assets/9320b702-0ca5-4298-8c55-906e449a0af1" />


The two issues I see are, machine controls are the most useful buttons (IMO) and making them less accessible is disservice to the user, secondly the "trigger" is based on a fixed width, ~1400px which is always a poor choice as it would have to be updated any time buttons change.

What could be interesting to discuss in case

1. What buttons should be grouped and hid when width is narrowed down
2. How can the toolbar manage its width to decide if it needs to collapse to fit the window.