### PR TITLE
macOS fix(tasker): defer DictProxy type annotations to prevent startup crash

### DIFF
--- a/rayforge/shared/tasker/pool.py
+++ b/rayforge/shared/tasker/pool.py
@@ -3,6 +3,8 @@ Defines the WorkerPoolManager, a class for managing a pool of long-lived
 worker processes to execute tasks efficiently.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import threading


### PR DESCRIPTION
Fixed a (macOS only?) startup crash caused by runtime evaluation of `DictProxy[...]` type hints in `tasker/pool.py`.

Adding `from __future__ import annotations` defers annotation evaluation, so imports no longer fail with `TypeError: type 'DictProxy' is not subscriptable`.
