### PR TITLE
Handle handshake timeout with sleeping backoff in GRBL connection loop

### DIFF
--- a/rayforge/machine/driver/grbl_serial.py
+++ b/rayforge/machine/driver/grbl_serial.py
@@ -325,6 +325,8 @@ class GrblSerialDriver(Driver):
                         TransportStatus.ERROR,
                         _("No response from device"),
                     )
+                    self._update_connection_status(TransportStatus.SLEEPING)
+                    await asyncio.sleep(5)
                     continue
 
                 logger.info("Connection established successfully.")


### PR DESCRIPTION
Hi!

While working on the macOS CI I fixed an annoying issue (I don't know if it only affects macOS builds...): there are always 2 open tasks that never close:

<img width="1339" height="807" alt="Screenshot 2026-02-24 at 10 08 01" src="https://github.com/user-attachments/assets/5cfcdf3e-e381-4eca-966a-62874d12cd81" />

So the fix improves the GRBL serial connection retry behavior when a port is open but no device responds to the initial handshake.

## What was happening
On handshake timeout (`"?"` probe), the driver disconnected and immediately retried the connection loop. This could cause tight retry cycles on phantom or disconnected serial ports.

## What changed
- After setting `TransportStatus.ERROR` for handshake timeout, the driver now:
  - sets `TransportStatus.SLEEPING`
  - waits 5 seconds before retrying

## Why
This aligns timeout handling with the existing reconnect backoff behavior and avoids aggressive reconnect attempts.


So, does it make sense to you?