### PR TITLE
macOS: fallback shader program compile without validation on macOS

### DIFF
--- a/rayforge/ui_gtk/canvas3d/gl_utils.py
+++ b/rayforge/ui_gtk/canvas3d/gl_utils.py
@@ -47,6 +47,17 @@ class Shader:
                 shaders.compileShader(vertex_source, GL.GL_VERTEX_SHADER),
                 shaders.compileShader(fragment_source, GL.GL_FRAGMENT_SHADER),
             )
+        except shaders.ShaderValidationError as e:
+            logger.warning(
+                "Shader validation failed during program creation; "
+                "retrying without validation: %s",
+                e,
+            )
+            self.program = shaders.compileProgram(
+                shaders.compileShader(vertex_source, GL.GL_VERTEX_SHADER),
+                shaders.compileShader(fragment_source, GL.GL_FRAGMENT_SHADER),
+                validate=False,
+            )
         except Exception as e:
             logger.error(f"Shader Compilation Failed: {e}", exc_info=True)
             raise


### PR DESCRIPTION
### Summary
This PR improves 3D canvas initialization robustness on macOS by handling early shader validation failures.

### Problem
On some macOS/OpenGL contexts, shader program creation fails during validation with:
- `ShaderValidationError: Current draw framebuffer is invalid`

This can happen when validation runs before a valid draw framebuffer is available, causing 3D initialization to fail.

### Change
In `rayforge/ui_gtk/canvas3d/gl_utils.py`:
- Keep the normal shader compile/link path.
- If `ShaderValidationError` occurs, retry `compileProgram(..., validate=False)`.

### Impact
- Prevents 3D initialization failure in affected macOS contexts.
- Preserves normal behavior when validation succeeds.
- Scoped to shader initialization; no changes to 2D pipeline or artifact generation.
