### PR TITLE
fix: cancel button not working on GRBL network driver

### DIFF
--- a/rayforge/machine/driver/grbl/grbl_network.py
+++ b/rayforge/machine/driver/grbl/grbl_network.py
@@ -472,9 +472,13 @@ class GrblNetworkDriver(Driver):
         await self._send_command("!" if hold else "~")
 
     async def cancel(self) -> None:
-        # Cancel is a fire-and-forget soft reset, doesn't always
-        # respond with 'ok'
-        await self._send_command("%18")
+        # Soft reset: send Ctrl-X (0x18) as a raw byte.  _send_command
+        # URL-encodes the argument, so '\x18' becomes '%18' on the wire —
+        # which is what the ESP3D/FluidNC web interface interprets as the
+        # GRBL soft-reset byte.  (Do NOT pass the literal string '%18',
+        # because quote() would double-encode the '%' to '%2518'.)
+        await self._send_command("\x18")
+        self.job_finished.send(self)
 
     def can_home(self, axis: Optional[Axis] = None) -> bool:
         """GRBL supports homing for all axes."""


### PR DESCRIPTION
## Summary

Fixes #222 — the cancel button does nothing when using the GRBL network driver.

### Root Cause

Commit 7f927a18 added URL encoding to  to fix the  command being mangled. This broke cancel: the cancel method sent the literal string `%18`, which `quote()` double-encoded to `%2518`. The ESP3D/FluidNC web server decoded `%25` back to `%`, so the firmware received the literal string `%18` instead of the Ctrl-X soft-reset byte (0x18).

### Fix

- **cancel() now sends `\x18` (raw Ctrl-X byte)** instead of the string `%18`. `quote('\x18')` produces `%18` on the wire — exactly what the web server expects.
- **cancel() now emits `job_finished`** so the UI exits the running state, matching the serial driver behavior.

### Testing

All 5331 existing tests pass. Lint clean.