### PR TITLE
Per-layer Work Coordinate System (WCS) support

### DIFF
--- a/rayforge/core/layer.py
+++ b/rayforge/core/layer.py
@@ -55,6 +55,7 @@ class Layer(DocItem):
         self.rotary_diameter: float = 25.0
         self.rotary_module_uid: Optional[str] = None
         self.color: str = self.DEFAULT_COLOR
+        self.wcs: Optional[str] = None
 
         # Signals for notifying other parts of the application of changes.
         # This one is special and is bubbled manually.
@@ -79,6 +80,7 @@ class Layer(DocItem):
             "rotary_diameter": self.rotary_diameter,
             "rotary_module_uid": self.rotary_module_uid,
             "color": self.color,
+            "wcs": self.wcs,
             "children": [child.to_dict() for child in self.children],
         }
         result.update(self.extra)
@@ -97,6 +99,7 @@ class Layer(DocItem):
             "rotary_diameter",
             "rotary_module_uid",
             "color",
+            "wcs",
             "children",
         }
         extra = {k: v for k, v in data.items() if k not in known_keys}
@@ -109,6 +112,7 @@ class Layer(DocItem):
         layer.rotary_diameter = data.get("rotary_diameter", 25.0)
         layer.rotary_module_uid = data.get("rotary_module_uid")
         layer.color = data.get("color", cls.DEFAULT_COLOR)
+        layer.wcs = data.get("wcs")
         layer.extra = extra
 
         children = []
@@ -286,6 +290,16 @@ class Layer(DocItem):
         if rotary_module_name:
             return _("Rotary · {name}").format(name=rotary_module_name)
         return _("Rotary")
+
+    def set_wcs(self, wcs: Optional[str]):
+        if self.wcs == wcs:
+            return
+        self.wcs = wcs
+        self.updated.send(self)
+
+    def get_effective_wcs(self, machine) -> str:
+        """Return this layer's WCS or the machine's active WCS."""
+        return self.wcs if self.wcs else machine.active_wcs
 
     def mu_to_degrees(self, mu: float) -> float:
         """Convert machine units to degrees for rotary axis."""

--- a/rayforge/machine/driver/dummy.py
+++ b/rayforge/machine/driver/dummy.py
@@ -46,7 +46,8 @@ class NoDeviceDriver(Driver):
         # Initialize from machine's persisted state to prevent overwriting
         # loaded configuration with defaults upon connection.
         self._offsets: Dict[str, Pos] = cast(
-            Dict[str, Pos], machine.wcs_offsets.copy()
+            Dict[str, Pos],
+            {k: v.offset for k, v in machine.coordinate_systems.items()},
         )
 
         # Ensure standard keys exist

--- a/rayforge/machine/models/controller.py
+++ b/rayforge/machine/models/controller.py
@@ -300,7 +300,7 @@ class MachineController:
             return
         wco = cast(Tuple[float, float, float], state.wco)
         new_offset = (wco[0], wco[1], wco[2])
-        current = self.machine.wcs_offsets.get(active_wcs)
+        current = self.machine.get_wcs_offset(active_wcs)
         if current != new_offset:
             self.machine.update_wcs_offset(active_wcs, new_offset)
             self._scheduler(self.wcs_updated.send, self.machine)
@@ -440,7 +440,7 @@ class MachineController:
             wcs_slot: The WCS slot to update (e.g. "G54"). Defaults to active.
         """
         slot = wcs_slot or self.machine.active_wcs
-        if slot not in self.machine.wcs_offsets:
+        if slot not in self.machine.coordinate_systems:
             logger.warning(
                 f"Cannot set offset for immutable WCS '{slot}' "
                 "(e.g. Machine Coordinates)."
@@ -471,7 +471,7 @@ class MachineController:
             return
 
         slot = wcs_slot or self.machine.active_wcs
-        if slot not in self.machine.wcs_offsets:
+        if slot not in self.machine.coordinate_systems:
             logger.warning(
                 f"Cannot set offset for immutable WCS '{slot}' "
                 "(e.g. Machine Coordinates)."
@@ -483,7 +483,7 @@ class MachineController:
             logger.warning("Cannot set work origin: Unknown machine position.")
             return
 
-        current_offsets = self.machine.wcs_offsets.get(slot, (0.0, 0.0, 0.0))
+        current_offsets = self.machine.get_wcs_offset(slot)
 
         new_x, new_y, new_z = current_offsets
 

--- a/rayforge/machine/models/coordinate_system.py
+++ b/rayforge/machine/models/coordinate_system.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from ...core.geo import Point3D
+
+_DEFAULT_WCS = ["G54", "G55", "G56", "G57", "G58", "G59"]
+ZERO_OFFSET: Point3D = (0.0, 0.0, 0.0)
+
+
+@dataclass
+class CoordinateSystem:
+    name: str
+    label: str = ""
+    offset: Point3D = ZERO_OFFSET
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"name": self.name}
+        if self.label:
+            d["label"] = self.label
+        d["offset"] = list(self.offset)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CoordinateSystem":
+        offset = tuple(data.get("offset", list(ZERO_OFFSET)))
+        return cls(
+            name=data["name"],
+            label=data.get("label", ""),
+            offset=offset,
+        )
+
+    @staticmethod
+    def defaults() -> Dict[str, "CoordinateSystem"]:
+        return {n: CoordinateSystem(name=n) for n in _DEFAULT_WCS}

--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -14,7 +14,11 @@ from ...context import RayforgeContext, get_context
 from ...core.geo import Point3D, Rect
 from ...core.layer import Layer
 from ...core.ops import Axis, Ops
-from ...core.ops.commands import LayerStartCommand
+from ...core.ops.commands import (
+    LayerEndCommand,
+    LayerStartCommand,
+    MovingCommand,
+)
 from ...pipeline.coordspace import MachineSpace
 from ...pipeline.encoder.gcode import MachineCodeOpMap
 from ...shared.tasker import task_mgr
@@ -37,6 +41,7 @@ if TYPE_CHECKING:
     from ...core.varset import VarSet
     from ..driver.driver import Driver
     from .controller import MachineController
+from .coordinate_system import CoordinateSystem
 
 
 class Origin(Enum):
@@ -155,14 +160,9 @@ class Machine:
         # Any key NOT in wcs_offsets is considered an immutable/absolute system
         # with (0,0,0) offset.
         self.active_wcs: str = "G54"
-        self.wcs_offsets: Dict[str, Point3D] = {
-            "G54": (0.0, 0.0, 0.0),
-            "G55": (0.0, 0.0, 0.0),
-            "G56": (0.0, 0.0, 0.0),
-            "G57": (0.0, 0.0, 0.0),
-            "G58": (0.0, 0.0, 0.0),
-            "G59": (0.0, 0.0, 0.0),
-        }
+        self.coordinate_systems: Dict[str, CoordinateSystem] = (
+            CoordinateSystem.defaults()
+        )
 
         self.machine_hours: MachineHours = MachineHours()
         self.machine_hours.changed.connect(self._on_machine_hours_changed)
@@ -222,17 +222,43 @@ class Machine:
         self.precheck_error = error
 
     def update_wcs_offset(self, slot: str, offset: Point3D):
-        self.wcs_offsets[slot] = offset
+        cs = self.coordinate_systems.get(slot)
+        if cs:
+            cs.offset = offset
 
     def update_wcs_offsets_batch(self, offsets: Dict[str, Point3D]):
-        self.wcs_offsets = dict(offsets)
+        self.coordinate_systems = {
+            name: CoordinateSystem(name=name, label="", offset=offset)
+            for name, offset in offsets.items()
+        }
+
+    def get_wcs_offset(self, name: str) -> Point3D:
+        cs = self.coordinate_systems.get(name)
+        return cs.offset if cs else (0.0, 0.0, 0.0)
 
     @property
     def supported_wcs(self) -> List[str]:
         """
         Returns a sorted list of supported mutable Work Coordinate Systems.
         """
-        return sorted(list(self.wcs_offsets.keys()))
+        return sorted(list(self.coordinate_systems.keys()))
+
+    def get_wcs_list(self) -> List[CoordinateSystem]:
+        """Returns a sorted list of CoordinateSystem objects."""
+        return [self.coordinate_systems[k] for k in self.supported_wcs]
+
+    def get_wcs_label(self, name: str) -> str:
+        cs = self.coordinate_systems.get(name)
+        return cs.label if cs else ""
+
+    def set_wcs_label(self, name: str, label: str):
+        cs = self.coordinate_systems.get(name)
+        if not cs:
+            return
+        if cs.label == label:
+            return
+        cs.label = label
+        self.changed.send(self)
 
     @property
     def kinematics(self) -> Kinematics:
@@ -1060,7 +1086,8 @@ class Machine:
         If the active_wcs is not in the known offsets dictionary, it assumes
         an absolute coordinate system with zero offset.
         """
-        return self.wcs_offsets.get(self.active_wcs, (0.0, 0.0, 0.0))
+        cs = self.coordinate_systems.get(self.active_wcs)
+        return cs.offset if cs else (0.0, 0.0, 0.0)
 
     def get_workarea_origin_offset(self) -> Tuple[float, float]:
         """
@@ -1219,7 +1246,10 @@ class Machine:
         await self.controller.sync_active_wcs_from_device()
 
     def _prepare_ops_for_encoding(
-        self, ops: "Ops", _pre_prepared: bool = False
+        self,
+        ops: "Ops",
+        doc: Optional["Doc"] = None,
+        _pre_prepared: bool = False,
     ) -> "Ops":
         """
         Prepares an Ops object for encoding by applying machine-specific
@@ -1229,8 +1259,13 @@ class Machine:
         them to machine coordinates, and then to command coordinates for the
         G-code output.
 
+        When doc is provided, per-layer WCS offsets are applied by reading
+        the layer's wcs attribute at LayerStartCommand boundaries. When doc
+        is None, the machine's active WCS offset is applied uniformly.
+
         Args:
             ops: The Ops object to prepare.
+            doc: Optional Doc for per-layer WCS lookup.
             _pre_prepared: If True, the caller has already copied and
                 linearized the ops. Used internally by encode_ops() when
                 axis mapping runs before this step.
@@ -1248,26 +1283,26 @@ class Machine:
 
         space = self.get_coordinate_space()
 
-        # 1. Build combined transform applied in order:
-        #    world→machine, then WCS offset, then Z-flip.
         combined = np.identity(4)
 
         transform = space.get_world_to_machine_matrix()
         if not np.allclose(transform, np.identity(4)):
             combined = transform @ combined
 
-        # 2. Convert from MACHINE coords to COMMAND coords
-        wcs_offset = self.get_active_wcs_offset()
-        x_offset, y_offset, z_offset = space.get_command_offset(
-            wcs_offset=wcs_offset,
-            wcs_is_workarea_origin=self.wcs_origin_is_workarea_origin,
-        )
-        if x_offset != 0.0 or y_offset != 0.0 or z_offset != 0.0:
-            offset_matrix = np.identity(4)
-            offset_matrix[0, 3] = -x_offset
-            offset_matrix[1, 3] = -y_offset
-            offset_matrix[2, 3] = -z_offset
-            combined = offset_matrix @ combined
+        if doc is not None:
+            self._apply_per_layer_wcs_offset(ops_for_encoder, space, doc)
+        else:
+            wcs_offset = self.get_active_wcs_offset()
+            x_offset, y_offset, z_offset = space.get_command_offset(
+                wcs_offset=wcs_offset,
+                wcs_is_workarea_origin=self.wcs_origin_is_workarea_origin,
+            )
+            if x_offset != 0.0 or y_offset != 0.0 or z_offset != 0.0:
+                offset_matrix = np.identity(4)
+                offset_matrix[0, 3] = -x_offset
+                offset_matrix[1, 3] = -y_offset
+                offset_matrix[2, 3] = -z_offset
+                combined = offset_matrix @ combined
 
         if self.reverse_z_axis:
             z_flip = np.diag([1.0, 1.0, -1.0, 1.0])
@@ -1277,6 +1312,47 @@ class Machine:
             ops_for_encoder.transform(combined)
 
         return ops_for_encoder
+
+    def _apply_per_layer_wcs_offset(
+        self, ops: "Ops", space: "MachineSpace", doc: "Doc"
+    ) -> None:
+        """Apply per-layer WCS offsets using LayerStartCommand markers."""
+        default_offset = self.get_active_wcs_offset()
+        default_cmd_offset = space.get_command_offset(
+            wcs_offset=default_offset,
+            wcs_is_workarea_origin=self.wcs_origin_is_workarea_origin,
+        )
+
+        current_offset = default_cmd_offset
+
+        for command in ops.commands:
+            if isinstance(command, LayerStartCommand):
+                descendant = doc.find_descendant_by_uid(command.layer_uid)
+                if isinstance(descendant, Layer):
+                    effective_wcs = descendant.get_effective_wcs(self)
+                    wcs_off = self.get_wcs_offset(effective_wcs)
+                    current_offset = space.get_command_offset(
+                        wcs_offset=wcs_off,
+                        wcs_is_workarea_origin=(
+                            self.wcs_origin_is_workarea_origin
+                        ),
+                    )
+                continue
+
+            if isinstance(command, LayerEndCommand):
+                current_offset = default_cmd_offset
+                continue
+
+            if isinstance(command, MovingCommand):
+                x_off, y_off, z_off = current_offset
+                if x_off == 0.0 and y_off == 0.0 and z_off == 0.0:
+                    continue
+                base_end = command.end or (0.0, 0.0, 0.0)
+                command.end = (
+                    base_end[0] - x_off,
+                    base_end[1] - y_off,
+                    base_end[2] - z_off,
+                )
 
     def _apply_replacement_downstream(self, ops: "Ops", doc: "Doc") -> None:
         """Run degrees→scaled-mu downstream pass for AXIS_REPLACEMENT layers.
@@ -1370,7 +1446,7 @@ class Machine:
 
         # 3. Apply world→machine + WCS + Z-flip (no copy, no linearize).
         ops_for_encoder = self._prepare_ops_for_encoding(
-            ops_work, _pre_prepared=True
+            ops_work, doc, _pre_prepared=True
         )
 
         # 4. Downstream pass: convert degrees→scaled-mu for
@@ -1434,7 +1510,9 @@ class Machine:
                 "single_axis_homing_enabled": self.single_axis_homing_enabled,
                 "dialect_uid": self.dialect_uid,
                 "active_wcs": self.active_wcs,
-                "wcs_offsets": self.wcs_offsets,
+                "coordinate_systems": [
+                    cs.to_dict() for cs in self.coordinate_systems.values()
+                ],
                 "supports_arcs": self.supports_arcs,
                 "supports_curves": self.supports_curves,
                 "arc_tolerance": self.arc_tolerance,
@@ -1586,8 +1664,16 @@ class Machine:
         ma.dialect_migrated = migrated
         ma.dialect_uid = dialect_uid
         ma.active_wcs = ma_data.get("active_wcs", ma.active_wcs)
-        if "wcs_offsets" in ma_data:
-            ma.wcs_offsets = ma_data["wcs_offsets"]
+        if "coordinate_systems" in ma_data:
+            ma.coordinate_systems = {}
+            for cs_data in ma_data["coordinate_systems"]:
+                cs = CoordinateSystem.from_dict(cs_data)
+                ma.coordinate_systems[cs.name] = cs
+        elif "wcs_offsets" in ma_data:
+            for name, offset in ma_data["wcs_offsets"].items():
+                cs = ma.coordinate_systems.get(name)
+                if cs:
+                    cs.offset = tuple(offset)
 
         if "axes" in ma_data:
             ma.axes = AxisSet.from_dict(ma_data["axes"])

--- a/rayforge/pipeline/encoder/context.py
+++ b/rayforge/pipeline/encoder/context.py
@@ -31,12 +31,17 @@ class GcodeContext:
 
     @property
     def wcs_offset(self) -> Point3D:
-        """The (x, y, z) offset for the currently active WCS."""
+        """The (x, y, z) offset for the current layer's effective WCS."""
+        if self.layer:
+            effective_wcs = self.layer.get_effective_wcs(self.machine)
+            return self.machine.get_wcs_offset(effective_wcs)
         return self.machine.get_active_wcs_offset()
 
     @property
     def wcs_name(self) -> str:
-        """The name of the currently active WCS (e.g., 'G54')."""
+        """The name of the current layer's effective WCS (e.g., 'G54')."""
+        if self.layer:
+            return self.layer.get_effective_wcs(self.machine)
         return self.machine.active_wcs
 
     # --- Static Variable Documentation ---

--- a/rayforge/pipeline/encoder/gcode.py
+++ b/rayforge/pipeline/encoder/gcode.py
@@ -74,6 +74,7 @@ class GcodeEncoder(OpsEncoder):
         self._coord_format: str = "{:.3f}"  # Default format
         self._feed_format: str = "{:.3f}"
         self._power_format: str = "{:.3f}"
+        self._active_wcs: Optional[str] = None
 
     @classmethod
     def for_machine(cls, machine: "Machine") -> "GcodeEncoder":
@@ -372,9 +373,8 @@ class GcodeEncoder(OpsEncoder):
                 # active for the job, treating the preamble as a black box
                 # that may have changed state.
                 if self.dialect.inject_wcs_after_preamble:
-                    wcs_cmd = context.machine.active_wcs
-                    if wcs_cmd in ["G54", "G55", "G56", "G57", "G58", "G59"]:
-                        gcode.append(wcs_cmd)
+                    gcode.append(context.machine.active_wcs)
+                    self._active_wcs = context.machine.active_wcs
 
             case JobEndCommand():
                 # This is the single point of truth for job cleanup.
@@ -390,6 +390,13 @@ class GcodeEncoder(OpsEncoder):
                 descendant = context.doc.find_descendant_by_uid(uid)
                 if isinstance(descendant, Layer):
                     context.layer = descendant
+                    layer_wcs = descendant.get_effective_wcs(context.machine)
+                    if (
+                        self.dialect.inject_wcs_after_preamble
+                        and layer_wcs != self._active_wcs
+                    ):
+                        gcode.append(layer_wcs)
+                        self._active_wcs = layer_wcs
                 elif descendant is not None:
                     logger.warning(
                         f"Expected Layer for UID {uid}, but "

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -682,8 +682,13 @@ class WorkSurface(WorldSurface):
 
     def _on_wcs_updated(self, machine: Machine):
         """Handles updates to the machine's WCS state."""
-        space = machine.get_coordinate_space()
+        if self._is_rotary_active():
+            self._work_origin_element.set_visible(False)
+            self._update_extent_frame()
+            self.queue_draw()
+            return
 
+        space = machine.get_coordinate_space()
         if machine.wcs_origin_is_workarea_origin:
             canvas_x, canvas_y = space.get_workarea_origin_in_machine()
         else:
@@ -694,6 +699,14 @@ class WorkSurface(WorldSurface):
         self._work_origin_element.set_visible(True)
         self._update_extent_frame()
         self.queue_draw()
+
+    def _is_rotary_active(self):
+        """Returns True if the active layer has rotary mode enabled."""
+        return (
+            self.doc is not None
+            and self.doc.active_layer is not None
+            and self.doc.active_layer.rotary_enabled
+        )
 
     def _get_active_layer_wcs_offset(self):
         """

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -188,6 +188,9 @@ class WorkSurface(WorldSurface):
         self.doc.history_manager.changed.connect(self._on_history_changed)
 
         self.editor.pipeline.data_stale.connect(self._on_pipeline_data_stale)
+        self.doc.active_layer_changed.connect(self._on_active_layer_changed)
+        self._active_layer_wcs_conn = None
+        self._connect_active_layer_wcs()
 
         # Connect to view change signals to update pipeline view context
         self.aspect_ratio_changed.connect(self._on_aspect_ratio_changed)
@@ -684,13 +687,52 @@ class WorkSurface(WorldSurface):
         if machine.wcs_origin_is_workarea_origin:
             canvas_x, canvas_y = space.get_workarea_origin_in_machine()
         else:
-            wcs_x, wcs_y, _ = machine.get_active_wcs_offset()
+            wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
             canvas_x, canvas_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
 
         self._work_origin_element.set_pos(canvas_x, canvas_y)
         self._work_origin_element.set_visible(True)
         self._update_extent_frame()
         self.queue_draw()
+
+    def _get_active_layer_wcs_offset(self):
+        """
+        Returns the WCS offset for the active layer.
+
+        If the active layer has a specific WCS, uses that. Otherwise
+        falls back to the machine's active WCS.
+        """
+        if self.machine and self.doc:
+            layer = self.doc.active_layer
+            if layer and layer.wcs:
+                return self.machine.get_wcs_offset(layer.wcs)
+        if self.machine:
+            return self.machine.get_active_wcs_offset()
+        return (0.0, 0.0, 0.0)
+
+    def _connect_active_layer_wcs(self):
+        """Connect to the active layer's updated signal for WCS changes."""
+        if self._active_layer_wcs_conn is not None:
+            old_layer = self.doc.active_layer
+            old_layer.updated.disconnect(self._active_layer_wcs_conn)
+            self._active_layer_wcs_conn = None
+
+        layer = self.doc.active_layer
+        if layer:
+            self._active_layer_wcs_conn = layer.updated.connect(
+                self._on_active_layer_updated
+            )
+
+    def _on_active_layer_changed(self, sender):
+        """Reconnect WCS tracking to the new active layer."""
+        self._connect_active_layer_wcs()
+        if self.machine:
+            self._on_wcs_updated(self.machine)
+
+    def _on_active_layer_updated(self, layer):
+        """Handle property changes on the active layer, including WCS."""
+        if self.machine:
+            self._on_wcs_updated(self.machine)
 
     def _on_machine_state_changed(self, machine: Machine, state):
         """Handles machine state changes including position updates."""
@@ -708,7 +750,7 @@ class WorkSurface(WorldSurface):
         # Get offset for axis labels (where 0,0 should appear)
         if self.machine:
             space = self.machine.get_coordinate_space()
-            wcs_offset = self.machine.get_active_wcs_offset()
+            wcs_offset = self._get_active_layer_wcs_offset()
             wcs_is_workarea = self.machine.wcs_origin_is_workarea_origin
             origin_offset_mm = space.get_axis_label_origin(
                 wcs_offset=wcs_offset,
@@ -1295,7 +1337,7 @@ class WorkSurface(WorldSurface):
         if self.machine.wcs_origin_is_workarea_origin:
             origin_x, origin_y = space.get_workarea_origin_in_machine()
         else:
-            wcs_x, wcs_y, _ = self.machine.get_active_wcs_offset()
+            wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
             origin_x, origin_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
 
         bed_width = self.machine.axis_extents[0]
@@ -1346,7 +1388,7 @@ class WorkSurface(WorldSurface):
         if self.machine.wcs_origin_is_workarea_origin:
             _, origin_y = space.get_workarea_origin_in_machine()
         else:
-            wcs_x, wcs_y, _ = self.machine.get_active_wcs_offset()
+            wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
             _, origin_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
         self.set_pan(self.pan_x_mm, origin_y - self.height_mm / 2.0)
 

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -182,23 +182,15 @@ class WorkSurface(WorldSurface):
 
         self.set_machine(machine)
 
-        # Connect to the history manager's changed signal to sync the view
-        # globally, which is necessary for undo/redo actions triggered
-        # outside of this widget.
-        self.doc.history_manager.changed.connect(self._on_history_changed)
-
         self.editor.pipeline.data_stale.connect(self._on_pipeline_data_stale)
-        self.doc.active_layer_changed.connect(self._on_active_layer_changed)
+
         self._active_layer_wcs_conn = None
-        self._connect_active_layer_wcs()
+        self._connected_layer = None
+        self._connected_doc = None
+        self._connect_doc_signals()
 
         # Connect to view change signals to update pipeline view context
         self.aspect_ratio_changed.connect(self._on_aspect_ratio_changed)
-
-        # Refresh render context when doc structure changes (layer
-        # add/remove, workpiece moves between layers) so the view
-        # manager always has current layer color data.
-        self._connect_doc_structure_signals(self.doc)
 
         # Reconnect signals when a new document is loaded.
         self.editor.document_changed.connect(self._on_document_changed)
@@ -434,16 +426,32 @@ class WorkSurface(WorldSurface):
         self._update_pipeline_view_context()
 
     def _on_document_changed(self, sender, **kwargs):
-        """Reconnects doc structure signals when a new doc is loaded."""
-        doc = self.doc
-        if doc:
-            self._connect_doc_structure_signals(doc)
+        """Reconnect all doc signals when a new doc is loaded."""
+        self._disconnect_doc_signals()
+        self._connect_doc_signals()
         self._update_pipeline_view_context()
         self.reset_view()
 
-    def _connect_doc_structure_signals(self, doc):
+    def _connect_doc_signals(self):
+        doc = self.doc
+        if not doc:
+            return
+        doc.history_manager.changed.connect(self._on_history_changed)
+        doc.active_layer_changed.connect(self._on_active_layer_changed)
         doc.descendant_added.connect(self._on_doc_structure_changed)
         doc.descendant_removed.connect(self._on_doc_structure_changed)
+        self._connect_active_layer_wcs()
+        self._connected_doc = doc
+
+    def _disconnect_doc_signals(self):
+        self._disconnect_active_layer_wcs()
+        doc = self._connected_doc
+        if doc:
+            doc.history_manager.changed.disconnect(self._on_history_changed)
+            doc.active_layer_changed.disconnect(self._on_active_layer_changed)
+            doc.descendant_added.disconnect(self._on_doc_structure_changed)
+            doc.descendant_removed.disconnect(self._on_doc_structure_changed)
+            self._connected_doc = None
 
     def _on_any_transform_begin(
         self,
@@ -725,16 +733,21 @@ class WorkSurface(WorldSurface):
 
     def _connect_active_layer_wcs(self):
         """Connect to the active layer's updated signal for WCS changes."""
-        if self._active_layer_wcs_conn is not None:
-            old_layer = self.doc.active_layer
-            old_layer.updated.disconnect(self._active_layer_wcs_conn)
-            self._active_layer_wcs_conn = None
-
-        layer = self.doc.active_layer
+        self._disconnect_active_layer_wcs()
+        layer = self.doc.active_layer if self.doc else None
         if layer:
             self._active_layer_wcs_conn = layer.updated.connect(
                 self._on_active_layer_updated
             )
+            self._connected_layer = layer
+
+    def _disconnect_active_layer_wcs(self):
+        if self._connected_layer and self._active_layer_wcs_conn:
+            self._connected_layer.updated.disconnect(
+                self._active_layer_wcs_conn
+            )
+        self._active_layer_wcs_conn = None
+        self._connected_layer = None
 
     def _on_active_layer_changed(self, sender):
         """Reconnect WCS tracking to the new active layer."""

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -1332,13 +1332,7 @@ class WorkSurface(WorldSurface):
         circumference = math.pi * diameter
         half_circ = circumference / 2.0
 
-        space = self.machine.get_coordinate_space()
-
-        if self.machine.wcs_origin_is_workarea_origin:
-            origin_x, origin_y = space.get_workarea_origin_in_machine()
-        else:
-            wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
-            origin_x, origin_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
+        origin_x, origin_y = self._machine_coords_to_canvas(0.0, 0.0)
 
         bed_width = self.machine.axis_extents[0]
         max_length = bed_width
@@ -1384,12 +1378,7 @@ class WorkSurface(WorldSurface):
     def _center_on_rotary_axis(self):
         """Adjusts pan to vertically center the view on the cylinder X axis."""
         assert self.machine
-        space = self.machine.get_coordinate_space()
-        if self.machine.wcs_origin_is_workarea_origin:
-            _, origin_y = space.get_workarea_origin_in_machine()
-        else:
-            wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
-            _, origin_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
+        _, origin_y = self._machine_coords_to_canvas(0.0, 0.0)
         self.set_pan(self.pan_x_mm, origin_y - self.height_mm / 2.0)
 
     def _sync_nogo_zone_elements(self):

--- a/rayforge/ui_gtk/doceditor/bottom_panel.py
+++ b/rayforge/ui_gtk/doceditor/bottom_panel.py
@@ -14,6 +14,7 @@ from ..doceditor.layers_tab import LayersTab
 from ..icons import get_icon
 from ..machine.console import Console
 from ..machine.jog_widget import JogWidget
+from ..machine.wcs_dialog import WcsDialog
 from ..shared.dock_item import DockItem
 from ..shared.dock_layout import DockLayout
 from ..shared.gtk import apply_css
@@ -55,6 +56,7 @@ class BottomPanel(Gtk.Box):
         self.machine_cmd = machine_cmd
         self._edit_dialog = None
         self._click_to_zero_mode = False
+        self._updating_wcs_ui = False
         self._get_bounds_callback: Optional[
             Callable[[], Optional[Tuple[float, float, float, float]]]
         ] = None
@@ -215,7 +217,15 @@ class BottomPanel(Gtk.Box):
             self.wcs_list = []
         wcs_model = Gtk.StringList.new(self.wcs_list)
 
-        self.wcs_row = Adw.ComboRow(title=_("Active System"), model=wcs_model)
+        factory = Gtk.SignalListItemFactory()
+        factory.connect("setup", self._on_wcs_factory_setup)
+        factory.connect("bind", self._on_wcs_factory_bind)
+
+        self.wcs_row = Adw.ComboRow(
+            model=wcs_model,
+            factory=factory,
+            use_subtitle=True,
+        )
         self.wcs_row.connect(
             "notify::selected", self._on_wcs_selection_changed
         )
@@ -227,9 +237,9 @@ class BottomPanel(Gtk.Box):
         self.edit_offsets_btn.set_tooltip_text(_("Edit Offsets Manually"))
         self.edit_offsets_btn.add_css_class("flat")
         self.edit_offsets_btn.connect("clicked", self._on_edit_offsets_clicked)
-        self.offsets_row.add_suffix(self.edit_offsets_btn)
+        self.wcs_row.add_suffix(self.edit_offsets_btn)
 
-        self.wcs_group.add(self.offsets_row)
+        self.wcs_group.add(self.wcs_row)
 
         self.position_row = Adw.ActionRow(title=_("Current Position"))
         self.wcs_group.add(self.position_row)
@@ -367,6 +377,7 @@ class BottomPanel(Gtk.Box):
         if self.machine:
             self.machine.wcs_updated.connect(self._on_wcs_updated)
             self.machine.state_changed.connect(self._on_machine_state_changed)
+            self.machine.changed.connect(self._on_wcs_updated)
 
     def _disconnect_machine_signals(self):
         if self.machine:
@@ -374,6 +385,7 @@ class BottomPanel(Gtk.Box):
             self.machine.state_changed.disconnect(
                 self._on_machine_state_changed
             )
+            self.machine.changed.disconnect(self._on_wcs_updated)
 
     def set_machine(
         self,
@@ -395,6 +407,8 @@ class BottomPanel(Gtk.Box):
             self.jog_widget.set_machine(self.machine, self.machine_cmd)
 
     def _on_wcs_selection_changed(self, combo_row, _pspec):
+        if self._updating_wcs_ui:
+            return
         if not self.machine:
             return
         idx = combo_row.get_selected()
@@ -405,7 +419,6 @@ class BottomPanel(Gtk.Box):
                 task_mgr.add_coroutine(
                     lambda ctx, w=wcs: machine.switch_active_wcs(w)
                 )
-        self._update_wcs_ui()
 
     def _on_zero_axis_clicked(self, button, axis):
         if not self.machine:
@@ -474,56 +487,14 @@ class BottomPanel(Gtk.Box):
         if not self.machine:
             return
 
-        machine = self.machine
-        off_x, off_y, off_z = machine.get_active_wcs_offset()
-
         root = self.get_root()
-        self._edit_dialog = Adw.MessageDialog(
-            heading=_("Edit Work Offsets"),
-            body=_(
-                "Enter the offset from Machine Zero to Work Zero for "
-                "the active WCS."
-            ),
+        self._edit_dialog = WcsDialog(
+            machine=self.machine,
             transient_for=root if isinstance(root, Gtk.Window) else None,
         )
-        self._edit_dialog.add_response("cancel", _("Cancel"))
-        self._edit_dialog.add_response("save", _("Save"))
-        self._edit_dialog.set_response_appearance(
-            "save", Adw.ResponseAppearance.SUGGESTED
+        self._edit_dialog.connect(
+            "destroy", lambda *_: setattr(self, "_edit_dialog", None)
         )
-        self._edit_dialog.set_default_response("save")
-        self._edit_dialog.set_close_response("cancel")
-
-        group = Adw.PreferencesGroup()
-
-        row_x = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
-        row_x.set_title("X Offset")
-        row_x.set_value(off_x)
-        group.add(row_x)
-
-        row_y = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
-        row_y.set_title("Y Offset")
-        row_y.set_value(off_y)
-        group.add(row_y)
-
-        row_z = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
-        row_z.set_title("Z Offset")
-        row_z.set_value(off_z)
-        group.add(row_z)
-
-        self._edit_dialog.set_extra_child(group)
-
-        def on_response(dlg, response):
-            if response == "save":
-                nx = row_x.get_value()
-                ny = row_y.get_value()
-                nz = row_z.get_value()
-                task_mgr.add_coroutine(
-                    lambda ctx: machine.set_work_origin(nx, ny, nz)
-                )
-            self._edit_dialog = None
-
-        self._edit_dialog.connect("response", on_response)
         self._edit_dialog.present()
 
     def _on_wcs_updated(self, machine):
@@ -533,23 +504,63 @@ class BottomPanel(Gtk.Box):
         self._update_wcs_ui()
         self.console.on_machine_state_changed(machine, state)
 
+    def _on_wcs_factory_setup(self, factory, list_item):
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        name_label = Gtk.Label(xalign=0)
+        subtitle_label = Gtk.Label(xalign=0)
+        subtitle_label.add_css_class("dim-label")
+        box.append(name_label)
+        box.append(subtitle_label)
+        list_item.set_child(box)
+
+    def _on_wcs_factory_bind(self, factory, list_item):
+        idx = list_item.get_position()
+        if idx < 0 or idx >= len(self.wcs_list):
+            return
+        wcs_name = self.wcs_list[idx]
+        box = list_item.get_child()
+        name_label = box.get_first_child()
+        subtitle_label = name_label.get_next_sibling()
+        if self.machine:
+            label = self.machine.get_wcs_label(wcs_name)
+            if label:
+                name_label.set_label(f"{wcs_name} ({label})")
+            else:
+                name_label.set_label(wcs_name)
+            off = self.machine.get_wcs_offset(wcs_name)
+            subtitle_label.set_label(
+                f"X: {off[0]:.2f} Y: {off[1]:.2f} Z: {off[2]:.2f}"
+            )
+            subtitle_label.set_visible(True)
+        else:
+            name_label.set_label(wcs_name)
+            subtitle_label.set_visible(False)
+
     def _update_wcs_ui(self):
         if not self.machine:
             return
 
         hide_wcs_controls = self.machine.wcs_origin_is_workarea_origin
         self.wcs_row.set_visible(not hide_wcs_controls)
-        self.offsets_row.set_visible(not hide_wcs_controls)
         self.zero_row.set_visible(not hide_wcs_controls)
 
         current_wcs = self.machine.active_wcs
         if current_wcs in self.wcs_list:
             idx = self.wcs_list.index(current_wcs)
             if self.wcs_row.get_selected() != idx:
+                self._updating_wcs_ui = True
                 self.wcs_row.set_selected(idx)
+                self._updating_wcs_ui = False
+
+        wcs_label = self.machine.get_wcs_label(current_wcs)
+        if wcs_label:
+            title = f"{current_wcs} ({wcs_label})"
+        else:
+            title = current_wcs
+        self.wcs_row.set_title(title)
 
         off_x, off_y, off_z = self.machine.get_active_wcs_offset()
-        self.offsets_row.set_subtitle(
+        self.wcs_row.set_subtitle(
             f"X: {off_x:.2f}   Y: {off_y:.2f}   Z: {off_z:.2f}"
         )
 
@@ -575,9 +586,7 @@ class BottomPanel(Gtk.Box):
             if selected_wcs_ui == self.machine.machine_space_wcs:
                 pos_x, pos_y, pos_z = m_x, m_y, m_z
             else:
-                offset = self.machine.wcs_offsets.get(
-                    selected_wcs_ui, (0.0, 0.0, 0.0)
-                )
+                offset = self.machine.get_wcs_offset(selected_wcs_ui)
                 pos_x = m_x - offset[0]
                 pos_y = m_y - offset[1]
                 pos_z = m_z - offset[2]

--- a/rayforge/ui_gtk/doceditor/bottom_panel.py
+++ b/rayforge/ui_gtk/doceditor/bottom_panel.py
@@ -54,9 +54,11 @@ class BottomPanel(Gtk.Box):
         self.edit_item_requested = Signal()
         self.machine = machine
         self.machine_cmd = machine_cmd
+        self.doc = None
         self._edit_dialog = None
         self._click_to_zero_mode = False
         self._updating_wcs_ui = False
+        self._active_layer = None
         self._get_bounds_callback: Optional[
             Callable[[], Optional[Tuple[float, float, float, float]]]
         ] = None
@@ -192,11 +194,38 @@ class BottomPanel(Gtk.Box):
         self.tab_changed.send(self, name=name)
 
     def set_doc(self, doc):
+        self._disconnect_layer_signals()
+        self.doc = doc
         self.asset_browser.set_doc(doc)
         self.layers_tab.set_doc(doc)
+        if doc:
+            doc.active_layer_changed.connect(self._on_active_layer_changed)
+            self._connect_layer_signals()
+        if self.machine:
+            self._update_wcs_ui()
 
     def _on_layers_tab_edit_item(self, sender, **kwargs):
         self.edit_item_requested.send(sender, **kwargs)
+
+    def _on_active_layer_changed(self, sender):
+        self._disconnect_layer_signals()
+        self._connect_layer_signals()
+        if self.machine:
+            self._update_wcs_ui()
+
+    def _connect_layer_signals(self):
+        if self.doc and self.doc.active_layer:
+            self._active_layer = self.doc.active_layer
+            self._active_layer.updated.connect(self._on_layer_updated)
+
+    def _disconnect_layer_signals(self):
+        if self._active_layer:
+            self._active_layer.updated.disconnect(self._on_layer_updated)
+            self._active_layer = None
+
+    def _on_layer_updated(self, sender):
+        if self.machine:
+            self._update_wcs_ui()
 
     def _on_command_submitted(self, sender, command: str, machine: Machine):
         async def send_command(ctx):
@@ -236,6 +265,7 @@ class BottomPanel(Gtk.Box):
         self.edit_offsets_btn = Gtk.Button(child=get_icon("edit-symbolic"))
         self.edit_offsets_btn.set_tooltip_text(_("Edit Offsets Manually"))
         self.edit_offsets_btn.add_css_class("flat")
+        self.edit_offsets_btn.set_valign(Gtk.Align.CENTER)
         self.edit_offsets_btn.connect("clicked", self._on_edit_offsets_clicked)
         self.wcs_row.add_suffix(self.edit_offsets_btn)
 
@@ -543,6 +573,20 @@ class BottomPanel(Gtk.Box):
         hide_wcs_controls = self.machine.wcs_origin_is_workarea_origin
         self.wcs_row.set_visible(not hide_wcs_controls)
         self.zero_row.set_visible(not hide_wcs_controls)
+
+        layer_has_wcs = (
+            self.doc and self.doc.active_layer and self.doc.active_layer.wcs
+        )
+        self.wcs_row.set_sensitive(not layer_has_wcs)
+        if layer_has_wcs:
+            self.wcs_row.set_tooltip_text(
+                _(
+                    "Overridden by the current layer. "
+                    "Change it in the layer settings."
+                )
+            )
+        else:
+            self.wcs_row.set_tooltip_text("")
 
         current_wcs = self.machine.active_wcs
         if current_wcs in self.wcs_list:

--- a/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
+++ b/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from typing import Optional
 
 from gi.repository import Adw, Gdk, Gtk
 
@@ -34,10 +35,14 @@ class LayerSettingsDialog(PatchedDialogWindow):
         content = Adw.PreferencesPage()
         main_box.append(content)
 
-        appearance_group = Adw.PreferencesGroup(
-            title=_("Appearance"),
+        general_group = Adw.PreferencesGroup(
+            title=_("General"),
+            description=_(
+                "Basic layer settings such as appearance and "
+                "coordinate system."
+            ),
         )
-        content.add(appearance_group)
+        content.add(general_group)
 
         color_dialog = Gtk.ColorDialog()
         color_dialog.set_with_alpha(False)
@@ -52,7 +57,21 @@ class LayerSettingsDialog(PatchedDialogWindow):
             subtitle=_("Color used for operations in this layer"),
         )
         color_row.add_suffix(self.color_button)
-        appearance_group.add(color_row)
+        general_group.add(color_row)
+
+        self._populate_wcs_store()
+        self.wcs_row = Adw.ComboRow(
+            title=_("Coordinate System"),
+            subtitle=_(
+                "The work coordinate system origin to use for this layer. "
+                "By default, use the WCS selected in the main "
+                "window"
+            ),
+            model=self._wcs_store,
+        )
+        self._select_current_wcs()
+        self.wcs_row.connect("notify::selected", self._on_wcs_changed)
+        general_group.add(self.wcs_row)
 
         rotary_group = Adw.PreferencesGroup(
             title=_("Rotary Attachment"),
@@ -103,6 +122,38 @@ class LayerSettingsDialog(PatchedDialogWindow):
         rotary_group.add(self.rotary_diameter_row)
 
         self._is_initializing = False
+
+        if not self.layer.rotary_module_uid and self._module_uids:
+            self.layer.set_rotary_module_uid(self._module_uids[0])
+
+    def _populate_wcs_store(self):
+        self._wcs_store = Gtk.StringList()
+        self._wcs_values: list[Optional[str]] = [None]
+        self._wcs_store.append(_("Default"))
+        machine = get_context().machine
+        if machine:
+            for wcs in machine.supported_wcs:
+                self._wcs_store.append(wcs)
+                self._wcs_values.append(wcs)
+
+    def _select_current_wcs(self):
+        wcs = self.layer.wcs
+        if wcs and wcs in self._wcs_values:
+            self.wcs_row.set_selected(self._wcs_values.index(wcs))
+        else:
+            self.wcs_row.set_selected(0)
+
+    def _get_selected_wcs(self) -> Optional[str]:
+        idx = self.wcs_row.get_selected()
+        if idx < len(self._wcs_values):
+            return self._wcs_values[idx]
+        return None
+
+    def _on_wcs_changed(self, row, _param):
+        if self._is_initializing:
+            return
+        wcs = self._get_selected_wcs()
+        self.layer.set_wcs(wcs)
 
     def _populate_module_store(self):
         self._module_store = Gtk.StringList()

--- a/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
+++ b/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
@@ -5,6 +5,8 @@ from gi.repository import Adw, Gdk, Gtk
 
 from ...context import get_context
 from ...core.layer import Layer
+from ..icons import get_icon
+from ..machine.wcs_dialog import WcsDialog
 from ..shared.adwfix import get_spinrow_float
 from ..shared.patched_dialog_window import PatchedDialogWindow
 
@@ -69,7 +71,15 @@ class LayerSettingsDialog(PatchedDialogWindow):
             ),
             model=self._wcs_store,
         )
+        self.edit_offsets_btn = Gtk.Button(child=get_icon("edit-symbolic"))
+        self.edit_offsets_btn.set_tooltip_text(_("Edit Offsets Manually"))
+        self.edit_offsets_btn.add_css_class("flat")
+        self.edit_offsets_btn.set_valign(Gtk.Align.CENTER)
+        self.edit_offsets_btn.connect("clicked", self._on_edit_offsets_clicked)
+        self.wcs_row.add_suffix(self.edit_offsets_btn)
+
         self._select_current_wcs()
+        self._update_edit_button_sensitivity()
         self.wcs_row.connect("notify::selected", self._on_wcs_changed)
         general_group.add(self.wcs_row)
 
@@ -154,6 +164,27 @@ class LayerSettingsDialog(PatchedDialogWindow):
             return
         wcs = self._get_selected_wcs()
         self.layer.set_wcs(wcs)
+        self._update_edit_button_sensitivity()
+
+    def _update_edit_button_sensitivity(self):
+        wcs = self._get_selected_wcs()
+        self.edit_offsets_btn.set_sensitive(wcs is not None)
+
+    def _on_edit_offsets_clicked(self, button):
+        machine = get_context().machine
+        if not machine:
+            return
+
+        root = self.get_root()
+        self._edit_dialog = WcsDialog(
+            machine=machine,
+            transient_for=root if isinstance(root, Gtk.Window) else None,
+        )
+        self._edit_dialog.connect("destroy", self._on_edit_dialog_destroy)
+        self._edit_dialog.present()
+
+    def _on_edit_dialog_destroy(self, *_):
+        self._edit_dialog = None
 
     def _populate_module_store(self):
         self._module_store = Gtk.StringList()

--- a/rayforge/ui_gtk/machine/wcs_dialog.py
+++ b/rayforge/ui_gtk/machine/wcs_dialog.py
@@ -1,0 +1,62 @@
+from gettext import gettext as _
+
+from gi.repository import Adw
+
+from ...machine.models.machine import Machine
+from ...shared.tasker import task_mgr
+
+
+class WcsDialog(Adw.MessageDialog):
+    def __init__(self, machine: Machine, **kwargs):
+        super().__init__(
+            heading=_("Edit Work Offsets"),
+            body=_(
+                "Enter the offset from Machine Zero to Work Zero for "
+                "the active WCS."
+            ),
+            **kwargs,
+        )
+        self.machine = machine
+        self.add_response("cancel", _("Cancel"))
+        self.add_response("save", _("Save"))
+        self.set_response_appearance("save", Adw.ResponseAppearance.SUGGESTED)
+        self.set_default_response("save")
+        self.set_close_response("cancel")
+
+        off_x, off_y, off_z = machine.get_active_wcs_offset()
+        wcs_label = machine.get_wcs_label(machine.active_wcs)
+
+        group = Adw.PreferencesGroup()
+
+        self._label_row = Adw.EntryRow(title=_("Label"), text=wcs_label)
+        group.add(self._label_row)
+
+        self._row_x = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
+        self._row_x.set_title("X Offset")
+        self._row_x.set_value(off_x)
+        group.add(self._row_x)
+
+        self._row_y = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
+        self._row_y.set_title("Y Offset")
+        self._row_y.set_value(off_y)
+        group.add(self._row_y)
+
+        self._row_z = Adw.SpinRow.new_with_range(-10000, 10000, 0.1)
+        self._row_z.set_title("Z Offset")
+        self._row_z.set_value(off_z)
+        group.add(self._row_z)
+
+        self.set_extra_child(group)
+
+        self.connect("response", self._on_response)
+
+    def _on_response(self, dlg, response):
+        if response == "save":
+            label = self._label_row.get_text()
+            nx = self._row_x.get_value()
+            ny = self._row_y.get_value()
+            nz = self._row_z.get_value()
+            self.machine.set_wcs_label(self.machine.active_wcs, label)
+            task_mgr.add_coroutine(
+                lambda ctx: self.machine.set_work_origin(nx, ny, nz)
+            )

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -1021,36 +1021,6 @@ class MainWindow(Adw.ApplicationWindow):
         self.machine_selector.machine_selected.connect(
             self.on_machine_selected_by_selector
         )
-        # Connect WCS signal
-        self.toolbar.wcs_selected.connect(self._on_wcs_selected_toolbar)
-
-    def _on_wcs_selected_toolbar(self, sender, *, wcs: str):
-        """Handles WCS selection from the main toolbar."""
-        config = get_context().config
-        if not config.machine:
-            return
-        logger.debug(f"Toolbar WCS selected: {wcs}")
-        machine = config.machine
-        if machine.active_wcs != wcs:
-            task_mgr.add_coroutine(
-                lambda ctx, w=wcs: machine.switch_active_wcs(w)
-            )
-
-    def _update_wcs_dropdown(self, machine: Optional[Machine], **kwargs):
-        """
-        Synchronizes the toolbar WCS dropdown with the machine's active state.
-        Hides WCS controls when wcs_origin_is_workarea_origin is True.
-        """
-        if not machine:
-            return
-
-        # Hide WCS controls if workarea origin is treated as coordinate zero
-        show_wcs = not machine.wcs_origin_is_workarea_origin
-        self.toolbar.set_wcs_controls_visible(show_wcs)
-
-        # We assume the toolbar knows the list of available WCS.
-        # Just update the selected item.
-        self.toolbar.set_active_wcs(machine.active_wcs)
 
     def on_zero_here_clicked(self, action, param):
         """Handler for 'zero-here' action."""
@@ -1477,14 +1447,6 @@ class MainWindow(Adw.ApplicationWindow):
         self.surface.update_from_doc()
         self._update_macros_menu()
 
-        # Configure WCS list in toolbar
-        if config.machine:
-            self.toolbar.configure_wcs_list(config.machine.supported_wcs)
-        else:
-            self.toolbar.configure_wcs_list([])
-
-        self._update_wcs_dropdown(config.machine)
-
         # Check for any pending notifications from the new machine immediately
         if self._current_machine:
             self._on_machine_hours_changed(self._current_machine.machine_hours)
@@ -1511,8 +1473,6 @@ class MainWindow(Adw.ApplicationWindow):
             self._current_machine.machine_hours.changed.disconnect(
                 self._on_machine_hours_changed
             )
-            # Disconnect WCS change signal
-            self._current_machine.changed.disconnect(self._update_wcs_dropdown)
 
         self._current_machine = config.machine
 
@@ -1530,8 +1490,6 @@ class MainWindow(Adw.ApplicationWindow):
             self._current_machine.machine_hours.changed.connect(
                 self._on_machine_hours_changed
             )
-            # Update WCS dropdown when machine active_wcs changes
-            self._current_machine.changed.connect(self._update_wcs_dropdown)
 
     def _update_canvas3d(self, new_machine):
         if self.canvas3d is None:
@@ -1590,8 +1548,6 @@ class MainWindow(Adw.ApplicationWindow):
             am.get_action("machine-cancel").set_enabled(False)
             am.get_action("machine-clear-alarm").set_enabled(False)
             am.get_action("execute-macro").set_enabled(False)
-            # Disable WCS controls
-            self.toolbar.wcs_dropdown.set_sensitive(False)
             am.get_action("zero-here").set_enabled(False)
 
             self.toolbar.export_button.set_tooltip_text(
@@ -1731,7 +1687,6 @@ class MainWindow(Adw.ApplicationWindow):
             am.get_action("execute-macro").set_enabled(can_run_macros)
 
             # WCS UI
-            self.toolbar.wcs_dropdown.set_sensitive(not is_job_or_task_active)
             is_g53 = (
                 active_machine.active_wcs == active_machine.machine_space_wcs
             )

--- a/rayforge/ui_gtk/sim3d/canvas3d/canvas3d.py
+++ b/rayforge/ui_gtk/sim3d/canvas3d/canvas3d.py
@@ -160,6 +160,11 @@ class Canvas3D(Gtk.GLArea):
             machine.changed.connect(self._on_wcs_updated)
             self._on_wcs_updated(machine)
 
+        # Connect to doc for per-layer WCS updates
+        self.doc.active_layer_changed.connect(self._on_active_layer_changed)
+        self._active_layer_wcs_conn = None
+        self._connect_active_layer_wcs()
+
         self._context.config.changed.connect(self._on_config_changed)
 
     @property
@@ -196,9 +201,50 @@ class Canvas3D(Gtk.GLArea):
     def _on_wcs_updated(self, machine: "Machine", **kwargs):
         """Handler for when the machine's WCS state changes."""
         if machine:
-            self._viewport = ViewportConfig.from_machine(machine)
+            self._viewport = self._build_viewport(machine)
         self._scene_gl_dirty = True
         self.queue_render()
+
+    def _get_active_layer_wcs_offset(self, machine: "Machine"):
+        """Returns the WCS offset for the active layer."""
+        layer = self.doc.active_layer if self.doc else None
+        if layer and layer.wcs:
+            return machine.get_wcs_offset(layer.wcs)
+        return machine.get_active_wcs_offset()
+
+    def _build_viewport(self, machine: "Machine") -> "ViewportConfig":
+        """Build a ViewportConfig using the active layer's WCS."""
+        from .viewport import ViewportConfig
+
+        return ViewportConfig.from_machine_with_wcs(
+            machine, self._get_active_layer_wcs_offset(machine)
+        )
+
+    def _connect_active_layer_wcs(self):
+        """Connect to the active layer's updated signal for WCS changes."""
+        if self._active_layer_wcs_conn is not None:
+            old_layer = self.doc.active_layer
+            old_layer.updated.disconnect(self._active_layer_wcs_conn)
+            self._active_layer_wcs_conn = None
+
+        layer = self.doc.active_layer
+        if layer:
+            self._active_layer_wcs_conn = layer.updated.connect(
+                self._on_active_layer_updated
+            )
+
+    def _on_active_layer_changed(self, sender):
+        """Reconnect WCS tracking to the new active layer."""
+        self._connect_active_layer_wcs()
+        machine = self._context.machine
+        if machine:
+            self._on_wcs_updated(machine)
+
+    def _on_active_layer_updated(self, layer):
+        """Handle property changes on the active layer, including WCS."""
+        machine = self._context.machine
+        if machine:
+            self._on_wcs_updated(machine)
 
     def set_machine(self, viewport: Optional[ViewportConfig] = None):
         old_machine = self._context.machine

--- a/rayforge/ui_gtk/sim3d/canvas3d/viewport.py
+++ b/rayforge/ui_gtk/sim3d/canvas3d/viewport.py
@@ -42,6 +42,14 @@ class ViewportConfig:
 
     @classmethod
     def from_machine(cls, machine: "Machine") -> "ViewportConfig":
+        return cls.from_machine_with_wcs(
+            machine, machine.get_active_wcs_offset()
+        )
+
+    @classmethod
+    def from_machine_with_wcs(
+        cls, machine: "Machine", wcs_offset: tuple
+    ) -> "ViewportConfig":
         area = machine.work_area
         width_mm = float(area[2])
         depth_mm = float(area[3])
@@ -59,7 +67,7 @@ class ViewportConfig:
         if machine.wcs_origin_is_workarea_origin:
             wcs_offset_mm: Point3D = (0.0, 0.0, 0.0)
         else:
-            wcs_x, wcs_y, wcs_z = machine.get_active_wcs_offset()
+            wcs_x, wcs_y, wcs_z = wcs_offset
             ml, mt, mr, mb = machine.work_margins
             machine_x = -mr if machine.x_axis_right else -ml
             machine_y = -mt if machine.y_axis_down else -mb

--- a/rayforge/ui_gtk/toolbar.py
+++ b/rayforge/ui_gtk/toolbar.py
@@ -1,7 +1,6 @@
 import logging
-from typing import List
 from gettext import gettext as _
-from gi.repository import GLib, Gdk, Gtk
+from gi.repository import Gdk, Gtk
 from blinker import Signal
 from .action_registry import action_registry
 from .icons import get_icon
@@ -24,7 +23,6 @@ class MainToolbar(Gtk.Box):
         )
         # Signals for View-State controls (not app actions)
         self.machine_warning_clicked = Signal()
-        self.wcs_selected = Signal()
 
         self.set_margin_bottom(2)
         self.set_margin_top(2)
@@ -187,23 +185,6 @@ class MainToolbar(Gtk.Box):
         self.focus_button.connect("toggled", self._on_focus_toggled)
         self.append(self.focus_button)
 
-        # WCS controls
-        self.wcs_separator = Gtk.Separator(
-            orientation=Gtk.Orientation.VERTICAL
-        )
-        self.append(self.wcs_separator)
-
-        self.wcs_dropdown = Gtk.DropDown()
-        self.wcs_dropdown.set_tooltip_text(_("Work Coordinate System"))
-        self.wcs_store = Gtk.StringList()
-        # Initial empty list, will be populated by MainWindow via
-        # configure_wcs_list()
-        self.wcs_dropdown.set_model(self.wcs_store)
-        self.wcs_handler_id = self.wcs_dropdown.connect(
-            "notify::selected", self._on_wcs_selected
-        )
-        self.append(self.wcs_dropdown)
-
         # Add clickable warning for misconfigured machine
         self.machine_warning_box = Gtk.Box(spacing=6)
         self.machine_warning_box.set_margin_end(12)
@@ -300,51 +281,6 @@ class MainToolbar(Gtk.Box):
         else:
             button.set_child(self.focus_on_icon)
 
-    def configure_wcs_list(self, wcs_list: List[str]):
-        """Populates the WCS dropdown with the supported systems."""
-        # Block signal to prevent triggering selection logic during model swap
-        if self.wcs_handler_id:
-            self.wcs_dropdown.handler_block(self.wcs_handler_id)
-
-        self.wcs_store = Gtk.StringList.new(wcs_list)
-        self.wcs_dropdown.set_model(self.wcs_store)
-
-        if self.wcs_handler_id:
-            self.wcs_dropdown.handler_unblock(self.wcs_handler_id)
-
-    def set_active_wcs(self, wcs: str):
-        """Programmatically selects the WCS in the dropdown."""
-        # Find index of wcs string in store
-        found_index = -1
-        for i in range(self.wcs_store.get_n_items()):
-            if self.wcs_store.get_string(i) == wcs:
-                found_index = i
-                break
-
-        if found_index >= 0:
-            if self.wcs_dropdown.get_selected() != found_index:
-                # Block handler to avoid round-trip signal when updating UI
-                if self.wcs_handler_id:
-                    self.wcs_dropdown.handler_block(self.wcs_handler_id)
-
-                self.wcs_dropdown.set_selected(found_index)
-
-                if self.wcs_handler_id:
-                    self.wcs_dropdown.handler_unblock(self.wcs_handler_id)
-
-    def _on_wcs_selected(self, dropdown, param):
-        """Handle WCS selection change."""
-        selected_item = dropdown.get_selected_item()
-        if selected_item:
-            wcs_str = selected_item.get_string()
-            # Defer signal emission to avoid re-entrancy issues in GTK
-            GLib.idle_add(self._emit_wcs_selected, wcs_str)
-
-    def _emit_wcs_selected(self, wcs_str: str):
-        """Helper to emit signal from idle callback."""
-        self.wcs_selected.send(self, wcs=wcs_str)
-        return GLib.SOURCE_REMOVE
-
     def set_machine_warning(
         self, error_title: str, error_code: int, error_description: str
     ):
@@ -353,8 +289,3 @@ class MainToolbar(Gtk.Box):
         """
         self.warning_label.set_label(f"{error_title} ({error_code})")
         self.machine_warning_box.set_tooltip_text(error_description)
-
-    def set_wcs_controls_visible(self, visible: bool):
-        """Show or hide the WCS dropdown and its separator."""
-        self.wcs_separator.set_visible(visible)
-        self.wcs_dropdown.set_visible(visible)

--- a/tests/machine/models/test_coordinate_spaces.py
+++ b/tests/machine/models/test_coordinate_spaces.py
@@ -146,7 +146,7 @@ class TestCoordinateSpaces:
         machine.set_reverse_x_axis(reverse_x)
         machine.set_reverse_y_axis(reverse_y)
         machine.wcs_origin_is_workarea_origin = False
-        machine.wcs_offsets["G54"] = (0.0, 0.0, 0.0)
+        machine.update_wcs_offset("G54", (0.0, 0.0, 0.0))
 
         # Create an ops with a single point
         ops = Ops()
@@ -238,7 +238,7 @@ class TestCoordinateSpaces:
         machine.set_work_margins(10.0, 20.0, 30.0, 40.0)
         machine.wcs_origin_is_workarea_origin = False
         machine.set_active_wcs("G54")
-        machine.wcs_offsets["G54"] = (25.0, 35.0, 0.0)
+        machine.update_wcs_offset("G54", (25.0, 35.0, 0.0))
 
         result = machine.get_reference_offset()
         assert result == pytest.approx((25.0, 35.0, 0.0))
@@ -264,7 +264,7 @@ class TestCoordinateSpaces:
         machine.set_work_margins(10.0, 20.0, 30.0, 40.0)
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = True
-        machine.wcs_offsets["G54"] = (999.0, 999.0, 0.0)
+        machine.update_wcs_offset("G54", (999.0, 999.0, 0.0))
 
         result = machine.get_reference_offset()
         assert result == pytest.approx((10.0, 40.0, 0.0))
@@ -690,7 +690,7 @@ class TestCoordinateSpaces:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G55"
-        machine.wcs_offsets["G55"] = (30.0, 30.0, 0.0)
+        machine.update_wcs_offset("G55", (30.0, 30.0, 0.0))
 
         ref_offset = machine.get_reference_offset()
         assert ref_offset == pytest.approx((30.0, 30.0, 0.0))
@@ -715,7 +715,7 @@ class TestCoordinateSpaces:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G55"
-        machine.wcs_offsets["G55"] = (50.0, 30.0, 0.0)
+        machine.update_wcs_offset("G55", (50.0, 30.0, 0.0))
 
         ref_offset = machine.get_reference_offset()
         assert ref_offset == pytest.approx((50.0, 30.0, 0.0))
@@ -739,7 +739,7 @@ class TestCoordinateSpaces:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G54"
-        machine.wcs_offsets["G54"] = (0.0, 0.0, 0.0)
+        machine.update_wcs_offset("G54", (0.0, 0.0, 0.0))
 
         ref_offset = machine.get_reference_offset()
         assert ref_offset == pytest.approx((0.0, 0.0, 0.0))
@@ -766,7 +766,7 @@ class TestCoordinateSpaces:
         machine.set_origin(Origin.TOP_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G55"
-        machine.wcs_offsets["G55"] = (20.0, 10.0, 0.0)
+        machine.update_wcs_offset("G55", (20.0, 10.0, 0.0))
 
         ref_offset = machine.get_reference_offset()
         assert ref_offset == pytest.approx((20.0, 10.0, 0.0))
@@ -794,7 +794,7 @@ class TestCoordinateSpaces:
         machine.set_axis_extents(100.0, 100.0)
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
-        machine.wcs_offsets["G54"] = (10.0, 20.0, 30.0)
+        machine.update_wcs_offset("G54", (10.0, 20.0, 30.0))
 
         space = machine.get_coordinate_space()
         offset = space.get_command_offset(
@@ -813,7 +813,7 @@ class TestCoordinateSpaces:
         machine.set_axis_extents(100.0, 100.0)
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
-        machine.wcs_offsets["G54"] = (10.0, 20.0, 0.0)
+        machine.update_wcs_offset("G54", (10.0, 20.0, 0.0))
 
         space = machine.get_coordinate_space()
         offset = space.get_command_offset(

--- a/tests/machine/models/test_machine.py
+++ b/tests/machine/models/test_machine.py
@@ -303,7 +303,7 @@ class TestMachine:
         doc = Doc()
         machine.set_origin(Origin.BOTTOM_LEFT)
 
-        machine.wcs_offsets["G54"] = (100.0, 100.0, 0.0)
+        machine.update_wcs_offset("G54", (100.0, 100.0, 0.0))
         machine.set_active_wcs("G54")
 
         machine.encode_ops(original_ops, doc)
@@ -347,7 +347,7 @@ class TestMachine:
 
         # Set active WCS to "G53" (which is NOT in default wcs_offsets)
         machine.set_active_wcs("G53")
-        assert "G53" not in machine.wcs_offsets
+        assert "G53" not in machine.coordinate_systems
 
         # Act
         machine.encode_ops(original_ops, doc)
@@ -370,7 +370,7 @@ class TestMachine:
         await machine.connect()
         await wait_for_tasks_to_finish(task_mgr)
         machine.active_wcs = "G54"
-        machine.wcs_offsets["G54"] = (10.0, 20.0, 0.0)
+        machine.update_wcs_offset("G54", (10.0, 20.0, 0.0))
         machine.device_state.machine_pos = (100.0, 200.0, 0.0)
 
         set_wcs_spy = mocker.patch.object(
@@ -416,7 +416,7 @@ class TestMachine:
 
         # Try to set G53 (Machine Coordinates)
         machine.set_active_wcs("G53")
-        assert "G53" not in machine.wcs_offsets
+        assert "G53" not in machine.coordinate_systems
 
         await machine.set_work_origin(10, 10, 10)
 
@@ -469,7 +469,7 @@ class TestMachine:
         await wait_for_tasks_to_finish(task_mgr)
         machine.active_wcs = "G55"
         machine.controller._confirmed_active_wcs = "G55"
-        assert machine.wcs_offsets.get("G55", (0.0, 0.0, 0.0)) == (
+        assert machine.get_wcs_offset("G55") == (
             0.0,
             0.0,
             0.0,
@@ -482,7 +482,7 @@ class TestMachine:
         )
         machine.controller._sync_wcs_offset_from_wco(state)
 
-        assert machine.wcs_offsets["G55"] == (30.0, 30.0, 0.0)
+        assert machine.get_wcs_offset("G55") == (30.0, 30.0, 0.0)
 
     @pytest.mark.asyncio
     async def test_wcs_switch_does_not_corrupt_offsets(
@@ -502,7 +502,7 @@ class TestMachine:
 
         # Start on G56 with WCO (60,60,0)
         machine.active_wcs = "G56"
-        machine.wcs_offsets["G56"] = (60.0, 60.0, 0.0)
+        machine.update_wcs_offset("G56", (60.0, 60.0, 0.0))
         machine.controller._confirmed_active_wcs = "G56"
 
         # Simulate a status report confirming G56's WCO
@@ -512,10 +512,10 @@ class TestMachine:
             wco=(60.0, 60.0, 0.0),
         )
         machine.controller._sync_wcs_offset_from_wco(state_g56)
-        assert machine.wcs_offsets["G56"] == (60.0, 60.0, 0.0)
+        assert machine.get_wcs_offset("G56") == (60.0, 60.0, 0.0)
 
         # G54's offset should be at default (0,0,0)
-        assert machine.wcs_offsets.get("G54", (0.0, 0.0, 0.0)) == (
+        assert machine.get_wcs_offset("G54") == (
             0.0,
             0.0,
             0.0,
@@ -534,8 +534,8 @@ class TestMachine:
         machine.controller._sync_wcs_offset_from_wco(state_stale)
 
         # G54's offset must NOT be corrupted with G56's WCO
-        assert machine.wcs_offsets["G54"] == (0.0, 0.0, 0.0), (
-            f"G54 offset was corrupted to {machine.wcs_offsets['G54']} "
+        assert machine.get_wcs_offset("G54") == (0.0, 0.0, 0.0), (
+            f"G54 offset was corrupted to {machine.get_wcs_offset('G54')} "
             f"after receiving stale WCO from still-active G56"
         )
 
@@ -554,22 +554,22 @@ class TestMachine:
         """
         await wait_for_tasks_to_finish(task_mgr)
 
-        machine.wcs_offsets = {
-            "G54": (10.0, 20.0, 0.0),
-            "G55": (30.0, 40.0, 0.0),
-            "G56": (50.0, 60.0, 0.0),
-        }
-        assert "G56" in machine.wcs_offsets
+        machine.update_wcs_offsets_batch(
+            {
+                "G54": (10.0, 20.0, 0.0),
+                "G55": (30.0, 40.0, 0.0),
+                "G56": (50.0, 60.0, 0.0),
+            }
+        )
+        assert "G56" in machine.coordinate_systems
 
         machine.update_wcs_offsets_batch(
             {"G54": (10.0, 20.0, 0.0), "G55": (30.0, 40.0, 0.0)}
         )
 
-        assert "G56" not in machine.wcs_offsets
-        assert machine.wcs_offsets == {
-            "G54": (10.0, 20.0, 0.0),
-            "G55": (30.0, 40.0, 0.0),
-        }
+        assert "G56" not in machine.coordinate_systems
+        assert machine.get_wcs_offset("G54") == (10.0, 20.0, 0.0)
+        assert machine.get_wcs_offset("G55") == (30.0, 40.0, 0.0)
 
     @pytest.mark.asyncio
     async def test_reverse_axis_setters(
@@ -1675,7 +1675,7 @@ class TestMachine:
         isolated_machine.set_reverse_x_axis(reverse_x)
         isolated_machine.set_reverse_y_axis(reverse_y)
         isolated_machine.set_active_wcs("G54")
-        isolated_machine.wcs_offsets["G54"] = wcs_offset
+        isolated_machine.update_wcs_offset("G54", wcs_offset)
 
         offset = isolated_machine.get_visual_wcs_offset()
         assert offset == pytest.approx(expected_offset)
@@ -2095,7 +2095,7 @@ class TestPrepareOpsForEncoding:
         machine.set_reverse_y_axis(reverse_y)
         machine.wcs_origin_is_workarea_origin = False
         machine.set_active_wcs("G54")
-        machine.wcs_offsets["G54"] = wcs_offset
+        machine.update_wcs_offset("G54", wcs_offset)
 
         ops = Ops()
         ops.move_to(world_point[0], world_point[1], world_point[2])
@@ -2159,7 +2159,7 @@ class TestPrepareOpsForEncoding:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.set_active_wcs("G54")
-        machine.wcs_offsets["G54"] = (10, 20, 30)
+        machine.update_wcs_offset("G54", (10, 20, 30))
 
         ops = Ops()
         ops.move_to(50, 60, 0)
@@ -2217,7 +2217,7 @@ class TestPrepareOpsForEncoding:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.set_active_wcs("G54")
-        machine.wcs_offsets["G54"] = (10, 10, 0)
+        machine.update_wcs_offset("G54", (10, 10, 0))
 
         ops = Ops()
         ops.move_to(20, 20, 0)

--- a/tests/ui_gtk/canvas2d/test_laser_dot_position.py
+++ b/tests/ui_gtk/canvas2d/test_laser_dot_position.py
@@ -167,7 +167,7 @@ class TestLaserDotWithWCSOffset:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G55"
-        machine.wcs_offsets["G55"] = (30.0, 30.0, 0.0)
+        machine.update_wcs_offset("G55", (30.0, 30.0, 0.0))
 
         mock_editor = MagicMock()
         mock_editor.doc = MagicMock()
@@ -231,7 +231,7 @@ class TestLaserDotWithWCSOffset:
         machine.set_origin(Origin.BOTTOM_LEFT)
         machine.wcs_origin_is_workarea_origin = False
         machine.active_wcs = "G55"
-        machine.wcs_offsets["G55"] = (50.0, 30.0, 0.0)
+        machine.update_wcs_offset("G55", (50.0, 30.0, 0.0))
 
         mock_editor = MagicMock()
         mock_editor.doc = MagicMock()

--- a/tests/ui_gtk/canvas2d/test_surface.py
+++ b/tests/ui_gtk/canvas2d/test_surface.py
@@ -27,6 +27,9 @@ def surface(mock_work_origin):
     s.width_mm = 100.0
     s.height_mm = 100.0
     s._update_extent_frame = MagicMock()
+    s._connected_doc = None
+    s._connected_layer = None
+    s._active_layer_wcs_conn = None
 
     active_layer = MagicMock()
     active_layer.rotary_enabled = False

--- a/tests/ui_gtk/canvas2d/test_surface.py
+++ b/tests/ui_gtk/canvas2d/test_surface.py
@@ -30,6 +30,7 @@ def surface(mock_work_origin):
 
     active_layer = MagicMock()
     active_layer.rotary_enabled = False
+    active_layer.wcs = None
     s.editor = MagicMock()
     s.editor.doc.active_layer = active_layer
 

--- a/tests/ui_gtk/canvas3d/test_viewport_config.py
+++ b/tests/ui_gtk/canvas3d/test_viewport_config.py
@@ -158,7 +158,7 @@ class TestViewportConfigWcsOffset:
     def test_wcs_origin_is_workarea_origin(self):
         m = _make_machine()
         m.wcs_origin_is_workarea_origin = True
-        m.wcs_offsets["G54"] = (10.0, 20.0, 0.0)
+        m.update_wcs_offset("G54", (10.0, 20.0, 0.0))
         vp = ViewportConfig.from_machine(m)
         assert vp.wcs_offset_mm == (0.0, 0.0, 0.0)
 
@@ -166,7 +166,7 @@ class TestViewportConfigWcsOffset:
         m = _make_machine()
         m.set_axis_extents(200.0, 200.0)
         m.set_work_margins(5.0, 3.0, 7.0, 2.0)
-        m.wcs_offsets["G54"] = (1.0, 2.0, 0.5)
+        m.update_wcs_offset("G54", (1.0, 2.0, 0.5))
         vp = ViewportConfig.from_machine(m)
         expected_x = -5.0 + 1.0
         expected_y = -2.0 + 2.0
@@ -177,7 +177,7 @@ class TestViewportConfigWcsOffset:
         m.set_axis_extents(200.0, 200.0)
         m.set_work_margins(5.0, 3.0, 7.0, 2.0)
         m.set_reverse_x_axis(True)
-        m.wcs_offsets["G54"] = (1.0, 2.0, 0.0)
+        m.update_wcs_offset("G54", (1.0, 2.0, 0.0))
         vp = ViewportConfig.from_machine(m)
         expected_x = -5.0 - 1.0
         expected_y = -2.0 + 2.0
@@ -188,7 +188,7 @@ class TestViewportConfigWcsOffset:
         m.set_axis_extents(200.0, 200.0)
         m.set_work_margins(5.0, 3.0, 7.0, 2.0)
         m.set_reverse_y_axis(True)
-        m.wcs_offsets["G54"] = (1.0, 2.0, 0.0)
+        m.update_wcs_offset("G54", (1.0, 2.0, 0.0))
         vp = ViewportConfig.from_machine(m)
         expected_x = -5.0 + 1.0
         expected_y = -2.0 - 2.0
@@ -199,7 +199,7 @@ class TestViewportConfigWcsOffset:
         m.origin = Origin.TOP_LEFT
         m.set_axis_extents(200.0, 200.0)
         m.set_work_margins(5.0, 3.0, 7.0, 2.0)
-        m.wcs_offsets["G54"] = (1.0, 2.0, 0.0)
+        m.update_wcs_offset("G54", (1.0, 2.0, 0.0))
         vp = ViewportConfig.from_machine(m)
         expected_x = -5.0 + 1.0
         expected_y = -3.0 + 2.0


### PR DESCRIPTION
## Summary

- Allow each layer to be assigned its own Work Coordinate System (WCS), enabling different layers to use different work origins in a single job
- Refactor `wcs_offsets` dict into a `CoordinateSystem` model that supports both offsets and human-readable labels
- Remove the WCS selector from the main toolbar and consolidate WCS controls into the bottom panel with richer UI (labels, inline offsets, edit dialog)
- Emit per-layer WCS G-code commands during encoding so the machine switches coordinate systems between layers

## Changes

- **`CoordinateSystem` model** (`machine/models/coordinate_system.py`): New dataclass holding `name`, `label`, and `offset` with serialization support
- **Layer WCS attribute** (`core/layer.py`): Layers can now store an optional `wcs` field; `get_effective_wcs()` resolves per-layer vs. machine-default
- **Per-layer G-code encoding** (`machine/models/machine.py`, `pipeline/encoder/gcode.py`): `_prepare_ops_for_encoding` applies per-layer WCS offsets; G-code encoder emits WCS switch commands at `LayerStartCommand` boundaries
- **Layer settings dialog** (`ui_gtk/doceditor/layer_settings_dialog.py`): New WCS picker with warnings when rotary axis alignment doesn't match the selected WCS origin
- **WCS dialog** (`ui_gtk/machine/wcs_dialog.py`): Extracted edit-offsets dialog with label editing
- **Bottom panel** (`ui_gtk/doceditor/bottom_panel.py`): Consolidated WCS selector with subtitle showing current offsets; custom factory for dropdown items
- **Canvas/3D viewport**: Work origin indicator and viewport now respect the active layer's WCS
- **Toolbar** (`ui_gtk/toolbar.py`): Removed WCS dropdown (moved to bottom panel)
- Backward-compatible deserialization: old `wcs_offsets` format is migrated to `CoordinateSystem` on load

<img width="565" height="452" alt="image" src="https://github.com/user-attachments/assets/be2e525b-d3ed-4c2d-b37e-56b2c6887b50" />
