### PR TITLE
Limit the scheduled `download-stats` workflow to the upstream repository

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-stats:
+    if: github.repository == 'barebaric/rayforge'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The workflow depends on repository-specific secrets and external services:

- `STORE_LOGIN`
- `METRICS_URL`
- `METRICS_API_USER`
- `METRICS_API_PASSWORD`

In forks or personal clones, the daily scheduled run can fail because those secrets are not available. This change keeps the workflow active for your original repository, `barebaric/rayforge`, while making it skip cleanly elsewhere.