### PR TITLE
New Material Test Grid parameter combinations

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/__init__.py
@@ -10,6 +10,7 @@ from .frame_producer import FrameProducer
 from .material_test_grid_producer import (
     MaterialTestGridProducer,
     MaterialTestGridType,
+    GridMode,
     get_material_test_proportional_size,
     draw_material_test_preview,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "FrameProducer",
     "MaterialTestGridProducer",
     "MaterialTestGridType",
+    "GridMode",
     "get_material_test_proportional_size",
     "draw_material_test_preview",
     "ShrinkWrapProducer",

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
@@ -72,6 +72,14 @@ class MaterialTestGridType(Enum):
     ENGRAVE = "Engrave"
 
 
+class GridMode(Enum):
+    """Defines which parameters vary on grid axes."""
+
+    POWER_VS_SPEED = "Power vs Speed"
+    POWER_VS_PASSES = "Power vs Passes"
+    SPEED_VS_PASSES = "Speed vs Passes"
+
+
 class MaterialTestGridProducer(OpsProducer):
     """
     Generates a material test grid with varying speed and power settings.
@@ -82,8 +90,12 @@ class MaterialTestGridProducer(OpsProducer):
     def __init__(
         self,
         test_type: MaterialTestGridType = MaterialTestGridType.CUT,
+        grid_mode: GridMode = GridMode.POWER_VS_SPEED,
         speed_range: Tuple[float, float] = (100.0, 500.0),
         power_range: Tuple[float, float] = (10.0, 100.0),
+        passes_range: Tuple[int, int] = (1, 5),
+        fixed_speed: float = 1000.0,
+        fixed_power: float = 50.0,
         grid_dimensions: Tuple[int, int] = (5, 5),
         shape_size: float = 10.0,
         spacing: float = 2.0,
@@ -97,8 +109,15 @@ class MaterialTestGridProducer(OpsProducer):
             self.test_type = MaterialTestGridType(test_type)
         else:
             self.test_type = test_type
+        if isinstance(grid_mode, str):
+            self.grid_mode = GridMode(grid_mode)
+        else:
+            self.grid_mode = grid_mode
         self.speed_range = speed_range
         self.power_range = power_range
+        self.passes_range = passes_range
+        self.fixed_speed = fixed_speed
+        self.fixed_power = fixed_power
         self.grid_dimensions = grid_dimensions
         self.shape_size = shape_size
         self.spacing = spacing
@@ -178,7 +197,18 @@ class MaterialTestGridProducer(OpsProducer):
         main_ops.ops_section_start(section_type, workpiece.uid)
 
         # Sort for risk, highest risk first (high speed -> low speed)
-        grid_elements.sort(key=lambda e: (-e["speed"], e["power"]))
+        grid_elements.sort(
+            key=lambda e: (-e["speed"], e["power"], e.get("passes", 1))
+        )
+
+        is_engrave = self.test_type == MaterialTestGridType.ENGRAVE
+        line_spacing = 0.0
+        if is_engrave:
+            line_spacing = (
+                self.line_interval_mm
+                if self.line_interval_mm is not None
+                else laser.spot_size_mm[1]
+            )
 
         for element in grid_elements:
             # Force laser state to OFF before setting new parameters.
@@ -188,15 +218,12 @@ class MaterialTestGridProducer(OpsProducer):
             main_ops.set_power(0.0)
             main_ops.set_power(element["power"] / 100.0)
             main_ops.set_cut_speed(element["speed"])
-            if self.test_type == MaterialTestGridType.ENGRAVE:
-                line_spacing = (
-                    self.line_interval_mm
-                    if self.line_interval_mm is not None
-                    else laser.spot_size_mm[1]
-                )
-                self._draw_filled_box(main_ops, line_spacing, **element)
-            else:
-                self._draw_rectangle(main_ops, **element)
+            passes = element.get("passes", 1)
+            for _ in range(passes):
+                if is_engrave:
+                    self._draw_filled_box(main_ops, line_spacing, **element)
+                else:
+                    self._draw_rectangle(main_ops, **element)
 
         main_ops.ops_section_end(section_type)
 
@@ -235,7 +262,7 @@ class MaterialTestGridProducer(OpsProducer):
 
         for el in elements:
             if el["class"] == "grid-rect":
-                ctx.set_line_width(0.2 * (width_px / 73.0))  # Scale line
+                ctx.set_line_width(0.2 * (width_px / 73.0))  # Scale line width
                 ctx.rectangle(el["x"], el["y"], el["width"], el["height"])
                 if test_type == MaterialTestGridType.ENGRAVE:
                     ctx.set_source_rgb(0.5, 0.5, 0.5)
@@ -265,9 +292,35 @@ class MaterialTestGridProducer(OpsProducer):
         shape_size = params.get("shape_size", 10.0)
         spacing = params.get("spacing", 2.0)
         include_labels = params.get("include_labels", True)
+        grid_mode = params.get("grid_mode", "Power vs Speed")
+        passes_range = params.get("passes_range", (1, 5))
+        fixed_speed = params.get("fixed_speed", 1000.0)
+        fixed_power = params.get("fixed_power", 50.0)
 
-        speed_step = (max_speed - min_speed) / (rows - 1) if rows > 1 else 0
-        power_step = (max_power - min_power) / (cols - 1) if cols > 1 else 0
+        min_passes, max_passes = int(passes_range[0]), int(passes_range[1])
+
+        if grid_mode == "Power vs Passes":
+            col_range = (min_power, max_power)
+            row_range = (float(min_passes), float(max_passes))
+            col_label_text = "Power (%)"
+            row_label_text = "Passes"
+        elif grid_mode == "Speed vs Passes":
+            col_range = (min_speed, max_speed)
+            row_range = (float(min_passes), float(max_passes))
+            col_label_text = "Speed (mm/min)"
+            row_label_text = "Passes"
+        else:
+            col_range = (min_power, max_power)
+            row_range = (min_speed, max_speed)
+            col_label_text = "Power (%)"
+            row_label_text = "Speed (mm/min)"
+
+        col_step = (
+            (col_range[1] - col_range[0]) / (cols - 1) if cols > 1 else 0
+        )
+        row_step = (
+            (row_range[1] - row_range[0]) / (rows - 1) if rows > 1 else 0
+        )
 
         base_margin = min(shape_size * 1.5, 15.0)
         margin_left, margin_top = (
@@ -281,6 +334,22 @@ class MaterialTestGridProducer(OpsProducer):
         elements = []
         for r in range(rows):
             for c in range(cols):
+                col_val = col_range[0] + c * col_step
+                row_val = row_range[0] + r * row_step
+
+                if grid_mode == "Power vs Passes":
+                    speed = fixed_speed
+                    power = col_val
+                    passes = max(1, int(round(row_val)))
+                elif grid_mode == "Speed vs Passes":
+                    speed = col_val
+                    power = fixed_power
+                    passes = max(1, int(round(row_val)))
+                else:
+                    speed = row_val
+                    power = col_val
+                    passes = 1
+
                 elements.append(
                     {
                         "class": "grid-rect",
@@ -288,8 +357,9 @@ class MaterialTestGridProducer(OpsProducer):
                         "y": margin_top + r * (shape_h + spacing_y),
                         "width": shape_w,
                         "height": shape_h,
-                        "speed": min_speed + r * speed_step,
-                        "power": min_power + c * power_step,
+                        "speed": speed,
+                        "power": power,
+                        "passes": passes,
                     }
                 )
 
@@ -309,28 +379,29 @@ class MaterialTestGridProducer(OpsProducer):
             grid_w = target_width - margin_left
             grid_h = target_height - margin_top
 
-            # Position labels proportionally within their margin spaces.
             elements.extend(
                 [
                     {
                         "x": margin_left + grid_w / 2,
                         "y": margin_top * 0.3,
-                        "text": "Power (%)",
+                        "text": col_label_text,
                         "class": "axis-label",
                         "font_size": font_size_axis,
                     },
                     {
                         "x": margin_left * 0.3,
                         "y": margin_top + grid_h / 2,
-                        "text": "Speed (mm/min)",
+                        "text": row_label_text,
                         "class": "axis-label",
                         "font_size": font_size_axis,
                         "transform": "rotate(-90)",
                     },
                 ]
             )
+            # Position labels proportionally within their margin spaces.
             for c in range(cols):
-                text = f"{int(min_power + c * power_step)}"
+                col_val = col_range[0] + c * col_step
+                text = f"{int(col_val)}"
                 elements.append(
                     {
                         "x": margin_left
@@ -343,7 +414,8 @@ class MaterialTestGridProducer(OpsProducer):
                     }
                 )
             for r in range(rows):
-                text = f"{int(min_speed + r * speed_step)}"
+                row_val = row_range[0] + r * row_step
+                text = f"{int(round(row_val))}"
                 elements.append(
                     {
                         "x": margin_left * 0.9,
@@ -472,8 +544,12 @@ class MaterialTestGridProducer(OpsProducer):
             "type": self.__class__.__name__,
             "params": {
                 "test_type": self.test_type.value,
+                "grid_mode": self.grid_mode.value,
                 "speed_range": list(self.speed_range),
                 "power_range": list(self.power_range),
+                "passes_range": list(self.passes_range),
+                "fixed_speed": self.fixed_speed,
+                "fixed_power": self.fixed_power,
                 "grid_dimensions": list(self.grid_dimensions),
                 "shape_size": self.shape_size,
                 "spacing": self.spacing,

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
@@ -379,25 +379,50 @@ class MaterialTestGridProducer(OpsProducer):
             grid_w = target_width - margin_left
             grid_h = target_height - margin_top
 
-            elements.extend(
-                [
+            axis_labels = [
+                {
+                    "x": margin_left + grid_w / 2,
+                    "y": margin_top * 0.3,
+                    "text": col_label_text,
+                    "class": "axis-label",
+                    "font_size": font_size_axis,
+                },
+                {
+                    "x": margin_left * 0.3,
+                    "y": margin_top + grid_h / 2,
+                    "text": row_label_text,
+                    "class": "axis-label",
+                    "font_size": font_size_axis,
+                    "transform": "rotate(-90)",
+                },
+            ]
+
+            fixed_label_font_size = font_size_grid * 0.8
+            fixed_label_offset = min(margin_left, margin_top) * 0.15
+            if grid_mode == "Power vs Passes":
+                axis_labels.append(
                     {
-                        "x": margin_left + grid_w / 2,
-                        "y": margin_top * 0.3,
-                        "text": col_label_text,
-                        "class": "axis-label",
-                        "font_size": font_size_axis,
-                    },
+                        "x": fixed_label_offset,
+                        "y": fixed_label_offset,
+                        "text": f"Speed: {int(fixed_speed)} mm/min",
+                        "class": "grid-label",
+                        "font_size": fixed_label_font_size,
+                        "align_h": "left",
+                    }
+                )
+            elif grid_mode == "Speed vs Passes":
+                axis_labels.append(
                     {
-                        "x": margin_left * 0.3,
-                        "y": margin_top + grid_h / 2,
-                        "text": row_label_text,
-                        "class": "axis-label",
-                        "font_size": font_size_axis,
-                        "transform": "rotate(-90)",
-                    },
-                ]
-            )
+                        "x": fixed_label_offset,
+                        "y": fixed_label_offset,
+                        "text": f"Power: {int(fixed_power)}%",
+                        "class": "grid-label",
+                        "font_size": fixed_label_font_size,
+                        "align_h": "left",
+                    }
+                )
+
+            elements.extend(axis_labels)
             # Position labels proportionally within their margin spaces.
             for c in range(cols):
                 col_val = col_range[0] + c * col_step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
@@ -68,7 +68,7 @@ class MaterialTestStep(Step):
         )
         assert OverscanTransformer is not None
         auto_distance = OverscanTransformer.calculate_auto_distance(
-            machine.max_cut_speed, machine.acceleration
+            step.cut_speed, machine.acceleration
         )
         for t in per_wp:
             if t.get("name") == "OverscanTransformer":

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
@@ -459,6 +459,18 @@ class MaterialTestGridSettingsWidget(
         self.min_power_adj.set_value(power_range[0])
         self.max_power_adj.set_value(power_range[1])
 
+        # Cancel any debounced callbacks triggered by set_value() above.
+        # DebounceMixin uses a single timer slot, so rapid set_value()
+        # calls cause earlier callbacks to be lost. We commit directly
+        # below instead.
+        if self._debounce_timer > 0:
+            GLib.source_remove(self._debounce_timer)
+            self._debounce_timer = 0
+
+        self._update_range_param("speed_range", 0, min_speed)
+        self._update_range_param("speed_range", 1, max_speed)
+        self._commit_power_range_change()
+
         model = cast(Gtk.StringList, self.test_type_row.get_model())
         for i in range(model.get_n_items()):
             if model.get_string(i) == test_type:

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
@@ -74,6 +74,7 @@ class MaterialTestGridSettingsWidget(
 
         self._build_preset_selector(producer)
         self._build_test_type_selector(producer)
+        self._build_grid_mode_selector(producer)
         self._build_grid_dimensions(producer)
         self._build_shape_size(producer)
         self._build_spacing(producer)
@@ -117,17 +118,76 @@ class MaterialTestGridSettingsWidget(
             "notify::selected", self._on_test_type_changed
         )
 
+    def _build_grid_mode_selector(self, producer: MaterialTestGridProducer):
+        """Builds the grid mode dropdown."""
+        from ..producers.material_test_grid_producer import GridMode
+
+        mode_labels = [m.value for m in GridMode]
+        string_list = Gtk.StringList.new(mode_labels)
+        self.grid_mode_row = Adw.ComboRow(
+            title=_("Grid Mode"),
+            subtitle=_("Choose which parameters to vary on axes"),
+            model=string_list,
+        )
+        current_mode = producer.grid_mode.value
+        for i, label in enumerate(mode_labels):
+            if label == current_mode:
+                self.grid_mode_row.set_selected(i)
+                break
+        self.add(self.grid_mode_row)
+        self.grid_mode_row.connect(
+            "notify::selected", self._on_grid_mode_changed
+        )
+
     def _build_power_and_speed_group(self, producer: MaterialTestGridProducer):
         """Builds the group for power and speed settings."""
         group = Adw.PreferencesGroup(
-            title=_("Speed &amp; Power"),
-            description=_(
-                "Define the range of speeds and powers for the test grid"
-            ),
+            title=_("Parameters"),
+            description=_("Define the parameter ranges for the test grid"),
         )
         self.page.add(group)
+        self._param_group = group
 
-        # Power Range
+        machine_max_speed = self.step.max_cut_speed
+
+        # Fixed Speed (used in Power vs Passes mode)
+        fixed_speed_adj = Gtk.Adjustment(
+            lower=1.0,
+            upper=machine_max_speed,
+            step_increment=10.0,
+            value=min(producer.fixed_speed, machine_max_speed),
+        )
+        self.fixed_speed_row = Adw.SpinRow(
+            title=_("Fixed Speed"),
+            subtitle=_("Constant speed for all cells (mm/min)"),
+            adjustment=fixed_speed_adj,
+            digits=0,
+        )
+        group.add(self.fixed_speed_row)
+        self.fixed_speed_row.connect(
+            "changed",
+            lambda r: self._debounce(self._on_fixed_speed_changed, r),
+        )
+
+        # Fixed Power (used in Speed vs Passes mode)
+        fixed_power_adj = Gtk.Adjustment(
+            lower=1,
+            upper=100,
+            step_increment=0.1,
+            value=producer.fixed_power,
+        )
+        self.fixed_power_row, self.fixed_power_scale = create_slider_row(
+            title=_("Fixed Power (%)"),
+            adjustment=fixed_power_adj,
+            subtitle=_("Constant power for all cells"),
+            digits=1,
+            on_value_changed=lambda s: self._debounce(
+                self._on_fixed_power_changed, s
+            ),
+        )
+        group.add(self.fixed_power_row)
+
+        # Power Range (used in Power vs Speed and Power vs Passes modes)
         min_power, max_power = producer.power_range
         self.min_power_adj = Gtk.Adjustment(
             lower=1, upper=100, step_increment=0.1, value=min_power
@@ -138,7 +198,8 @@ class MaterialTestGridSettingsWidget(
             subtitle=_("For first column"),
             digits=1,
         )
-        group.add(min_power_row)
+        self.min_power_row = min_power_row
+        group.add(self.min_power_row)
 
         self.max_power_adj = Gtk.Adjustment(
             lower=1, upper=100, step_increment=0.1, value=max_power
@@ -149,7 +210,8 @@ class MaterialTestGridSettingsWidget(
             subtitle=_("For last column"),
             digits=1,
         )
-        group.add(max_power_row)
+        self.max_power_row = max_power_row
+        group.add(self.max_power_row)
 
         self.min_power_handler_id = self.min_power_scale.connect(
             "value-changed", self._on_min_power_scale_changed
@@ -158,7 +220,7 @@ class MaterialTestGridSettingsWidget(
             "value-changed", self._on_max_power_scale_changed
         )
 
-        # Speed Range
+        # Speed Range (used in Power vs Speed and Speed vs Passes modes)
         min_speed, max_speed = producer.speed_range
         machine_max_speed = self.step.max_cut_speed
         min_speed = min(min_speed, machine_max_speed)
@@ -192,6 +254,39 @@ class MaterialTestGridSettingsWidget(
         )
         self.speed_max_row.connect(
             "changed", lambda r: self._debounce(self._on_speed_max_changed, r)
+        )
+
+        # Passes Range (used in Power vs Passes and Speed vs Passes modes)
+        min_passes, max_passes = producer.passes_range
+        min_passes_adj = Gtk.Adjustment(
+            lower=1, upper=50, step_increment=1, value=min_passes
+        )
+        self.passes_min_row = Adw.SpinRow(
+            title=_("Minimum Passes"),
+            subtitle=_("Starting number of passes"),
+            adjustment=min_passes_adj,
+            digits=0,
+        )
+        group.add(self.passes_min_row)
+
+        max_passes_adj = Gtk.Adjustment(
+            lower=1, upper=50, step_increment=1, value=max_passes
+        )
+        self.passes_max_row = Adw.SpinRow(
+            title=_("Maximum Passes"),
+            subtitle=_("Ending number of passes"),
+            adjustment=max_passes_adj,
+            digits=0,
+        )
+        group.add(self.passes_max_row)
+
+        self.passes_min_row.connect(
+            "changed",
+            lambda r: self._debounce(self._on_passes_min_changed, r),
+        )
+        self.passes_max_row.connect(
+            "changed",
+            lambda r: self._debounce(self._on_passes_max_changed, r),
         )
 
         # Label settings
@@ -232,6 +327,9 @@ class MaterialTestGridSettingsWidget(
         self._on_labels_toggled(
             self.include_labels_switch, producer.include_labels
         )
+
+        self._update_control_visibility()
+        self._update_dimension_labels()
 
         return False  # for GLib.idle_add
 
@@ -464,6 +562,85 @@ class MaterialTestGridSettingsWidget(
     def _on_label_speed_changed(self, spin_row):
         new_value = get_spinrow_float(spin_row)
         self._update_param("label_speed", new_value)
+
+    def _on_grid_mode_changed(self, row: Adw.ComboRow, _pspec):
+        selected_idx = row.get_selected()
+        if selected_idx == Gtk.INVALID_LIST_POSITION:
+            return
+        model = cast(Gtk.StringList, row.get_model())
+        mode_text = model.get_string(selected_idx)
+        self._update_param("grid_mode", mode_text)
+        self._update_control_visibility()
+        self._update_dimension_labels()
+
+    def _on_fixed_speed_changed(self, spin_row):
+        new_value = get_spinrow_float(spin_row)
+        self._update_param("fixed_speed", new_value)
+
+    def _on_fixed_power_changed(self, scale: Gtk.Scale):
+        self._update_param("fixed_power", scale.get_value())
+
+    def _on_passes_min_changed(self, spin_row):
+        new_value = get_spinrow_int(spin_row)
+        self._update_range_param("passes_range", 0, new_value)
+
+    def _on_passes_max_changed(self, spin_row):
+        new_value = get_spinrow_int(spin_row)
+        self._update_range_param("passes_range", 1, new_value)
+
+    def _get_current_grid_mode(self) -> str:
+        from ..producers.material_test_grid_producer import GridMode
+
+        selected_idx = self.grid_mode_row.get_selected()
+        if selected_idx == Gtk.INVALID_LIST_POSITION:
+            return GridMode.POWER_VS_SPEED.value
+        model = cast(Gtk.StringList, self.grid_mode_row.get_model())
+        text = model.get_string(selected_idx)
+        return text if text else GridMode.POWER_VS_SPEED.value
+
+    def _update_control_visibility(self):
+        mode = self._get_current_grid_mode()
+        show_power_range = mode in ("Power vs Speed", "Power vs Passes")
+        show_speed_range = mode in ("Power vs Speed", "Speed vs Passes")
+        show_passes_range = mode in ("Power vs Passes", "Speed vs Passes")
+        show_fixed_speed = mode == "Power vs Passes"
+        show_fixed_power = mode == "Speed vs Passes"
+
+        self.fixed_speed_row.set_visible(show_fixed_speed)
+        self.fixed_power_row.set_visible(show_fixed_power)
+
+        self.min_power_row.set_visible(show_power_range)
+        self.max_power_row.set_visible(show_power_range)
+        self.min_power_scale.set_visible(show_power_range)
+        self.max_power_scale.set_visible(show_power_range)
+
+        self.speed_min_row.set_visible(show_speed_range)
+        self.speed_max_row.set_visible(show_speed_range)
+
+        self.passes_min_row.set_visible(show_passes_range)
+        self.passes_max_row.set_visible(show_passes_range)
+
+    def _update_dimension_labels(self):
+        mode = self._get_current_grid_mode()
+        if mode == "Power vs Passes":
+            col_title = _("Columns (Power Steps)")
+            col_sub = _("Number of power variations")
+            row_title = _("Rows (Passes Steps)")
+            row_sub = _("Number of passes variations")
+        elif mode == "Speed vs Passes":
+            col_title = _("Columns (Speed Steps)")
+            col_sub = _("Number of speed variations")
+            row_title = _("Rows (Passes Steps)")
+            row_sub = _("Number of passes variations")
+        else:
+            col_title = _("Columns (Power Steps)")
+            col_sub = _("Number of power variations")
+            row_title = _("Rows (Speed Steps)")
+            row_sub = _("Number of speed variations")
+        self.cols_row.set_title(col_title)
+        self.cols_row.set_subtitle(col_sub)
+        self.rows_row.set_title(row_title)
+        self.rows_row.set_subtitle(row_sub)
 
     # Helper methods
     def _update_param(self, param_name: str, new_value: Any):

--- a/rayforge/image/material_test_grid_renderer.py
+++ b/rayforge/image/material_test_grid_renderer.py
@@ -47,37 +47,80 @@ class MaterialTestRenderer(Renderer):
         speed_range = params["speed_range"]
         power_range = params["power_range"]
         test_type = params.get("test_type", "Cut")
+        grid_mode = params.get("grid_mode", "Power vs Speed")
+        passes_range = params.get("passes_range", (1, 5))
 
         min_speed, max_speed = speed_range
         min_power, max_power = power_range
+        min_passes, max_passes = int(passes_range[0]), int(passes_range[1])
 
-        # Rows vary speed (Y-axis), columns vary power (X-axis)
-        speed_step = (max_speed - min_speed) / (rows - 1) if rows > 1 else 0
-        power_step = (max_power - min_power) / (cols - 1) if cols > 1 else 0
+        if grid_mode == "Power vs Passes":
+            col_range = (min_power, max_power)
+            row_range = (float(min_passes), float(max_passes))
+        elif grid_mode == "Speed vs Passes":
+            col_range = (min_speed, max_speed)
+            row_range = (float(min_passes), float(max_passes))
+        else:
+            col_range = (min_power, max_power)
+            row_range = (min_speed, max_speed)
+
+        col_step = (
+            (col_range[1] - col_range[0]) / (cols - 1) if cols > 1 else 0
+        )
+        row_step = (
+            (row_range[1] - row_range[0]) / (rows - 1) if rows > 1 else 0
+        )
+
+        col_span = col_range[1] - col_range[0]
+        row_span = row_range[1] - row_range[0]
 
         for r in range(rows):
             for c in range(cols):
-                current_speed = min_speed + r * speed_step
-                current_power = min_power + c * power_step
+                col_val = col_range[0] + c * col_step
+                row_val = row_range[0] + r * row_step
 
-                x = c * (shape_size + spacing)
-                y = r * (shape_size + spacing)
-
-                # Calculate intensity (darker = more aggressive)
-                speed_factor = (
-                    1.0 - (current_speed - min_speed) / (max_speed - min_speed)
-                    if max_speed > min_speed
-                    else 0
-                )
-                power_factor = (
-                    (current_power - min_power) / (max_power - min_power)
-                    if max_power > min_power
-                    else 0
-                )
-                intensity = (speed_factor + power_factor) / 2.0
+                if grid_mode == "Power vs Passes":
+                    power_factor = (
+                        (col_val - col_range[0]) / col_span
+                        if col_span > 0
+                        else 0
+                    )
+                    passes_factor = (
+                        (row_val - row_range[0]) / row_span
+                        if row_span > 0
+                        else 0
+                    )
+                    intensity = (power_factor + passes_factor) / 2.0
+                elif grid_mode == "Speed vs Passes":
+                    speed_factor = (
+                        1.0 - (col_val - col_range[0]) / col_span
+                        if col_span > 0
+                        else 0
+                    )
+                    passes_factor = (
+                        (row_val - row_range[0]) / row_span
+                        if row_span > 0
+                        else 0
+                    )
+                    intensity = (speed_factor + passes_factor) / 2.0
+                else:
+                    speed_factor = (
+                        1.0 - (row_val - row_range[0]) / row_span
+                        if row_span > 0
+                        else 0
+                    )
+                    power_factor = (
+                        (col_val - col_range[0]) / col_span
+                        if col_span > 0
+                        else 0
+                    )
+                    intensity = (speed_factor + power_factor) / 2.0
 
                 # Gradient from light gray (0.9) to dark gray (0.3)
                 gray = 0.9 - (intensity * 0.6)
+
+                x = c * (shape_size + spacing)
+                y = r * (shape_size + spacing)
 
                 if test_type == "Engrave":
                     # Fill cell with horizontal lines for engrave mode

--- a/rayforge/ui_gtk/canvas/element.py
+++ b/rayforge/ui_gtk/canvas/element.py
@@ -155,6 +155,7 @@ class CanvasElement:
         self.debounce_ms: int = debounce_ms
         self._debounce_timer_id: Optional[int] = None
         self._update_future: Optional[Future] = None
+        self._update_generation: int = 0
         self.pixel_perfect_hit = pixel_perfect_hit
         self.hit_distance: float = hit_distance
         self.is_editable: bool = is_editable
@@ -398,16 +399,24 @@ class CanvasElement:
                 self.canvas.queue_draw()
             return False
 
+        # Bump the generation so that any stale render results from
+        # earlier updates (still in-flight on other thread-pool workers)
+        # are silently discarded in _on_update_complete.
+        self._update_generation += 1
+        gen = self._update_generation
+
         # Submit the thread-safe part to the executor with correct pixel dims.
         self._update_future = self._executor.submit(
             self.render_to_surface, render_width, render_height
         )
         # Add a callback to handle the result on the main thread
-        self._update_future.add_done_callback(self._on_update_complete)
+        self._update_future.add_done_callback(
+            lambda f, g=gen: self._on_update_complete(f, g)
+        )
 
         return False  # For GLib.timeout_add, run only once
 
-    def _on_update_complete(self, future: Future):
+    def _on_update_complete(self, future: Future, generation: int):
         """
         Callback executed when the background render is finished.
 
@@ -416,6 +425,8 @@ class CanvasElement:
 
         Args:
             future: The Future object from the completed task.
+            generation: The generation counter value that was current
+                when this render was submitted.
         """
         if future.cancelled():
             logger.debug(f"Update for {self.__class__.__name__} cancelled.")
@@ -427,6 +438,13 @@ class CanvasElement:
                 f"{self.__class__.__name__}: {exc}",
                 exc_info=exc,
             )
+            return
+
+        # Discard stale render results.  When rapid changes occur
+        # (e.g. switching presets), multiple render futures can be
+        # in-flight concurrently.  Only the result whose generation
+        # matches the current one is applied.
+        if generation != self._update_generation:
             return
 
         # The result is the new cairo surface


### PR DESCRIPTION
## Summary
- Adds new parameter combinations to the Material Test Grid
- Fixes debouncing issue that prevented material test from updating when switching presets (#187)
- Updates the grid producer, widget, and renderer to support expanded parameter options

## Changes
- `material_test_grid_producer.py`: Extended grid generation logic
- `material_test_grid_widget.py`: Updated UI widget for new parameters
- `material_test_grid_renderer.py`: Enhanced rendering support
- `material_test.py`: Minor fix for preset switching