### PR TITLE
macOS: shorten shared-memory creator tags for step artifacts on macOS

### DIFF
--- a/rayforge/pipeline/stage/step_runner.py
+++ b/rayforge/pipeline/stage/step_runner.py
@@ -101,7 +101,7 @@ def make_step_artifact_in_subprocess(
 
     # 1. Store Render Artifact
     render_handle = artifact_store.put(
-        render_artifact, creator_tag=f"{creator_tag}_render"
+        render_artifact, creator_tag=f"{creator_tag}_r"
     )
 
     # Inter-process handoff: Send handle to main process and wait for adoption.
@@ -124,7 +124,7 @@ def make_step_artifact_in_subprocess(
 
     # 2. Store Ops Artifact
     ops_handle = artifact_store.put(
-        ops_artifact, creator_tag=f"{creator_tag}_ops"
+        ops_artifact, creator_tag=f"{creator_tag}_o"
     )
 
     # Inter-process handoff: Send handle to main process and wait for adoption.


### PR DESCRIPTION
### Summary
This PR fixes a macOS runtime failure when creating shared-memory artifacts for step assembly (Intel, Apple Silicon, and universal builds).

### Problem
Step artifact creation used creator tags that produced shared-memory names like `rf_step_render_*`, which can exceed the POSIX shared-memory name limit on macOS. This caused:
- `OSError: [Errno 63] File name too long`
- step assembly failures
- downstream preview/simulation errors (`Job dependencies are not ready`)

### Change
In `rayforge/pipeline/stage/step_runner.py`, creator tags were shortened:
- `step_render` -> `step_r`
- `step_ops` -> `step_o`

### Impact
- Prevents shared-memory name overflow on macOS.
- Stabilizes step assembly and preview/simulation flow.
- Runtime-only fix; no functional change to toolpath/ops logic.
