### PR TITLE
add GRBL (Telnet) driver for networked grblHAL and ESP3D controllers

### DIFF
--- a/rayforge/machine/driver/__init__.py
+++ b/rayforge/machine/driver/__init__.py
@@ -4,6 +4,7 @@ from .driver import Driver
 from .dummy import NoDeviceDriver
 from .grbl import GrblNetworkDriver
 from .grbl_serial import GrblSerialDriver
+from .grbl_telnet import GrblTelnetDriver
 from .smoothie import SmoothieDriver
 
 
@@ -34,5 +35,6 @@ __all__ = [
     "NoDeviceDriver",
     "GrblNetworkDriver",
     "GrblSerialDriver",
+    "GrblTelnetDriver",
     "SmoothieDriver",
 ]

--- a/rayforge/machine/driver/grbl_telnet.py
+++ b/rayforge/machine/driver/grbl_telnet.py
@@ -1,0 +1,106 @@
+import logging
+from typing import Any, Optional, cast
+from gettext import gettext as _
+from ...core.varset import Var, VarSet, HostnameVar, PortVar
+from ..transport import TelnetTransport
+from ..transport.grbl import GrblSerialTransport
+from ..transport.validators import is_valid_hostname_or_ip
+from .driver import DriverPrecheckError, DriverSetupError
+from .grbl_serial import GrblSerialDriver
+
+
+logger = logging.getLogger(__name__)
+
+
+class GrblTelnetDriver(GrblSerialDriver):
+    """
+    GRBL-compatible controller connected over raw TCP (telnet).
+
+    Intended for networked grblHAL controllers with the "raw" telnet
+    service enabled, and for ESP3D firmware's telnet bridge. Reuses the
+    full GRBL protocol stack from GrblSerialDriver, swapping only the
+    underlying byte transport from SerialTransport to TelnetTransport.
+    """
+
+    label = _("GRBL (Telnet)")
+    subtitle = _(
+        "GRBL-compatible controller over a raw TCP/telnet connection"
+    )
+
+    def __init__(self, context, machine):
+        super().__init__(context, machine)
+        self._host: Optional[str] = None
+        self._port: Optional[int] = None
+
+    @property
+    def resource_uri(self) -> Optional[str]:
+        if self._host and self._port:
+            return f"tcp://{self._host}:{self._port}"
+        return None
+
+    @classmethod
+    def precheck(cls, **kwargs: Any) -> None:
+        host = cast(str, kwargs.get("host", ""))
+        if not is_valid_hostname_or_ip(host):
+            raise DriverPrecheckError(
+                _("Invalid hostname or IP address: '{host}'").format(
+                    host=host
+                )
+            )
+
+    @classmethod
+    def get_setup_vars(cls) -> "VarSet":
+        return VarSet(
+            vars=[
+                HostnameVar(
+                    key="host",
+                    label=_("Hostname"),
+                    description=_(
+                        "The IP address or hostname of the device"
+                    ),
+                ),
+                PortVar(
+                    key="port",
+                    label=_("Port"),
+                    description=_(
+                        "TCP port for the raw/telnet service"
+                    ),
+                    default=23,
+                ),
+                Var(
+                    key="poll_status_while_running",
+                    label=_(
+                        "Enable status polling during running jobs"
+                    ),
+                    description=_(
+                        "Whether to query status during jobs. "
+                        "Disabling can help reduce load on slow "
+                        "machines"
+                    ),
+                    var_type=bool,
+                    default=True,
+                ),
+            ]
+        )
+
+    def _setup_implementation(self, **kwargs: Any) -> None:
+        host = cast(str, kwargs.get("host", ""))
+        port = cast(int, kwargs.get("port", 23))
+        self._poll_status_while_running = bool(
+            kwargs.get("poll_status_while_running", True)
+        )
+
+        if not host:
+            raise DriverSetupError(_("Hostname must be configured."))
+        if not port:
+            raise DriverSetupError(_("Port must be configured."))
+
+        self._host = host
+        self._port = port
+
+        telnet_transport = TelnetTransport(host, port)
+        self.grbl_transport = GrblSerialTransport(telnet_transport)
+        self.grbl_transport.received.connect(self.on_serial_data_received)
+        self.grbl_transport.status_changed.connect(
+            self.on_serial_status_changed
+        )

--- a/rayforge/machine/transport/grbl.py
+++ b/rayforge/machine/transport/grbl.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 
 from ...shared.tasker import task_mgr
 from .serial import SerialTransport
+from .transport import Transport
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class GrblSerialTransport:
     the serial receive callback.
     """
 
-    def __init__(self, transport: SerialTransport):
+    def __init__(self, transport: Transport):
         self._transport = transport
         self._rx_buffer_count = 0
         self._lock = threading.Lock()
@@ -61,7 +62,9 @@ class GrblSerialTransport:
 
     @property
     def port(self) -> str:
-        return self._transport.port
+        if isinstance(self._transport, SerialTransport):
+            return self._transport.port
+        return ""
 
     async def connect(self) -> None:
         await self._transport.connect()


### PR DESCRIPTION
Subclasses GrblSerialDriver and swaps SerialTransport for TelnetTransport.
Covers networked grblHAL and ESP3D controllers with telnet enabled — the
existing GRBL (Network) driver only targets ESP3D+WebUI3.

Relaxes GrblSerialTransport to accept any Transport (it only used the
base-class API anyway); .port returns "" for non-serial backends.

- New `GrblTelnetDriver` for networked grblHAL / ESP3D via raw telnet (port 23).
- Subclass of `GrblSerialDriver` — reuses the full protocol stack, only swaps the byte transport.
- `GrblSerialTransport` constructor now typed as `Transport` instead of `SerialTransport` (strict annotation relax, no behaviour change).

## Why a new driver
grblHAL exposes telnet, WebSocket, HTTP, and WebUI as independent services. The existing `GrblNetworkDriver` hard-requires the WebUI3 HTTP endpoints
(`[ESP420]`/`[ESP800]`/`[ESP400]`, `/command?commandText=...`), so it can't talk to a plain networked grblHAL or an ESP3D bridge.

## Test plan
- [x] lint + full test suite (2 preexisting unrelated failures)
- [x] smoke test against networked grblHAL
- [x] smoke test against ESP3D