### PR TITLE
Fix missing laser toolpaths in macOS app bundle by packaging built-in addons

### DIFF
--- a/Rayforge.spec
+++ b/Rayforge.spec
@@ -6,6 +6,7 @@ from PyInstaller.utils.hooks import collect_submodules
 hiddenimports = ['gi._gi_cairo', 'cairosvg']
 hiddenimports += collect_submodules('rayforge.ui_gtk.canvas2d')
 hiddenimports += collect_submodules('rayforge.ui_gtk.canvas2d.elements')
+hiddenimports += collect_submodules('rayforge.ui_gtk.shared')
 hiddenimports += collect_submodules('rayforge.image')
 hiddenimports.append('rayforge.ui_gtk.canvas2d.elements.workpiece')
 


### PR DESCRIPTION
## Summary
This fixes a series of macOS app bundle packaging gaps that prevented the
built-in laser addon from loading completely.

The initial issue was that Rayforge launched and opened files, but no laser
toolpaths were generated or displayed. After investigating startup logs,
the root cause turned out to be incomplete packaging of built-in addons and
their runtime dependencies inside the macOS PyInstaller bundle.

This PR updates the macOS bundle to include:

- built-in addons under `rayforge/builtin_addons`
- dynamically imported image modules under `rayforge.image`
- shared GTK UI modules under `rayforge.ui_gtk.shared`

These are all required for the built-in `laser_essentials` addon to load
both its backend and frontend successfully.

## Problems observed
Startup logs showed several clear failures across iterations:

- `No step factories found in registry`
- `Error importing addon laser_essentials: No module named 'rayforge.image.dither'`
- `Error importing addon laser_essentials: No module named 'rayforge.ui_gtk.shared.direction_preview'`

Those failures explain the behavior seen in the packaged app:

- Rayforge could start normally
- projects and SVGs could open
- `Contour` could eventually become available after partial fixes
- but `Rasterizer` remained unavailable because the addon frontend still
  could not import its widget dependencies

## Root cause
The built-in laser addon was present in source, but the macOS bundle did
not initially include everything PyInstaller needed for runtime imports.

Specifically:

1. `laser_essentials` itself was missing from the bundle at first because
   `rayforge/builtin_addons` was not packaged.
2. After that was fixed, the addon backend still failed because
   `rayforge.image.dither` was not bundled.
3. After that was fixed, the addon frontend still failed because shared UI
   helpers such as `rayforge.ui_gtk.shared.direction_preview` were not
   bundled.

Because addon loading is split between backend and frontend registration,
partial import success led to partial functionality:
- laser steps like `Contour` could appear
- raster-related UI components like `Rasterizer` could still be missing
