### PR TITLE
macOS: Avoid importing GTK/UI modules from code paths that are also loaded by background workers

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/frontend.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/frontend.py
@@ -8,6 +8,7 @@ import gettext
 from pathlib import Path
 
 from rayforge.core.hooks import hookimpl
+from rayforge.ui_gtk.icons import register_icon_path
 from .widgets import PRODUCER_WIDGETS
 
 _localedir = Path(__file__).parent.parent / "locale"
@@ -17,6 +18,9 @@ _t = gettext.translation(
 _ = _t.gettext
 
 ADDON_NAME = "laser_essentials"
+_ICONS_DIR = Path(__file__).parent / "resources" / "icons"
+
+register_icon_path(_ICONS_DIR)
 
 
 @hookimpl

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/worker.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/worker.py
@@ -7,11 +7,7 @@ Registers producers and actions with the main application.
 import gettext
 from pathlib import Path
 
-from gi.repository import Gio
-
 from rayforge.core.hooks import hookimpl
-from rayforge.ui_gtk.action_registry import MenuPlacement
-from rayforge.ui_gtk.icons import register_icon_path
 from .producers import (
     ContourProducer,
     FrameProducer,
@@ -26,7 +22,6 @@ from .steps import (
     MaterialTestStep,
     ShrinkWrapStep,
 )
-from .commands import MaterialTestCmd
 
 _localedir = Path(__file__).parent.parent / "locale"
 _t = gettext.translation(
@@ -35,9 +30,6 @@ _t = gettext.translation(
 _ = _t.gettext
 
 ADDON_NAME = "laser_essentials"
-_ICONS_DIR = Path(__file__).parent / "resources" / "icons"
-
-register_icon_path(_ICONS_DIR)
 
 
 @hookimpl
@@ -70,12 +62,18 @@ def register_steps(step_registry):
 @hookimpl
 def register_commands(command_registry):
     """Register editor command handlers."""
+    from .commands import MaterialTestCmd
+
     command_registry.register("material_test", MaterialTestCmd, ADDON_NAME)
 
 
 @hookimpl
 def register_actions(action_registry):
     """Register actions with menu placement."""
+    from gi.repository import Gio
+
+    from rayforge.ui_gtk.action_registry import MenuPlacement
+
     action = Gio.SimpleAction.new("material_test", None)
 
     def on_activate(action, param):

--- a/rayforge/ui_gtk/__init__.py
+++ b/rayforge/ui_gtk/__init__.py
@@ -1,7 +1,16 @@
-from .canvas2d.elements.dot import DotElement
-from .canvas2d.surface import WorkSurface
-
 __all__ = [
     "WorkSurface",
     "DotElement",
 ]
+
+
+def __getattr__(name):
+    if name == "WorkSurface":
+        from .canvas2d.surface import WorkSurface
+
+        return WorkSurface
+    if name == "DotElement":
+        from .canvas2d.elements.dot import DotElement
+
+        return DotElement
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
On macOS, worker processes that import GTK/UI modules appear as extra Rayforge app instances in the Dock (bouncing like crazy and they never close, every new calculation creates new instances...)

So, I made these changes:

- Move `laser_essentials.worker` UI-only imports into command/action registration hooks.
- Move laser addon icon registration into the frontend entry point.
- Make `rayforge.ui_gtk` convenience exports lazy to avoid loading the 2D canvas when workers import 3D scene modules.

This way Rayforge works again fine in macOS 😄
