### PR TITLE
Add Print & Cut alignment addon (#180)

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/__init__.py
@@ -1,0 +1,3 @@
+"""
+Print & Cut - Align workpieces to physical objects using registration marks.
+"""

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/backend.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/backend.py
@@ -1,0 +1,6 @@
+from rayforge.core.hooks import hookimpl
+
+
+@hookimpl
+def on_unload():
+    pass

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/frontend.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/frontend.py
@@ -1,0 +1,71 @@
+import gettext
+import logging
+from pathlib import Path
+
+from gi.repository import Gio
+
+from rayforge.core.hooks import hookimpl
+from rayforge.ui_gtk.action_registry import (
+    MenuPlacement,
+    action_registry,
+)
+from rayforge.ui_gtk.actions import action_extension_registry
+
+_localedir = Path(__file__).parent.parent / "locale"
+_t = gettext.translation("print_and_cut", localedir=_localedir, fallback=True)
+_ = _t.gettext
+
+ADDON_NAME = "print_and_cut"
+logger = logging.getLogger(__name__)
+
+
+def _register_actions(action_manager):
+    action = Gio.SimpleAction.new("align-workpiece", None)
+
+    def on_activate(action, param):
+        window = action_manager.win
+        surface = window.surface
+        selected = surface.get_selected_workpieces()
+        if len(selected) != 1:
+            return
+        from rayforge.context import get_context
+        from .wizard import PrintAndCutWizard
+
+        ctx = get_context()
+        machine = ctx.machine
+        if not machine:
+            return
+        wizard = PrintAndCutWizard(
+            parent=window,
+            workpiece=selected[0],
+            machine=machine,
+            machine_cmd=window.machine_cmd,
+            editor=window.doc_editor,
+        )
+        wizard.present()
+
+    action.connect("activate", on_activate)
+    action_manager.win.add_action(action)
+    action_manager.actions["align-workpiece"] = action
+    action_registry.register(
+        action_name="align-workpiece",
+        action=action,
+        addon_name=ADDON_NAME,
+        label=_("Align to Physical Position"),
+        menu=MenuPlacement(menu_id="tools", priority=50),
+    )
+
+
+def _update_action_states(action_manager):
+    selected_wps = action_manager.win.surface.get_selected_workpieces()
+    action = action_manager.actions.get("align-workpiece")
+    if action:
+        action.set_enabled(len(selected_wps) == 1)
+
+
+@hookimpl
+def register_actions(action_registry):
+    action_extension_registry.register_setup(_register_actions, ADDON_NAME)
+    action_extension_registry.register_state_update(
+        _update_action_states, ADDON_NAME
+    )

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
@@ -104,6 +104,21 @@ class PickSurface(WorldSurface):
         self.points_reset.send(self)
         self.queue_draw()
 
+    def set_points(
+        self,
+        p1: Optional[Tuple[float, float]],
+        p2: Optional[Tuple[float, float]],
+    ):
+        self._point1 = p1
+        self._point2 = p2
+        if p1 is not None and p2 is not None:
+            self._pick_phase = 2
+        elif p1 is not None:
+            self._pick_phase = 1
+        else:
+            self._pick_phase = 0
+        self.queue_draw()
+
     def _hit_test_point(self, px: float, py: float) -> Optional[int]:
         if self._point1 is not None:
             sx, sy = self._world_to_pixel(*self._point1)

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
@@ -1,0 +1,235 @@
+import math
+import logging
+from typing import Optional, Tuple
+
+from gi.repository import Gdk, Graphene, Gtk
+from blinker import Signal
+
+from rayforge.ui_gtk.canvas import WorldSurface
+from rayforge.ui_gtk.canvas2d.elements.workpiece import WorkPieceElement
+
+logger = logging.getLogger(__name__)
+
+MARKER_RADIUS = 4.0
+HIT_RADIUS = 12.0
+POINT_COLOR_1 = (0.18, 0.80, 0.44, 0.9)
+POINT_COLOR_2 = (0.29, 0.56, 0.85, 0.9)
+DASH_COLOR = (0.5, 0.5, 0.5, 0.7)
+
+
+class PickSurface(WorldSurface):
+    """A minimal canvas for picking alignment points on a workpiece."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            show_grid=True,
+            show_axis=True,
+            **kwargs,
+        )
+        self.remove_controller(self._drag_gesture)
+        self._ops_suppressed: bool = True
+        self._workpiece_elem: Optional[WorkPieceElement] = None
+
+        self._pick_phase: int = 0
+        self._point1: Optional[Tuple[float, float]] = None
+        self._point2: Optional[Tuple[float, float]] = None
+        self._dragging: Optional[int] = None
+
+        self.point_picked = Signal()
+        self.points_reset = Signal()
+        self.points_changed = Signal()
+
+        self._click_gesture = Gtk.GestureClick()
+        self._click_gesture.set_button(Gdk.BUTTON_PRIMARY)
+        self._click_gesture.connect("pressed", self._on_click)
+        self._click_gesture.set_propagation_phase(Gtk.PropagationPhase.BUBBLE)
+        self.add_controller(self._click_gesture)
+
+        self._drag_gesture = Gtk.GestureDrag.new()
+        self._drag_gesture.set_button(Gdk.BUTTON_PRIMARY)
+        self._drag_gesture.connect("drag-begin", self._on_drag_begin)
+        self._drag_gesture.connect("drag-update", self._on_drag_update)
+        self._drag_gesture.connect("drag-end", self._on_drag_end)
+        self.add_controller(self._drag_gesture)
+
+        self._motion_controller = Gtk.EventControllerMotion()
+        self._motion_controller.connect("motion", self._on_motion)
+        self.add_controller(self._motion_controller)
+
+        self._hover_pos: Optional[Tuple[float, float]] = None
+        self._drag_start_px: Optional[Tuple[float, float]] = None
+
+        self.set_cursor(Gdk.Cursor.new_from_name("crosshair"))
+
+    def set_workpiece_elem(self, elem: WorkPieceElement):
+        self._workpiece_elem = elem
+        elem.selectable = False
+        elem.show_selection_frame = False
+        self.root.add(elem)
+
+    @property
+    def ops_suppressed(self) -> bool:
+        return self._ops_suppressed
+
+    def get_global_tab_visibility(self) -> bool:
+        return False
+
+    def get_view_scale(self):
+        return super().get_view_scale()
+
+    def _rebuild_view_transform(self) -> bool:
+        scale_changed = super()._rebuild_view_transform()
+        if scale_changed and self._workpiece_elem is not None:
+            ppm_x, _ = self.get_view_scale()
+            self._workpiece_elem.trigger_view_update(ppm_x)
+        return scale_changed
+
+    @property
+    def point1(self) -> Optional[Tuple[float, float]]:
+        return self._point1
+
+    @property
+    def point2(self) -> Optional[Tuple[float, float]]:
+        return self._point2
+
+    @property
+    def is_complete(self) -> bool:
+        return self._pick_phase >= 2
+
+    def reset(self):
+        self._pick_phase = 0
+        self._point1 = None
+        self._point2 = None
+        self._dragging = None
+        self.points_reset.send(self)
+        self.queue_draw()
+
+    def _hit_test_point(self, px: float, py: float) -> Optional[int]:
+        if self._point1 is not None:
+            sx, sy = self._world_to_pixel(*self._point1)
+            if math.hypot(px - sx, py - sy) <= HIT_RADIUS:
+                return 0
+        if self._point2 is not None:
+            sx, sy = self._world_to_pixel(*self._point2)
+            if math.hypot(px - sx, py - sy) <= HIT_RADIUS:
+                return 1
+        return None
+
+    def _on_click(self, gesture, n_press, x, y):
+        if self._dragging is not None:
+            return
+
+        hit = self._hit_test_point(x, y)
+        if hit is not None:
+            return
+
+        world_x, world_y = self._get_world_coords(x, y)
+
+        if self._pick_phase == 0:
+            self._point1 = (world_x, world_y)
+            self._pick_phase = 1
+            self.point_picked.send(self, index=0, x=world_x, y=world_y)
+        elif self._pick_phase == 1:
+            self._point2 = (world_x, world_y)
+            self._pick_phase = 2
+            self.point_picked.send(self, index=1, x=world_x, y=world_y)
+
+        self.queue_draw()
+
+    def _on_drag_begin(self, gesture, start_x, start_y):
+        hit = self._hit_test_point(start_x, start_y)
+        if hit is not None:
+            self._dragging = hit
+            self._drag_start_px = (start_x, start_y)
+
+    def _on_drag_update(self, gesture, offset_x, offset_y):
+        if self._dragging is None or self._drag_start_px is None:
+            return
+
+        sx, sy = self._drag_start_px
+        current_x = sx + offset_x
+        current_y = sy + offset_y
+        world_x, world_y = self._get_world_coords(current_x, current_y)
+
+        if self._dragging == 0:
+            self._point1 = (world_x, world_y)
+        else:
+            self._point2 = (world_x, world_y)
+
+        self.points_changed.send(self)
+        self.queue_draw()
+
+    def _on_drag_end(self, gesture, offset_x, offset_y):
+        if self._dragging is not None:
+            self._on_drag_update(gesture, offset_x, offset_y)
+        self._dragging = None
+        self._drag_start_px = None
+
+    def _on_motion(self, controller, x, y):
+        self._hover_pos = (x, y)
+        self.queue_draw()
+
+    def do_snapshot(self, snapshot: Gtk.Snapshot) -> None:
+        super().do_snapshot(snapshot)
+
+        width = self.get_width()
+        height = self.get_height()
+        ctx = snapshot.append_cairo(Graphene.Rect().init(0, 0, width, height))
+
+        if self._point1 is not None:
+            self._draw_marker(ctx, self._point1, POINT_COLOR_1)
+        if self._point2 is not None:
+            self._draw_marker(ctx, self._point2, POINT_COLOR_2)
+        if self._point1 is not None and self._point2 is not None:
+            self._draw_dashed_line(ctx, self._point1, self._point2)
+        if (
+            self._hover_pos is not None
+            and self._pick_phase < 2
+            and self._dragging is None
+        ):
+            hx, hy = self._hover_pos
+            wx, wy = self._get_world_coords(hx, hy)
+            self._draw_crosshair(ctx, wx, wy)
+
+    def _world_to_pixel(self, wx, wy):
+        return self.view_transform.transform_point((wx, wy))
+
+    def _draw_marker(self, ctx, world_pos, color):
+        px, py = self._world_to_pixel(*world_pos)
+        r = MARKER_RADIUS
+
+        ctx.save()
+        ctx.arc(px, py, r, 0, 2 * math.pi)
+        ctx.set_source_rgba(*color)
+        ctx.fill_preserve()
+        ctx.set_source_rgba(1, 1, 1, 1)
+        ctx.set_line_width(1.5)
+        ctx.stroke()
+        ctx.restore()
+
+    def _draw_dashed_line(self, ctx, p1, p2):
+        px1, py1 = self._world_to_pixel(*p1)
+        px2, py2 = self._world_to_pixel(*p2)
+
+        ctx.save()
+        ctx.set_source_rgba(*DASH_COLOR)
+        ctx.set_line_width(1.5)
+        ctx.set_dash((6, 4))
+        ctx.move_to(px1, py1)
+        ctx.line_to(px2, py2)
+        ctx.stroke()
+        ctx.restore()
+
+    def _draw_crosshair(self, ctx, wx, wy):
+        px, py = self._world_to_pixel(wx, wy)
+        size = 10
+
+        ctx.save()
+        ctx.set_source_rgba(0.9, 0.9, 0.9, 0.8)
+        ctx.set_line_width(1.0)
+        ctx.move_to(px - size, py)
+        ctx.line_to(px + size, py)
+        ctx.move_to(px, py - size)
+        ctx.line_to(px, py + size)
+        ctx.stroke()
+        ctx.restore()

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
@@ -2,11 +2,13 @@ import math
 import logging
 from typing import Optional, Tuple
 
+import cairo
 from gi.repository import Gdk, Graphene, Gtk
 from blinker import Signal
 
-from rayforge.ui_gtk.canvas import WorldSurface
-from rayforge.ui_gtk.canvas2d.elements.workpiece import WorkPieceElement
+from rayforge.core.matrix import Matrix
+from rayforge.core.workpiece import WorkPiece
+from rayforge.ui_gtk.canvas import Canvas
 
 logger = logging.getLogger(__name__)
 
@@ -16,19 +18,32 @@ POINT_COLOR_1 = (0.18, 0.80, 0.44, 0.9)
 POINT_COLOR_2 = (0.29, 0.56, 0.85, 0.9)
 DASH_COLOR = (0.5, 0.5, 0.5, 0.7)
 
+MIN_ZOOM_FACTOR = 0.1
+MAX_PIXELS_PER_MM = 100.0
 
-class PickSurface(WorldSurface):
-    """A minimal canvas for picking alignment points on a workpiece."""
 
-    def __init__(self, **kwargs):
-        super().__init__(
-            show_grid=False,
-            show_axis=False,
-            **kwargs,
-        )
-        self.remove_controller(self._drag_gesture)
-        self._ops_suppressed: bool = True
-        self._workpiece_elem: Optional[WorkPieceElement] = None
+class PickSurface(Canvas):
+    """A canvas for picking alignment points on a workpiece image.
+
+    Displays the workpiece at its natural size fitted to view and reports
+    click coordinates in normalized workpiece-local space (0-1, origin at
+    bottom-left, Y-up). Supports scroll-to-zoom and middle-button panning.
+    """
+
+    def __init__(self, workpiece: WorkPiece, **kwargs):
+        super().__init__(**kwargs)
+        self._workpiece = workpiece
+        nw, nh = workpiece.natural_size
+        self._width_mm = max(nw, 1e-9)
+        self._height_mm = max(nh, 1e-9)
+
+        self.zoom_level: float = 1.0
+        self.pan_x_mm: float = 0.0
+        self.pan_y_mm: float = 0.0
+        self._base_scale: float = 0.0
+        self._base_offset_x: float = 0.0
+        self._base_offset_y: float = 0.0
+        self._base_img_h: float = 0.0
 
         self._pick_phase: int = 0
         self._point1: Optional[Tuple[float, float]] = None
@@ -45,12 +60,24 @@ class PickSurface(WorldSurface):
         self._click_gesture.set_propagation_phase(Gtk.PropagationPhase.BUBBLE)
         self.add_controller(self._click_gesture)
 
-        self._drag_gesture = Gtk.GestureDrag.new()
-        self._drag_gesture.set_button(Gdk.BUTTON_PRIMARY)
-        self._drag_gesture.connect("drag-begin", self._on_drag_begin)
-        self._drag_gesture.connect("drag-update", self._on_drag_update)
-        self._drag_gesture.connect("drag-end", self._on_drag_end)
-        self.add_controller(self._drag_gesture)
+        self._pick_drag_gesture = Gtk.GestureDrag.new()
+        self._pick_drag_gesture.set_button(Gdk.BUTTON_PRIMARY)
+        self._pick_drag_gesture.connect("drag-begin", self._on_drag_begin)
+        self._pick_drag_gesture.connect("drag-update", self._on_drag_update)
+        self._pick_drag_gesture.connect("drag-end", self._on_drag_end)
+        self.add_controller(self._pick_drag_gesture)
+
+        self._pan_gesture = Gtk.GestureDrag.new()
+        self._pan_gesture.set_button(Gdk.BUTTON_MIDDLE)
+        self._pan_gesture.connect("drag-begin", self._on_pan_begin)
+        self._pan_gesture.connect("drag-update", self._on_pan_update)
+        self.add_controller(self._pan_gesture)
+
+        self._scroll_controller = Gtk.EventControllerScroll.new(
+            Gtk.EventControllerScrollFlags.VERTICAL
+        )
+        self._scroll_controller.connect("scroll", self._on_scroll)
+        self.add_controller(self._scroll_controller)
 
         self._motion_controller = Gtk.EventControllerMotion()
         self._motion_controller.connect("motion", self._on_motion)
@@ -58,31 +85,102 @@ class PickSurface(WorldSurface):
 
         self._hover_pos: Optional[Tuple[float, float]] = None
         self._drag_start_px: Optional[Tuple[float, float]] = None
+        self._cached_surface: Optional[cairo.ImageSurface] = None
+        self._cached_ppmm: float = 0.0
+        self._pan_start_x_mm: float = 0.0
+        self._pan_start_y_mm: float = 0.0
 
         self.set_cursor(Gdk.Cursor.new_from_name("crosshair"))
 
-    def set_workpiece_elem(self, elem: WorkPieceElement):
-        self._workpiece_elem = elem
-        elem.selectable = False
-        elem.show_selection_frame = False
-        self.root.add(elem)
+    def _rebuild_view_transform(self):
+        widget_w, widget_h = self.get_width(), self.get_height()
+        if widget_w == 0 or widget_h == 0:
+            return
 
-    @property
-    def ops_suppressed(self) -> bool:
-        return self._ops_suppressed
+        scale_x = widget_w / self._width_mm
+        scale_y = widget_h / self._height_mm
+        base_scale = min(scale_x, scale_y)
 
-    def get_global_tab_visibility(self) -> bool:
-        return False
+        img_w = self._width_mm * base_scale
+        img_h = self._height_mm * base_scale
+        base_offset_x = (widget_w - img_w) / 2
+        base_offset_y = (widget_h - img_h) / 2
 
-    def get_view_scale(self):
-        return super().get_view_scale()
+        self._base_scale = base_scale
+        self._base_offset_x = base_offset_x
+        self._base_offset_y = base_offset_y
+        self._base_img_h = img_h
 
-    def _rebuild_view_transform(self) -> bool:
-        scale_changed = super()._rebuild_view_transform()
-        if scale_changed and self._workpiece_elem is not None:
-            ppm_x, _ = self.get_view_scale()
-            self._workpiece_elem.trigger_view_update(ppm_x)
-        return scale_changed
+        m_pan = Matrix.translation(-self.pan_x_mm, -self.pan_y_mm)
+        m_scale = Matrix.translation(0, img_h) @ Matrix.scale(
+            base_scale, -base_scale
+        )
+        m_zoom = Matrix.scale(self.zoom_level, self.zoom_level)
+        m_offset = Matrix.translation(base_offset_x, base_offset_y)
+
+        self.view_transform = m_offset @ m_zoom @ m_scale @ m_pan
+
+        new_ppmm = base_scale * self.zoom_level
+        if abs(new_ppmm - self._cached_ppmm) > 0.01:
+            self._cached_surface = None
+            self._cached_ppmm = new_ppmm
+
+        self.queue_draw()
+
+    def _get_image_surface(self) -> Optional[cairo.ImageSurface]:
+        if self._cached_surface is not None:
+            return self._cached_surface
+        ppmm = self._cached_ppmm
+        if ppmm <= 0:
+            return None
+        w = max(int(self._width_mm * ppmm), 1)
+        h = max(int(self._height_mm * ppmm), 1)
+        self._cached_surface = self._workpiece.render_to_pixels(w, h)
+        return self._cached_surface
+
+    def do_size_allocate(self, width, height, baseline):
+        super().do_size_allocate(width, height, baseline)
+        self._rebuild_view_transform()
+
+    def do_snapshot(self, snapshot: Gtk.Snapshot) -> None:
+        width = self.get_width()
+        height = self.get_height()
+        ctx = snapshot.append_cairo(Graphene.Rect().init(0, 0, width, height))
+
+        img_surface = self._get_image_surface()
+        if img_surface is not None:
+            ctx.save()
+            cairo_matrix = cairo.Matrix(*self.view_transform.for_cairo())
+            ctx.transform(cairo_matrix)
+            ctx.translate(0, self._height_mm)
+            ctx.scale(1, -1)
+            img_w = img_surface.get_width()
+            img_h = img_surface.get_height()
+            if img_w > 0 and img_h > 0:
+                ctx.scale(
+                    self._width_mm / img_w,
+                    self._height_mm / img_h,
+                )
+            ctx.set_source_surface(img_surface, 0, 0)
+            ctx.paint()
+            ctx.restore()
+
+        if self._point1 is not None:
+            self._draw_marker(ctx, self._point1, POINT_COLOR_1)
+        if self._point2 is not None:
+            self._draw_marker(ctx, self._point2, POINT_COLOR_2)
+        if self._point1 is not None and self._point2 is not None:
+            self._draw_dashed_line(ctx, self._point1, self._point2)
+        if (
+            self._hover_pos is not None
+            and self._pick_phase < 2
+            and self._dragging is None
+        ):
+            hx, hy = self._hover_pos
+            mm_x, mm_y = self._get_world_coords(hx, hy)
+            norm_x = mm_x / self._width_mm
+            norm_y = mm_y / self._height_mm
+            self._draw_crosshair(ctx, norm_x, norm_y)
 
     @property
     def point1(self) -> Optional[Tuple[float, float]]:
@@ -119,13 +217,54 @@ class PickSurface(WorldSurface):
             self._pick_phase = 0
         self.queue_draw()
 
+    def _on_scroll(self, controller, dx, dy):
+        zoom_speed = 0.1
+        desired_zoom = self.zoom_level * (
+            (1 - zoom_speed) if dy > 0 else (1 + zoom_speed)
+        )
+
+        if self._base_scale <= 0:
+            return
+        base_ppm = self._base_scale
+        min_ppm = base_ppm * MIN_ZOOM_FACTOR
+        max_ppm = MAX_PIXELS_PER_MM
+        clamped_ppm = max(min_ppm, min(base_ppm * desired_zoom, max_ppm))
+        final_zoom = clamped_ppm / base_ppm
+        if abs(final_zoom - self.zoom_level) < 1e-9:
+            return
+
+        if self._hover_pos is not None:
+            mx, my = self._hover_pos
+            focus_x, focus_y = self._get_world_coords(mx, my)
+            self.zoom_level = final_zoom
+            self._rebuild_view_transform()
+            new_x, new_y = self._get_world_coords(mx, my)
+            self.pan_x_mm += focus_x - new_x
+            self.pan_y_mm += focus_y - new_y
+        else:
+            self.zoom_level = final_zoom
+
+        self._rebuild_view_transform()
+
+    def _on_pan_begin(self, gesture, start_x, start_y):
+        self._pan_start_x_mm = self.pan_x_mm
+        self._pan_start_y_mm = self.pan_y_mm
+
+    def _on_pan_update(self, gesture, offset_x, offset_y):
+        if self._base_scale <= 0:
+            return
+        scale = self._base_scale * self.zoom_level
+        self.pan_x_mm = self._pan_start_x_mm - offset_x / scale
+        self.pan_y_mm = self._pan_start_y_mm + offset_y / scale
+        self._rebuild_view_transform()
+
     def _hit_test_point(self, px: float, py: float) -> Optional[int]:
         if self._point1 is not None:
-            sx, sy = self._world_to_pixel(*self._point1)
+            sx, sy = self._local_to_pixel(*self._point1)
             if math.hypot(px - sx, py - sy) <= HIT_RADIUS:
                 return 0
         if self._point2 is not None:
-            sx, sy = self._world_to_pixel(*self._point2)
+            sx, sy = self._local_to_pixel(*self._point2)
             if math.hypot(px - sx, py - sy) <= HIT_RADIUS:
                 return 1
         return None
@@ -138,16 +277,18 @@ class PickSurface(WorldSurface):
         if hit is not None:
             return
 
-        world_x, world_y = self._get_world_coords(x, y)
+        mm_x, mm_y = self._get_world_coords(x, y)
+        norm_x = mm_x / self._width_mm
+        norm_y = mm_y / self._height_mm
 
         if self._pick_phase == 0:
-            self._point1 = (world_x, world_y)
+            self._point1 = (norm_x, norm_y)
             self._pick_phase = 1
-            self.point_picked.send(self, index=0, x=world_x, y=world_y)
+            self.point_picked.send(self, index=0, x=norm_x, y=norm_y)
         elif self._pick_phase == 1:
-            self._point2 = (world_x, world_y)
+            self._point2 = (norm_x, norm_y)
             self._pick_phase = 2
-            self.point_picked.send(self, index=1, x=world_x, y=world_y)
+            self.point_picked.send(self, index=1, x=norm_x, y=norm_y)
 
         self.queue_draw()
 
@@ -164,12 +305,14 @@ class PickSurface(WorldSurface):
         sx, sy = self._drag_start_px
         current_x = sx + offset_x
         current_y = sy + offset_y
-        world_x, world_y = self._get_world_coords(current_x, current_y)
+        mm_x, mm_y = self._get_world_coords(current_x, current_y)
+        norm_x = mm_x / self._width_mm
+        norm_y = mm_y / self._height_mm
 
         if self._dragging == 0:
-            self._point1 = (world_x, world_y)
+            self._point1 = (norm_x, norm_y)
         else:
-            self._point2 = (world_x, world_y)
+            self._point2 = (norm_x, norm_y)
 
         self.points_changed.send(self)
         self.queue_draw()
@@ -184,33 +327,13 @@ class PickSurface(WorldSurface):
         self._hover_pos = (x, y)
         self.queue_draw()
 
-    def do_snapshot(self, snapshot: Gtk.Snapshot) -> None:
-        super().do_snapshot(snapshot)
+    def _local_to_pixel(self, norm_x, norm_y):
+        mm_x = norm_x * self._width_mm
+        mm_y = norm_y * self._height_mm
+        return self.view_transform.transform_point((mm_x, mm_y))
 
-        width = self.get_width()
-        height = self.get_height()
-        ctx = snapshot.append_cairo(Graphene.Rect().init(0, 0, width, height))
-
-        if self._point1 is not None:
-            self._draw_marker(ctx, self._point1, POINT_COLOR_1)
-        if self._point2 is not None:
-            self._draw_marker(ctx, self._point2, POINT_COLOR_2)
-        if self._point1 is not None and self._point2 is not None:
-            self._draw_dashed_line(ctx, self._point1, self._point2)
-        if (
-            self._hover_pos is not None
-            and self._pick_phase < 2
-            and self._dragging is None
-        ):
-            hx, hy = self._hover_pos
-            wx, wy = self._get_world_coords(hx, hy)
-            self._draw_crosshair(ctx, wx, wy)
-
-    def _world_to_pixel(self, wx, wy):
-        return self.view_transform.transform_point((wx, wy))
-
-    def _draw_marker(self, ctx, world_pos, color):
-        px, py = self._world_to_pixel(*world_pos)
+    def _draw_marker(self, ctx, local_pos, color):
+        px, py = self._local_to_pixel(*local_pos)
         r = MARKER_RADIUS
 
         ctx.save()
@@ -223,8 +346,8 @@ class PickSurface(WorldSurface):
         ctx.restore()
 
     def _draw_dashed_line(self, ctx, p1, p2):
-        px1, py1 = self._world_to_pixel(*p1)
-        px2, py2 = self._world_to_pixel(*p2)
+        px1, py1 = self._local_to_pixel(*p1)
+        px2, py2 = self._local_to_pixel(*p2)
 
         ctx.save()
         ctx.set_source_rgba(*DASH_COLOR)
@@ -235,8 +358,8 @@ class PickSurface(WorldSurface):
         ctx.stroke()
         ctx.restore()
 
-    def _draw_crosshair(self, ctx, wx, wy):
-        px, py = self._world_to_pixel(wx, wy)
+    def _draw_crosshair(self, ctx, lx, ly):
+        px, py = self._local_to_pixel(lx, ly)
         size = 10
 
         ctx.save()

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/pick_surface.py
@@ -22,8 +22,8 @@ class PickSurface(WorldSurface):
 
     def __init__(self, **kwargs):
         super().__init__(
-            show_grid=True,
-            show_axis=True,
+            show_grid=False,
+            show_axis=False,
             **kwargs,
         )
         self.remove_controller(self._drag_gesture)

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -13,10 +13,8 @@ from rayforge.doceditor.editor import DocEditor
 from rayforge.ui_gtk.shared.patched_dialog_window import (
     PatchedDialogWindow,
 )
-from rayforge.ui_gtk.canvas2d.elements.workpiece import WorkPieceElement
 from rayforge.ui_gtk.icons import get_icon
 from rayforge.ui_gtk.machine.jog_widget import JogWidget
-from rayforge.context import get_context
 from .pick_surface import PickSurface
 
 logger = logging.getLogger(__name__)
@@ -161,25 +159,9 @@ class PrintAndCutWizard(PatchedDialogWindow):
         )
 
     def _setup_left_panel(self):
-        ctx = get_context()
-        machine = ctx.machine
-        if machine:
-            wa_w = float(machine.axis_extents[0])
-            wa_h = float(machine.axis_extents[1])
-        else:
-            wa_w, wa_h = 100.0, 100.0
-
         self._pick_surface = PickSurface(
-            width_mm=wa_w,
-            height_mm=wa_h,
-        )
-
-        wp_elem = WorkPieceElement(
             workpiece=self._workpiece,
-            view_manager=self._editor.view_manager,
-            canvas=self._pick_surface,
         )
-        self._pick_surface.set_workpiece_elem(wp_elem)
         self._pick_surface.set_hexpand(True)
         self._pick_surface.set_vexpand(True)
         self._pick_surface.set_halign(Gtk.Align.FILL)
@@ -499,10 +481,10 @@ class PrintAndCutWizard(PatchedDialogWindow):
 
         if pp1 is not None:
             self._physical_point1 = pp1
-            self._pos1_row.set_subtitle(f"({pp1[0]:.2f}, {pp1[1]:.2f}) mm")
+            self._pos1_row.set_subtitle(f"({pp1[0]:.2f}, {pp1[1]:.2f})")
         if pp2 is not None:
             self._physical_point2 = pp2
-            self._pos2_row.set_subtitle(f"({pp2[0]:.2f}, {pp2[1]:.2f}) mm")
+            self._pos2_row.set_subtitle(f"({pp2[0]:.2f}, {pp2[1]:.2f})")
 
         self._update_pick_next_btn()
 
@@ -527,15 +509,13 @@ class PrintAndCutWizard(PatchedDialogWindow):
         if x_val is None or y_val is None:
             return
 
-        space = self._machine.get_coordinate_space()
-        wx, wy = space.machine_point_to_world(x_val, y_val)
-
+        subtitle = f"({x_val:.2f}, {y_val:.2f})"
         if pos_index == 0:
-            self._physical_point1 = (wx, wy)
-            self._pos1_row.set_subtitle(f"({wx:.2f}, {wy:.2f}) mm")
+            self._physical_point1 = (x_val, y_val)
+            self._pos1_row.set_subtitle(subtitle)
         else:
-            self._physical_point2 = (wx, wy)
-            self._pos2_row.set_subtitle(f"({wx:.2f}, {wy:.2f}) mm")
+            self._physical_point2 = (x_val, y_val)
+            self._pos2_row.set_subtitle(subtitle)
 
         self._update_jog_next_btn()
         self._save_session_state()
@@ -570,9 +550,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
         if pos:
             x_val, y_val, _z_val = pos
             if x_val is not None and y_val is not None:
-                self._laser_row.set_subtitle(
-                    f"X: {x_val:.2f}  Y: {y_val:.2f} mm"
-                )
+                self._laser_row.set_subtitle(f"X: {x_val:.2f}  Y: {y_val:.2f}")
 
     def _on_distance_changed(self, spin_row):
         self._jog_widget.jog_distance = float(spin_row.get_value())
@@ -622,6 +600,32 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._allow_scale = check_btn.get_active()
         self._update_apply_preview()
 
+    def _local_to_world(
+        self, norm_x: float, norm_y: float
+    ) -> Tuple[float, float]:
+        return self._workpiece.get_world_transform().transform_point(
+            (norm_x, norm_y)
+        )
+
+    def _machine_to_world(self, wx: float, wy: float) -> Tuple[float, float]:
+        space = self._machine.get_coordinate_space()
+        wcs_x, wcs_y, _wcs_z = self._machine.get_active_wcs_offset()
+        return space.machine_point_to_world(wx + wcs_x, wy + wcs_y)
+
+    def _get_world_design_points(self):
+        assert self._design_point1 is not None
+        assert self._design_point2 is not None
+        d1 = self._local_to_world(*self._design_point1)
+        d2 = self._local_to_world(*self._design_point2)
+        return d1, d2
+
+    def _get_world_physical_points(self):
+        assert self._physical_point1 is not None
+        assert self._physical_point2 is not None
+        p1 = self._machine_to_world(*self._physical_point1)
+        p2 = self._machine_to_world(*self._physical_point2)
+        return p1, p2
+
     def _update_apply_preview(self):
         if (
             self._design_point1 is None
@@ -631,18 +635,17 @@ class PrintAndCutWizard(PatchedDialogWindow):
         ):
             return
 
+        d1, d2 = self._get_world_design_points()
+        p1, p2 = self._get_world_physical_points()
+
         T = calculate_alignment_transform(
-            self._design_point1,
-            self._design_point2,
-            self._physical_point1,
-            self._physical_point2,
-            allow_scale=self._allow_scale,
+            d1, d2, p1, p2, allow_scale=self._allow_scale
         )
 
         _tx, _ty, angle, sx, sy, _skew = T.decompose()
         tx, ty = T.get_translation()
 
-        self._translation_row.set_subtitle(f"({tx:.2f}, {ty:.2f}) mm")
+        self._translation_row.set_subtitle(f"({tx:.2f}, {ty:.2f})")
         self._rotation_row.set_subtitle(f"{angle:.2f}\u00b0")
 
         if self._allow_scale:
@@ -650,8 +653,8 @@ class PrintAndCutWizard(PatchedDialogWindow):
             self._warning_label.set_visible(False)
         else:
             dist_d = math.hypot(
-                self._design_point2[0] - self._design_point1[0],
-                self._design_point2[1] - self._design_point1[1],
+                d2[0] - d1[0],
+                d2[1] - d1[1],
             )
             dist_p = math.hypot(
                 self._physical_point2[0] - self._physical_point1[0],
@@ -725,8 +728,8 @@ class PrintAndCutWizard(PatchedDialogWindow):
         ):
             return
 
-        d1, d2 = self._design_point1, self._design_point2
-        p1, p2 = self._physical_point1, self._physical_point2
+        d1, d2 = self._get_world_design_points()
+        p1, p2 = self._get_world_physical_points()
 
         T = calculate_alignment_transform(
             d1, d2, p1, p2, allow_scale=self._allow_scale
@@ -738,8 +741,6 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._editor.transform.create_transform_transaction(
             [(self._workpiece, old_matrix, new_matrix)]
         )
-
-        _session_state.pop(self._workpiece.uid, None)
 
         toast = Adw.Toast(title=_("Alignment applied"))
         self.toast_overlay.add_toast(toast)

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -276,7 +276,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
         )
         jog_frame.set_child(jog_inner)
 
-        self._jog_widget = JogWidget()
+        self._jog_widget = JogWidget(show_actions=False)
         self._jog_widget.set_machine(self._machine, self._machine_cmd)
         jog_inner.append(self._jog_widget)
 

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -1,0 +1,604 @@
+import math
+import logging
+from gettext import gettext as _
+from typing import Optional, Tuple
+
+from gi.repository import Adw, Gtk
+
+from rayforge.core.matrix import Matrix
+from rayforge.core.workpiece import WorkPiece
+from rayforge.machine.models.machine import Machine
+from rayforge.machine.cmd import MachineCmd
+from rayforge.doceditor.editor import DocEditor
+from rayforge.ui_gtk.shared.patched_dialog_window import (
+    PatchedDialogWindow,
+)
+from rayforge.ui_gtk.canvas2d.elements.workpiece import WorkPieceElement
+from rayforge.ui_gtk.machine.jog_widget import JogWidget
+from rayforge.context import get_context
+from .pick_surface import PickSurface
+
+logger = logging.getLogger(__name__)
+
+MIN_POINT_DISTANCE = 0.5
+
+
+def calculate_alignment_transform(
+    d1: Tuple[float, float],
+    d2: Tuple[float, float],
+    p1: Tuple[float, float],
+    p2: Tuple[float, float],
+    allow_scale: bool = False,
+) -> Matrix:
+    angle_d = math.atan2(d2[1] - d1[1], d2[0] - d1[0])
+    angle_p = math.atan2(p2[1] - p1[1], p2[0] - p1[0])
+    angle = math.degrees(angle_p - angle_d)
+
+    dist_d = math.hypot(d2[0] - d1[0], d2[1] - d1[1])
+    dist_p = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+    scale = dist_p / dist_d if allow_scale and dist_d > 0 else 1.0
+
+    return (
+        Matrix.translation(*p1)
+        @ Matrix.rotation(angle)
+        @ Matrix.scale(scale, scale)
+        @ Matrix.translation(-d1[0], -d1[1])
+    )
+
+
+class PrintAndCutWizard(PatchedDialogWindow):
+    def __init__(
+        self,
+        parent,
+        workpiece: WorkPiece,
+        machine: Machine,
+        machine_cmd: MachineCmd,
+        editor: DocEditor,
+        **kwargs,
+    ):
+        super().__init__(
+            transient_for=parent,
+            default_width=1150,
+            default_height=750,
+            title=_("Print & Cut"),
+            **kwargs,
+        )
+
+        self._workpiece = workpiece
+        self._machine = machine
+        self._machine_cmd = machine_cmd
+        self._editor = editor
+
+        self._design_point1: Optional[Tuple[float, float]] = None
+        self._design_point2: Optional[Tuple[float, float]] = None
+
+        self._physical_point1: Optional[Tuple[float, float]] = None
+        self._physical_point2: Optional[Tuple[float, float]] = None
+
+        self._allow_scale: bool = False
+
+        self._setup_ui()
+
+    def _setup_ui(self):
+        self.toast_overlay = Adw.ToastOverlay()
+        self.set_content(self.toast_overlay)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.toast_overlay.set_child(content)
+
+        header = Adw.HeaderBar()
+        content.append(header)
+
+        self._main_box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=16,
+            margin_start=12,
+            margin_top=12,
+            margin_bottom=12,
+        )
+        content.append(self._main_box)
+
+        self._left_panel = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+        )
+        self._left_panel.set_hexpand(True)
+        self._left_panel.set_vexpand(True)
+        self._main_box.append(self._left_panel)
+
+        self._right_stack = Gtk.Stack()
+        self._right_stack.set_transition_type(
+            Gtk.StackTransitionType.SLIDE_LEFT_RIGHT
+        )
+        self._right_stack.set_hexpand(False)
+        self._main_box.append(self._right_stack)
+
+        self._setup_left_panel()
+        self._setup_right_stack()
+
+        self._button_box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=12,
+            halign=Gtk.Align.END,
+            margin_end=12,
+            margin_bottom=12,
+        )
+        content.append(self._button_box)
+
+        self._back_btn = Gtk.Button(label=_("Back"))
+        self._back_btn.add_css_class("flat")
+        self._back_btn.connect("clicked", self._on_back_clicked)
+        self._back_btn.set_visible(False)
+        self._button_box.append(self._back_btn)
+
+        self._reset_btn = Gtk.Button(label=_("Reset"))
+        self._reset_btn.add_css_class("flat")
+        self._reset_btn.connect("clicked", self._on_reset_clicked)
+        self._button_box.append(self._reset_btn)
+
+        self._cancel_btn = Gtk.Button(label=_("Cancel"))
+        self._cancel_btn.add_css_class("flat")
+        self._cancel_btn.connect("clicked", lambda _: self.close())
+        self._button_box.append(self._cancel_btn)
+
+        self._next_btn = Gtk.Button(label=_("Next"))
+        self._next_btn.add_css_class("suggested-action")
+        self._next_btn.connect("clicked", self._on_next_clicked)
+        self._next_btn.set_sensitive(False)
+        self._button_box.append(self._next_btn)
+
+        self._apply_btn = Gtk.Button(label=_("Apply"))
+        self._apply_btn.add_css_class("suggested-action")
+        self._apply_btn.connect("clicked", self._on_apply_clicked)
+        self._apply_btn.set_visible(False)
+        self._button_box.append(self._apply_btn)
+
+        self._right_stack.connect(
+            "notify::visible-child", self._on_page_changed
+        )
+
+    def _setup_left_panel(self):
+        ctx = get_context()
+        machine = ctx.machine
+        if machine:
+            wa_w = float(machine.axis_extents[0])
+            wa_h = float(machine.axis_extents[1])
+        else:
+            wa_w, wa_h = 100.0, 100.0
+
+        self._pick_surface = PickSurface(
+            width_mm=wa_w,
+            height_mm=wa_h,
+        )
+
+        wp_elem = WorkPieceElement(
+            workpiece=self._workpiece,
+            view_manager=self._editor.view_manager,
+            canvas=self._pick_surface,
+        )
+        self._pick_surface.set_workpiece_elem(wp_elem)
+        self._pick_surface.set_hexpand(True)
+        self._pick_surface.set_vexpand(True)
+        self._pick_surface.set_halign(Gtk.Align.FILL)
+        self._pick_surface.point_picked.connect(self._on_design_point_picked)
+        self._pick_surface.points_reset.connect(self._on_design_points_reset)
+        self._pick_surface.points_changed.connect(
+            self._on_design_points_changed
+        )
+        self._left_panel.append(self._pick_surface)
+
+    def _setup_right_stack(self):
+        self._setup_pick_panel()
+        self._setup_jog_panel()
+        self._setup_apply_panel()
+
+    def _setup_pick_panel(self):
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._right_stack.add_named(scroll, "pick")
+
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+            width_request=500,
+            hexpand=False,
+        )
+        box.set_margin_start(12)
+        box.set_margin_end(32)
+        box.set_margin_top(4)
+        box.set_margin_bottom(12)
+        scroll.set_child(box)
+
+        intro_group = Adw.PreferencesGroup(
+            title=_("Instructions"),
+            description=_(
+                "Click on two alignment points on the design. "
+                "These will be matched to physical locations in "
+                "the next step."
+            ),
+        )
+        box.append(intro_group)
+
+        points_group = Adw.PreferencesGroup(title=_("Picked Points"))
+        box.append(points_group)
+
+        self._point1_row = Adw.ActionRow(title=_("Point 1"))
+        self._point1_row.set_subtitle(_("not set"))
+        points_group.add(self._point1_row)
+
+        self._point2_row = Adw.ActionRow(title=_("Point 2"))
+        self._point2_row.set_subtitle(_("not set"))
+        points_group.add(self._point2_row)
+
+        self._pick_status_row = Adw.ActionRow(title=_("Status"))
+        self._pick_status_row.set_subtitle(
+            _("Click on the first alignment point on the design.")
+        )
+        points_group.add(self._pick_status_row)
+
+    def _setup_jog_panel(self):
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._right_stack.add_named(scroll, "jog")
+
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+            width_request=500,
+            hexpand=False,
+        )
+        box.set_margin_start(12)
+        box.set_margin_end(32)
+        box.set_margin_top(4)
+        box.set_margin_bottom(12)
+        scroll.set_child(box)
+
+        intro_group = Adw.PreferencesGroup(
+            title=_("Instructions"),
+            description=_(
+                "Jog the laser to the physical location of each "
+                "point, then record the position."
+            ),
+        )
+        box.append(intro_group)
+
+        jog_frame = Gtk.Frame(halign=Gtk.Align.CENTER)
+        jog_frame.add_css_class("card")
+        box.append(jog_frame)
+
+        jog_inner = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=6,
+            margin_top=6,
+            margin_bottom=6,
+            margin_start=6,
+            margin_end=6,
+            halign=Gtk.Align.CENTER,
+        )
+        jog_frame.set_child(jog_inner)
+
+        self._jog_widget = JogWidget()
+        self._jog_widget.set_machine(self._machine, self._machine_cmd)
+        jog_inner.append(self._jog_widget)
+
+        positions_group = Adw.PreferencesGroup(title=_("Positions"))
+        box.append(positions_group)
+
+        self._record1_btn = Gtk.Button(
+            label=_("Record"), valign=Gtk.Align.CENTER
+        )
+        self._record1_btn.add_css_class("suggested-action")
+        self._record1_btn.connect("clicked", self._on_record_clicked, 0)
+
+        self._pos1_row = Adw.ActionRow(title=_("Position 1"))
+        self._pos1_row.set_subtitle(_("not set"))
+        self._pos1_row.add_suffix(self._record1_btn)
+        positions_group.add(self._pos1_row)
+
+        self._record2_btn = Gtk.Button(
+            label=_("Record"), valign=Gtk.Align.CENTER
+        )
+        self._record2_btn.add_css_class("suggested-action")
+        self._record2_btn.connect("clicked", self._on_record_clicked, 1)
+
+        self._pos2_row = Adw.ActionRow(title=_("Position 2"))
+        self._pos2_row.set_subtitle(_("not set"))
+        self._pos2_row.add_suffix(self._record2_btn)
+        positions_group.add(self._pos2_row)
+
+        self._laser_row = Adw.ActionRow(title=_("Laser Position"))
+        self._laser_row.set_subtitle(_("X: --- Y: ---"))
+        positions_group.add(self._laser_row)
+
+        if self._machine and self._machine.is_connected():
+            self._machine.state_changed.connect(self._on_machine_state_changed)
+            self._update_laser_position()
+        else:
+            self._jog_widget.set_sensitive(False)
+            self._record1_btn.set_sensitive(False)
+            self._record2_btn.set_sensitive(False)
+
+    def _setup_apply_panel(self):
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._right_stack.add_named(scroll, "apply")
+
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+            hexpand=True,
+        )
+        box.set_margin_start(24)
+        box.set_margin_end(24)
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        scroll.set_child(box)
+
+        intro_group = Adw.PreferencesGroup(
+            title=_("Transform Preview"),
+            description=_(
+                "Review the computed alignment transform before applying it."
+            ),
+        )
+        box.append(intro_group)
+
+        transform_group = Adw.PreferencesGroup(title=_("Transform"))
+        box.append(transform_group)
+
+        self._translation_row = Adw.ActionRow(title=_("Translation"))
+        self._translation_row.set_subtitle("---")
+        transform_group.add(self._translation_row)
+
+        self._rotation_row = Adw.ActionRow(title=_("Rotation"))
+        self._rotation_row.set_subtitle("---")
+        transform_group.add(self._rotation_row)
+
+        self._scale_row = Adw.ActionRow(title=_("Scale"))
+        self._scale_row.set_subtitle("---")
+        transform_group.add(self._scale_row)
+
+        self._scale_check = Gtk.CheckButton(
+            label=_("Allow scaling"),
+        )
+        self._scale_check.set_active(False)
+        self._scale_check.connect("toggled", self._on_scale_toggled)
+        box.append(self._scale_check)
+
+        self._warning_label = Gtk.Label(label="")
+        self._warning_label.add_css_class("warning-label")
+        self._warning_label.set_visible(False)
+        self._warning_label.set_wrap(True)
+        self._warning_label.set_xalign(0.0)
+        box.append(self._warning_label)
+
+    def _on_design_point_picked(self, sender, **kwargs):
+        index = kwargs.get("index", 0)
+        x = kwargs.get("x", 0.0)
+        y = kwargs.get("y", 0.0)
+
+        if index == 0:
+            self._design_point1 = (x, y)
+            self._point1_row.set_subtitle(f"({x:.2f}, {y:.2f}) mm")
+            self._pick_status_row.set_subtitle(
+                _("Click on the second alignment point on the design.")
+            )
+        elif index == 1:
+            self._design_point2 = (x, y)
+            self._point2_row.set_subtitle(f"({x:.2f}, {y:.2f}) mm")
+            self._pick_status_row.set_subtitle(
+                _("Both points selected. Click Next to continue.")
+            )
+
+        self._update_pick_next_btn()
+
+    def _on_design_points_changed(self, sender):
+        p1 = self._pick_surface.point1
+        p2 = self._pick_surface.point2
+        self._design_point1 = p1
+        self._design_point2 = p2
+        if p1 is not None:
+            self._point1_row.set_subtitle(f"({p1[0]:.2f}, {p1[1]:.2f}) mm")
+        if p2 is not None:
+            self._point2_row.set_subtitle(f"({p2[0]:.2f}, {p2[1]:.2f}) mm")
+        self._update_pick_next_btn()
+
+    def _on_design_points_reset(self, sender):
+        self._design_point1 = None
+        self._design_point2 = None
+        self._point1_row.set_subtitle(_("not set"))
+        self._point2_row.set_subtitle(_("not set"))
+        self._pick_status_row.set_subtitle(
+            _("Click on the first alignment point on the design.")
+        )
+        self._update_pick_next_btn()
+
+    def _update_pick_next_btn(self):
+        p1 = self._design_point1
+        p2 = self._design_point2
+        if p1 is not None and p2 is not None:
+            dist = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+            self._next_btn.set_sensitive(dist >= MIN_POINT_DISTANCE)
+            if dist < MIN_POINT_DISTANCE:
+                self._pick_status_row.set_subtitle(
+                    _("Points are too close. Pick points further apart.")
+                )
+        else:
+            self._next_btn.set_sensitive(False)
+
+    def _on_record_clicked(self, button, pos_index):
+        if not self._machine or not self._machine.is_connected():
+            return
+
+        pos = self._machine.get_current_position()
+        if pos is None:
+            return
+
+        x_val, y_val, _z_val = pos
+        if x_val is None or y_val is None:
+            return
+
+        space = self._machine.get_coordinate_space()
+        wx, wy = space.machine_point_to_world(x_val, y_val)
+
+        if pos_index == 0:
+            self._physical_point1 = (wx, wy)
+            self._pos1_row.set_subtitle(f"({wx:.2f}, {wy:.2f}) mm")
+        else:
+            self._physical_point2 = (wx, wy)
+            self._pos2_row.set_subtitle(f"({wx:.2f}, {wy:.2f}) mm")
+
+        self._update_jog_next_btn()
+
+    def _update_jog_next_btn(self):
+        p1 = self._physical_point1
+        p2 = self._physical_point2
+        if p1 is not None and p2 is not None:
+            dist = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+            self._next_btn.set_sensitive(dist >= MIN_POINT_DISTANCE)
+        else:
+            self._next_btn.set_sensitive(False)
+
+    def _on_machine_state_changed(self, machine, state):
+        self._update_laser_position()
+
+    def _update_laser_position(self):
+        if not self._machine:
+            return
+        pos = self._machine.get_current_position()
+        if pos:
+            x_val, y_val, _z_val = pos
+            if x_val is not None and y_val is not None:
+                self._laser_row.set_subtitle(
+                    f"X: {x_val:.2f}  Y: {y_val:.2f} mm"
+                )
+
+    def _on_scale_toggled(self, check_btn):
+        self._allow_scale = check_btn.get_active()
+        self._update_apply_preview()
+
+    def _update_apply_preview(self):
+        if (
+            self._design_point1 is None
+            or self._design_point2 is None
+            or self._physical_point1 is None
+            or self._physical_point2 is None
+        ):
+            return
+
+        T = calculate_alignment_transform(
+            self._design_point1,
+            self._design_point2,
+            self._physical_point1,
+            self._physical_point2,
+            allow_scale=self._allow_scale,
+        )
+
+        _tx, _ty, angle, sx, sy, _skew = T.decompose()
+        tx, ty = T.get_translation()
+
+        self._translation_row.set_subtitle(f"({tx:.2f}, {ty:.2f}) mm")
+        self._rotation_row.set_subtitle(f"{angle:.2f}\u00b0")
+
+        if self._allow_scale:
+            self._scale_row.set_subtitle(f"{sx:.4f} x {sy:.4f}")
+            self._warning_label.set_visible(False)
+        else:
+            dist_d = math.hypot(
+                self._design_point2[0] - self._design_point1[0],
+                self._design_point2[1] - self._design_point1[1],
+            )
+            dist_p = math.hypot(
+                self._physical_point2[0] - self._physical_point1[0],
+                self._physical_point2[1] - self._physical_point1[1],
+            )
+            self._scale_row.set_subtitle("1.0 (locked)")
+            if abs(dist_d - dist_p) > 0.1:
+                self._warning_label.set_text(
+                    _(
+                        "Note: Scale is locked. Point 2 may "
+                        "not align exactly if the physical "
+                        "distance differs from the design "
+                        "distance."
+                    )
+                )
+                self._warning_label.set_visible(True)
+            else:
+                self._warning_label.set_visible(False)
+
+    def _on_page_changed(self, stack, pspec):
+        visible = stack.get_visible_child_name()
+        if visible == "pick":
+            self._left_panel.set_visible(True)
+            self._back_btn.set_visible(False)
+            self._reset_btn.set_visible(True)
+            self._cancel_btn.set_visible(True)
+            self._next_btn.set_visible(True)
+            self._apply_btn.set_visible(False)
+            self._update_pick_next_btn()
+        elif visible == "jog":
+            self._left_panel.set_visible(True)
+            self._back_btn.set_visible(True)
+            self._reset_btn.set_visible(False)
+            self._cancel_btn.set_visible(True)
+            self._next_btn.set_visible(True)
+            self._apply_btn.set_visible(False)
+            self._update_jog_next_btn()
+        elif visible == "apply":
+            self._left_panel.set_visible(True)
+            self._back_btn.set_visible(True)
+            self._reset_btn.set_visible(False)
+            self._cancel_btn.set_visible(True)
+            self._next_btn.set_visible(False)
+            self._apply_btn.set_visible(True)
+            self._apply_btn.set_sensitive(True)
+            self._update_apply_preview()
+
+    def _on_back_clicked(self, button):
+        visible = self._right_stack.get_visible_child_name()
+        if visible == "jog":
+            self._right_stack.set_visible_child_name("pick")
+        elif visible == "apply":
+            self._right_stack.set_visible_child_name("jog")
+
+    def _on_next_clicked(self, button):
+        visible = self._right_stack.get_visible_child_name()
+        if visible == "pick":
+            self._right_stack.set_visible_child_name("jog")
+        elif visible == "jog":
+            self._right_stack.set_visible_child_name("apply")
+
+    def _on_reset_clicked(self, button):
+        self._pick_surface.reset()
+
+    def _on_apply_clicked(self, button):
+        if (
+            self._design_point1 is None
+            or self._design_point2 is None
+            or self._physical_point1 is None
+            or self._physical_point2 is None
+        ):
+            return
+
+        d1, d2 = self._design_point1, self._design_point2
+        p1, p2 = self._physical_point1, self._physical_point2
+
+        T = calculate_alignment_transform(
+            d1, d2, p1, p2, allow_scale=self._allow_scale
+        )
+
+        old_matrix = self._workpiece.matrix.copy()
+        new_matrix = T @ old_matrix
+
+        self._editor.transform.create_transform_transaction(
+            [(self._workpiece, old_matrix, new_matrix)]
+        )
+
+        toast = Adw.Toast(title=_("Alignment applied"))
+        self.toast_overlay.add_toast(toast)
+        self.close()
+
+    def close(self):
+        if self._machine:
+            self._machine.state_changed.disconnect(
+                self._on_machine_state_changed
+            )
+        super().close()

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -14,6 +14,7 @@ from rayforge.ui_gtk.shared.patched_dialog_window import (
     PatchedDialogWindow,
 )
 from rayforge.ui_gtk.canvas2d.elements.workpiece import WorkPieceElement
+from rayforge.ui_gtk.icons import get_icon
 from rayforge.ui_gtk.machine.jog_widget import JogWidget
 from rayforge.context import get_context
 from .pick_surface import PickSurface
@@ -280,6 +281,40 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._jog_widget.set_machine(self._machine, self._machine_cmd)
         jog_inner.append(self._jog_widget)
 
+        controls_group = Adw.PreferencesGroup()
+        box.append(controls_group)
+
+        distance_adjustment = Gtk.Adjustment(
+            value=10.0, lower=0.1, upper=1000, step_increment=1
+        )
+        self._distance_row = Adw.SpinRow(
+            title=_("Jog Distance"),
+            subtitle=_("Distance in machine units"),
+            adjustment=distance_adjustment,
+            digits=1,
+        )
+        self._distance_row.connect("changed", self._on_distance_changed)
+        controls_group.add(self._distance_row)
+
+        self._focus_active = False
+        self._focus_on_icon = get_icon("laser-on-symbolic")
+        self._focus_off_icon = get_icon("laser-off-symbolic")
+        self._focus_btn = Gtk.ToggleButton(
+            tooltip_text=_("Toggle focus laser"),
+            valign=Gtk.Align.CENTER,
+        )
+        self._focus_btn.set_child(self._focus_on_icon)
+        self._focus_btn.connect("toggled", self._on_focus_toggled)
+
+        self._focus_row = Adw.ActionRow(title=_("Focus Laser"))
+        self._focus_row.add_suffix(self._focus_btn)
+        controls_group.add(self._focus_row)
+
+        head = self._machine.get_default_head() if self._machine else None
+        if head:
+            head.changed.connect(self._on_head_changed)
+        self._update_focus_sensitivity()
+
         positions_group = Adw.PreferencesGroup(title=_("Positions"))
         box.append(positions_group)
 
@@ -471,6 +506,50 @@ class PrintAndCutWizard(PatchedDialogWindow):
                     f"X: {x_val:.2f}  Y: {y_val:.2f} mm"
                 )
 
+    def _on_distance_changed(self, spin_row):
+        self._jog_widget.jog_distance = float(spin_row.get_value())
+
+    def _on_focus_toggled(self, button):
+        if not self._machine or not self._machine_cmd:
+            return
+        head = self._machine.get_default_head()
+        if not head:
+            return
+        self._focus_active = button.get_active()
+        if self._focus_active:
+            self._machine_cmd.set_focus_power(head, head.focus_power_percent)
+            button.set_child(self._focus_off_icon)
+        else:
+            self._machine_cmd.set_focus_power(head, 0)
+            button.set_child(self._focus_on_icon)
+
+    def _disable_focus(self):
+        if self._focus_active and self._machine and self._machine_cmd:
+            head = self._machine.get_default_head()
+            if head:
+                self._machine_cmd.set_focus_power(head, 0)
+                self._focus_active = False
+                if self._focus_btn:
+                    self._focus_btn.set_active(False)
+
+    def _on_head_changed(self, head, *args):
+        self._update_focus_sensitivity()
+
+    def _update_focus_sensitivity(self):
+        head = self._machine.get_default_head() if self._machine else None
+        if head and head.focus_power_percent > 0:
+            self._focus_btn.set_sensitive(True)
+            self._focus_row.set_subtitle(
+                _("Turn on laser at focus power to locate position")
+            )
+        else:
+            self._focus_row.set_subtitle(
+                _("Set a focus power in laser preferences to enable")
+            )
+            self._focus_btn.set_sensitive(False)
+            if self._focus_active:
+                self._disable_focus()
+
     def _on_scale_toggled(self, check_btn):
         self._allow_scale = check_btn.get_active()
         self._update_apply_preview()
@@ -597,8 +676,11 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self.close()
 
     def close(self):
+        self._disable_focus()
         if self._machine:
             self._machine.state_changed.disconnect(
                 self._on_machine_state_changed
             )
+            head = self._machine.get_default_head()
+            head.changed.disconnect(self._on_head_changed)
         super().close()

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -226,11 +226,11 @@ class PrintAndCutWizard(PatchedDialogWindow):
         box.append(points_group)
 
         self._point1_row = Adw.ActionRow(title=_("Point 1"))
-        self._point1_row.set_subtitle(_("not set"))
+        self._point1_row.set_subtitle(_("No point picked"))
         points_group.add(self._point1_row)
 
         self._point2_row = Adw.ActionRow(title=_("Point 2"))
-        self._point2_row.set_subtitle(_("not set"))
+        self._point2_row.set_subtitle(_("No point picked"))
         points_group.add(self._point2_row)
 
         self._pick_status_row = Adw.ActionRow(title=_("Status"))
@@ -328,7 +328,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._record1_btn.connect("clicked", self._on_record_clicked, 0)
 
         self._pos1_row = Adw.ActionRow(title=_("Position 1"))
-        self._pos1_row.set_subtitle(_("not set"))
+        self._pos1_row.set_subtitle(_("Not recorded"))
         self._pos1_row.add_suffix(self._record1_btn)
         positions_group.add(self._pos1_row)
 
@@ -339,7 +339,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._record2_btn.connect("clicked", self._on_record_clicked, 1)
 
         self._pos2_row = Adw.ActionRow(title=_("Position 2"))
-        self._pos2_row.set_subtitle(_("not set"))
+        self._pos2_row.set_subtitle(_("Not recorded"))
         self._pos2_row.add_suffix(self._record2_btn)
         positions_group.add(self._pos2_row)
 
@@ -415,13 +415,13 @@ class PrintAndCutWizard(PatchedDialogWindow):
 
         if index == 0:
             self._design_point1 = (x, y)
-            self._point1_row.set_subtitle(f"({x:.2f}, {y:.2f}) mm")
+            self._point1_row.set_subtitle(_("Point picked"))
             self._pick_status_row.set_subtitle(
                 _("Click on the second alignment point on the design.")
             )
         elif index == 1:
             self._design_point2 = (x, y)
-            self._point2_row.set_subtitle(f"({x:.2f}, {y:.2f}) mm")
+            self._point2_row.set_subtitle(_("Point picked"))
             self._pick_status_row.set_subtitle(
                 _("Both points selected. Click Next to continue.")
             )
@@ -435,9 +435,9 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._design_point1 = p1
         self._design_point2 = p2
         if p1 is not None:
-            self._point1_row.set_subtitle(f"({p1[0]:.2f}, {p1[1]:.2f}) mm")
+            self._point1_row.set_subtitle(_("Point picked"))
         if p2 is not None:
-            self._point2_row.set_subtitle(f"({p2[0]:.2f}, {p2[1]:.2f}) mm")
+            self._point2_row.set_subtitle(_("Point picked"))
         self._update_pick_next_btn()
         self._save_session_state()
 
@@ -446,10 +446,10 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._design_point2 = None
         self._physical_point1 = None
         self._physical_point2 = None
-        self._point1_row.set_subtitle(_("not set"))
-        self._point2_row.set_subtitle(_("not set"))
-        self._pos1_row.set_subtitle(_("not set"))
-        self._pos2_row.set_subtitle(_("not set"))
+        self._point1_row.set_subtitle(_("No point picked"))
+        self._point2_row.set_subtitle(_("No point picked"))
+        self._pos1_row.set_subtitle(_("Not recorded"))
+        self._pos2_row.set_subtitle(_("Not recorded"))
         self._pick_status_row.set_subtitle(
             _("Click on the first alignment point on the design.")
         )
@@ -485,13 +485,9 @@ class PrintAndCutWizard(PatchedDialogWindow):
             self._design_point1 = dp1
             self._design_point2 = dp2
             if dp1 is not None:
-                self._point1_row.set_subtitle(
-                    f"({dp1[0]:.2f}, {dp1[1]:.2f}) mm"
-                )
+                self._point1_row.set_subtitle(_("Point picked"))
             if dp2 is not None:
-                self._point2_row.set_subtitle(
-                    f"({dp2[0]:.2f}, {dp2[1]:.2f}) mm"
-                )
+                self._point2_row.set_subtitle(_("Point picked"))
             if dp1 is not None and dp2 is not None:
                 self._pick_status_row.set_subtitle(
                     _("Both points selected. Click Next to continue.")

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -309,8 +309,18 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._record1_btn.add_css_class("suggested-action")
         self._record1_btn.connect("clicked", self._on_record_clicked, 0)
 
+        self._goto1_btn = Gtk.Button(
+            child=get_icon("zero-here-symbolic"),
+            valign=Gtk.Align.CENTER,
+            tooltip_text=_("Go to recorded position"),
+        )
+        self._goto1_btn.add_css_class("flat")
+        self._goto1_btn.connect("clicked", self._on_goto_clicked, 0)
+        self._goto1_btn.set_sensitive(False)
+
         self._pos1_row = Adw.ActionRow(title=_("Position 1"))
         self._pos1_row.set_subtitle(_("Not recorded"))
+        self._pos1_row.add_suffix(self._goto1_btn)
         self._pos1_row.add_suffix(self._record1_btn)
         positions_group.add(self._pos1_row)
 
@@ -320,8 +330,18 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._record2_btn.add_css_class("suggested-action")
         self._record2_btn.connect("clicked", self._on_record_clicked, 1)
 
+        self._goto2_btn = Gtk.Button(
+            child=get_icon("zero-here-symbolic"),
+            valign=Gtk.Align.CENTER,
+            tooltip_text=_("Go to recorded position"),
+        )
+        self._goto2_btn.add_css_class("flat")
+        self._goto2_btn.connect("clicked", self._on_goto_clicked, 1)
+        self._goto2_btn.set_sensitive(False)
+
         self._pos2_row = Adw.ActionRow(title=_("Position 2"))
         self._pos2_row.set_subtitle(_("Not recorded"))
+        self._pos2_row.add_suffix(self._goto2_btn)
         self._pos2_row.add_suffix(self._record2_btn)
         positions_group.add(self._pos2_row)
 
@@ -432,6 +452,8 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._point2_row.set_subtitle(_("No point picked"))
         self._pos1_row.set_subtitle(_("Not recorded"))
         self._pos2_row.set_subtitle(_("Not recorded"))
+        self._goto1_btn.set_sensitive(False)
+        self._goto2_btn.set_sensitive(False)
         self._pick_status_row.set_subtitle(
             _("Click on the first alignment point on the design.")
         )
@@ -486,6 +508,12 @@ class PrintAndCutWizard(PatchedDialogWindow):
             self._physical_point2 = pp2
             self._pos2_row.set_subtitle(f"({pp2[0]:.2f}, {pp2[1]:.2f})")
 
+        connected = self._machine and self._machine.is_connected()
+        if pp1 is not None:
+            self._goto1_btn.set_sensitive(connected)
+        if pp2 is not None:
+            self._goto2_btn.set_sensitive(connected)
+
         self._update_pick_next_btn()
 
     def _save_session_state(self):
@@ -513,12 +541,25 @@ class PrintAndCutWizard(PatchedDialogWindow):
         if pos_index == 0:
             self._physical_point1 = (x_val, y_val)
             self._pos1_row.set_subtitle(subtitle)
+            self._goto1_btn.set_sensitive(True)
         else:
             self._physical_point2 = (x_val, y_val)
             self._pos2_row.set_subtitle(subtitle)
+            self._goto2_btn.set_sensitive(True)
 
         self._update_jog_next_btn()
         self._save_session_state()
+
+    def _on_goto_clicked(self, button, pos_index):
+        if not self._machine or not self._machine.is_connected():
+            return
+        if pos_index == 0:
+            point = self._physical_point1
+        else:
+            point = self._physical_point2
+        if point is None:
+            return
+        self._machine_cmd.move_to(self._machine, point[0], point[1])
 
     def _update_jog_next_btn(self):
         p1 = self._physical_point1
@@ -539,6 +580,12 @@ class PrintAndCutWizard(PatchedDialogWindow):
         connected = self._machine and self._machine.is_connected()
         self._record1_btn.set_sensitive(connected)
         self._record2_btn.set_sensitive(connected)
+        self._goto1_btn.set_sensitive(
+            connected and self._physical_point1 is not None
+        )
+        self._goto2_btn.set_sensitive(
+            connected and self._physical_point2 is not None
+        )
         self._update_focus_sensitivity()
         if connected:
             self._update_laser_position()

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 MIN_POINT_DISTANCE = 0.5
 
+_session_state: dict = {}
+
 
 def calculate_alignment_transform(
     d1: Tuple[float, float],
@@ -79,6 +81,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._allow_scale: bool = False
 
         self._setup_ui()
+        self._restore_session_state()
 
     def _setup_ui(self):
         self.toast_overlay = Adw.ToastOverlay()
@@ -344,13 +347,13 @@ class PrintAndCutWizard(PatchedDialogWindow):
         self._laser_row.set_subtitle(_("X: --- Y: ---"))
         positions_group.add(self._laser_row)
 
-        if self._machine and self._machine.is_connected():
+        if self._machine:
             self._machine.state_changed.connect(self._on_machine_state_changed)
+            self._machine.connection_status_changed.connect(
+                self._on_connection_status_changed
+            )
+            self._update_connection_sensitive()
             self._update_laser_position()
-        else:
-            self._jog_widget.set_sensitive(False)
-            self._record1_btn.set_sensitive(False)
-            self._record2_btn.set_sensitive(False)
 
     def _setup_apply_panel(self):
         scroll = Gtk.ScrolledWindow()
@@ -424,6 +427,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
             )
 
         self._update_pick_next_btn()
+        self._save_session_state()
 
     def _on_design_points_changed(self, sender):
         p1 = self._pick_surface.point1
@@ -435,16 +439,22 @@ class PrintAndCutWizard(PatchedDialogWindow):
         if p2 is not None:
             self._point2_row.set_subtitle(f"({p2[0]:.2f}, {p2[1]:.2f}) mm")
         self._update_pick_next_btn()
+        self._save_session_state()
 
     def _on_design_points_reset(self, sender):
         self._design_point1 = None
         self._design_point2 = None
+        self._physical_point1 = None
+        self._physical_point2 = None
         self._point1_row.set_subtitle(_("not set"))
         self._point2_row.set_subtitle(_("not set"))
+        self._pos1_row.set_subtitle(_("not set"))
+        self._pos2_row.set_subtitle(_("not set"))
         self._pick_status_row.set_subtitle(
             _("Click on the first alignment point on the design.")
         )
         self._update_pick_next_btn()
+        self._save_session_state()
 
     def _update_pick_next_btn(self):
         p1 = self._design_point1
@@ -458,6 +468,56 @@ class PrintAndCutWizard(PatchedDialogWindow):
                 )
         else:
             self._next_btn.set_sensitive(False)
+
+    def _restore_session_state(self):
+        wp_id = self._workpiece.uid
+        state = _session_state.get(wp_id)
+        if state is None:
+            return
+
+        dp1 = state.get("design_point1")
+        dp2 = state.get("design_point2")
+        pp1 = state.get("physical_point1")
+        pp2 = state.get("physical_point2")
+
+        if dp1 is not None or dp2 is not None:
+            self._pick_surface.set_points(dp1, dp2)
+            self._design_point1 = dp1
+            self._design_point2 = dp2
+            if dp1 is not None:
+                self._point1_row.set_subtitle(
+                    f"({dp1[0]:.2f}, {dp1[1]:.2f}) mm"
+                )
+            if dp2 is not None:
+                self._point2_row.set_subtitle(
+                    f"({dp2[0]:.2f}, {dp2[1]:.2f}) mm"
+                )
+            if dp1 is not None and dp2 is not None:
+                self._pick_status_row.set_subtitle(
+                    _("Both points selected. Click Next to continue.")
+                )
+            elif dp1 is not None:
+                self._pick_status_row.set_subtitle(
+                    _("Click on the second alignment point on the design.")
+                )
+
+        if pp1 is not None:
+            self._physical_point1 = pp1
+            self._pos1_row.set_subtitle(f"({pp1[0]:.2f}, {pp1[1]:.2f}) mm")
+        if pp2 is not None:
+            self._physical_point2 = pp2
+            self._pos2_row.set_subtitle(f"({pp2[0]:.2f}, {pp2[1]:.2f}) mm")
+
+        self._update_pick_next_btn()
+
+    def _save_session_state(self):
+        wp_id = self._workpiece.uid
+        _session_state[wp_id] = {
+            "design_point1": self._design_point1,
+            "design_point2": self._design_point2,
+            "physical_point1": self._physical_point1,
+            "physical_point2": self._physical_point2,
+        }
 
     def _on_record_clicked(self, button, pos_index):
         if not self._machine or not self._machine.is_connected():
@@ -482,6 +542,7 @@ class PrintAndCutWizard(PatchedDialogWindow):
             self._pos2_row.set_subtitle(f"({wx:.2f}, {wy:.2f}) mm")
 
         self._update_jog_next_btn()
+        self._save_session_state()
 
     def _update_jog_next_btn(self):
         p1 = self._physical_point1
@@ -494,6 +555,17 @@ class PrintAndCutWizard(PatchedDialogWindow):
 
     def _on_machine_state_changed(self, machine, state):
         self._update_laser_position()
+
+    def _on_connection_status_changed(self, sender, **kwargs):
+        self._update_connection_sensitive()
+
+    def _update_connection_sensitive(self):
+        connected = self._machine and self._machine.is_connected()
+        self._record1_btn.set_sensitive(connected)
+        self._record2_btn.set_sensitive(connected)
+        self._update_focus_sensitivity()
+        if connected:
+            self._update_laser_position()
 
     def _update_laser_position(self):
         if not self._machine:
@@ -671,6 +743,8 @@ class PrintAndCutWizard(PatchedDialogWindow):
             [(self._workpiece, old_matrix, new_matrix)]
         )
 
+        _session_state.pop(self._workpiece.uid, None)
+
         toast = Adw.Toast(title=_("Alignment applied"))
         self.toast_overlay.add_toast(toast)
         self.close()
@@ -680,6 +754,9 @@ class PrintAndCutWizard(PatchedDialogWindow):
         if self._machine:
             self._machine.state_changed.disconnect(
                 self._on_machine_state_changed
+            )
+            self._machine.connection_status_changed.disconnect(
+                self._on_connection_status_changed
             )
             head = self._machine.get_default_head()
             head.changed.disconnect(self._on_head_changed)

--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/rayforge-addon.yaml
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/rayforge-addon.yaml
@@ -1,0 +1,12 @@
+name: print_and_cut
+display_name: "Print & Cut"
+description: "Align workpieces to physical objects using registration marks"
+api_version: 9
+author:
+  name: "Rayforge Team"
+  email: "noreply@rayforge.org"
+provides:
+  backend: "print_and_cut.backend"
+  frontend: "print_and_cut.frontend"
+license:
+  name: "MIT"

--- a/rayforge/ui_gtk/machine/jog_widget.py
+++ b/rayforge/ui_gtk/machine/jog_widget.py
@@ -14,7 +14,7 @@ _MAX_HEIGHT = 4 * 60 + 3 * _SPACING
 class JogWidget(Gtk.Widget):
     """Widget for manually jogging the machine."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, show_actions: bool = True, **kwargs):
         super().__init__(**kwargs)
 
         self._jog_grid = Gtk.Grid()
@@ -24,10 +24,13 @@ class JogWidget(Gtk.Widget):
         self._jog_grid.set_row_homogeneous(True)
         self._jog_grid.set_column_homogeneous(True)
 
+        self._show_actions = show_actions
+
         self._action_grid = Gtk.Grid()
         self._action_grid.set_parent(self)
         self._action_grid.set_row_spacing(_SPACING)
         self._action_grid.set_row_homogeneous(True)
+        self._action_grid.set_visible(show_actions)
 
         self.machine: Optional[Machine] = None
         self.machine_cmd: Optional[MachineCmd] = None
@@ -159,7 +162,9 @@ class JogWidget(Gtk.Widget):
         if orientation == Gtk.Orientation.HORIZONTAL:
             h = for_size if for_size > 0 else _MAX_HEIGHT
             jog_w, act_w = self._calc_grid_widths(h)
-            total = int(jog_w) + _GAP + int(act_w)
+            total = int(jog_w)
+            if self._show_actions:
+                total += _GAP + int(act_w)
             return (total, total, -1, -1)
         m = self._jog_grid.measure(orientation, for_size)
         return (m[0], min(m[1], _MAX_HEIGHT), -1, -1)
@@ -167,21 +172,27 @@ class JogWidget(Gtk.Widget):
     def do_size_allocate(self, width, height, baseline):
         jog_w, act_w = self._calc_grid_widths(height)
 
-        total_needed = jog_w + _GAP + act_w
-        if width > total_needed:
-            extra = width - total_needed
-            jog_w += extra * 3 / 4
-            act_w += extra / 4
+        if self._show_actions:
+            total_needed = jog_w + _GAP + act_w
+            if width > total_needed:
+                extra = width - total_needed
+                jog_w += extra * 3 / 4
+                act_w += extra / 4
+            act_w = int(act_w)
+        else:
+            jog_w = width
 
         jog_w = int(jog_w)
-        act_w = int(act_w)
 
         self._jog_grid.allocate(jog_w, height, baseline, None)
 
-        transform = Gsk.Transform().translate(
-            Graphene.Point().init(jog_w + _GAP, 0)
-        )
-        self._action_grid.allocate(act_w, height, baseline, transform)
+        if self._show_actions:
+            transform = Gsk.Transform().translate(
+                Graphene.Point().init(jog_w + _GAP, 0)
+            )
+            self._action_grid.allocate(act_w, height, baseline, transform)
+        else:
+            self._action_grid.allocate(0, 0, -1, None)
 
     def set_machine(
         self, machine: Optional[Machine], machine_cmd: Optional[MachineCmd]

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -273,14 +273,15 @@ class MainWindow(Adw.ApplicationWindow):
         action_registry.set_window(self)
         self.action_registry = action_registry
 
-        # Setup keyboard actions using the new ActionManager.
-        self.action_manager = ActionManager(self)
-        self.action_manager.register_actions()
-
-        # Let addons register their actions (must be after window is set)
+        # Let addons register action extension handlers before
+        # ActionManager.register_actions() invokes setup handlers.
         context.plugin_mgr.hook.register_actions(
             action_registry=action_registry
         )
+
+        # Setup keyboard actions using the new ActionManager.
+        self.action_manager = ActionManager(self)
+        self.action_manager.register_actions()
 
         shortcut_controller = Gtk.ShortcutController()
         self.action_manager.register_shortcuts(shortcut_controller)


### PR DESCRIPTION
## Summary

- Implements a "Print & Cut" feature as a builtin addon that allows users to align a digital workpiece to its physical counterpart on the machine bed (#180)
- 3-step wizard: (1) pick two alignment points on the design canvas, (2) jog laser to corresponding physical locations and record positions, (3) review and apply the computed affine transform (translation + rotation + optional scaling)
- Fixes addon action registration ordering bug in `mainwindow.py` — the `register_actions` hook was called after `ActionManager.register_actions()`, causing addon setup/state handlers to be registered too late

## Changes

**New addon files:**
- `rayforge-addon.yaml` — manifest (api_version 9)
- `backend.py` — minimal backend with `on_unload` hookimpl
- `frontend.py` — registers `align-workpiece` action, controls sensitivity based on workpiece selection
- `pick_surface.py` — custom `WorldSurface` subclass with point picking, dragging, crosshair cursor, and workpiece rendering
- `wizard.py` — non-modal 3-step wizard dialog with shared canvas (pick/jog pages) and right-panel stack

**Core fix:**
- `mainwindow.py` — moved `register_actions` hook call before `ActionManager.register_actions()` so addon actions are registered in time

**Key design decisions:**
- Physical positions are converted from machine coords to world coords via `MachineSpace.machine_point_to_world()` for correct alignment regardless of machine origin configuration
- PickSurface uses full `axis_extents` (not `work_area`) to match the workpiece matrix coordinate system
- Canvas remains visible across all wizard pages; only the right panel swaps content

<img width="1272" height="872" alt="image" src="https://github.com/user-attachments/assets/8f112c2c-e73f-4e9c-9df5-276068700b1a" />

<img width="1272" height="872" alt="Screenshot from 2026-04-14 15-19-43" src="https://github.com/user-attachments/assets/99aec26a-3530-47e8-861c-bd326d1d255b" />

<img width="1272" height="872" alt="image" src="https://github.com/user-attachments/assets/bc045aa0-f19e-4705-8bfe-04c2e9c454b4" />
