### PR TITLE
Wire macOS app menu About, Settings, and Quit actions

### DIFF
--- a/rayforge/app.py
+++ b/rayforge/app.py
@@ -164,10 +164,14 @@ def main():
                 self.add_action(action)
 
         def _get_main_window(self):
+            from rayforge.ui_gtk.mainwindow import MainWindow
+
             window = self.get_active_window()
-            if window is not None:
+            if isinstance(window, MainWindow):
                 return window
-            return self.win
+            if isinstance(self.win, MainWindow):
+                return self.win
+            return None
 
         def _on_app_about(self, action, param):
             window = self._get_main_window()


### PR DESCRIPTION
On macOS, the global application menu still exposed the standard `About`,
`Preferences`, and `Quit` entries, but they were not wired to the same actions
used by Rayforge's in-window menu:

<img width="449" height="445" alt="Screenshot 2026-03-09 at 16 35 35" src="https://github.com/user-attachments/assets/dbd2c7c5-5b74-4f47-aceb-bc7cd1690850" />

This change adds application-level actions
for `app.about`, `app.preferences`, and `app.quit` in
[rayforge/app.py](/Users/pablo/GitHub/rayforge/rayforge/app.py) and forwards
them to the active main window so the existing UI flows are reused.

As a result, `Rayforge > About Rayforge` now opens the same dialog as
`Help > About`, `Rayforge > Quit` exits through the same path as the main
window, and `Rayforge > Preferences` is handled as `Settings` on macOS and
opens the same window as `Edit > Settings`. The related keyboard accelerators
were also moved to the `app.*` action namespace, which is the correct scope for
the native macOS application menu.
