### PR TITLE
feat(device): add Sculpfun C1 engraver

### DIFF
--- a/rayforge/resources/devices/sculpfun-c1/device.yaml
+++ b/rayforge/resources/devices/sculpfun-c1/device.yaml
@@ -13,8 +13,8 @@ machine:
   max_cut_speed: 10000
   heads:
   - max_power: 1000
-    frame_power_percent: 0.0
-    focus_power_percent: 0.0
+    frame_power_percent: 0.25
+    focus_power_percent: 0.25
     spot_size_mm:
     - 0.1
     - 0.1

--- a/rayforge/resources/devices/sculpfun-c1/device.yaml
+++ b/rayforge/resources/devices/sculpfun-c1/device.yaml
@@ -16,5 +16,5 @@ machine:
     frame_power_percent: 0.25
     focus_power_percent: 0.25
     spot_size_mm:
-    - 0.1
-    - 0.1
+    - 0.04
+    - 0.04

--- a/rayforge/resources/devices/sculpfun-c1/device.yaml
+++ b/rayforge/resources/devices/sculpfun-c1/device.yaml
@@ -1,0 +1,20 @@
+api_version: 1
+device:
+  name: Sculpfun C1
+  description: Budget diode laser engraver with 150x130mm work area
+machine:
+  driver: GrblSerialDriver
+  gcode_precision: 3
+  axis_extents:
+  - 150.0
+  - 130.0
+  origin: bottom_left
+  max_travel_speed: 10000
+  max_cut_speed: 10000
+  heads:
+  - max_power: 1000
+    frame_power_percent: 0.0
+    focus_power_percent: 0.0
+    spot_size_mm:
+    - 0.1
+    - 0.1

--- a/rayforge/resources/devices/sculpfun-c1/dialect.yaml
+++ b/rayforge/resources/devices/sculpfun-c1/dialect.yaml
@@ -1,0 +1,31 @@
+laser_on: M4 S{power:.0f}
+laser_off: M5
+focus_laser_on: M3 S{power:.0f}
+tool_change: T{tool_number}
+set_speed: ''
+travel_move: G0{x_cmd}{y_cmd}{z_cmd}{extra_cmd}
+linear_move: G1{x_cmd}{y_cmd}{z_cmd}{extra_cmd}{f_command}
+arc_cw: G2{x_cmd}{y_cmd}{z_cmd}{extra_cmd} I{i} J{j}{f_command}
+arc_ccw: G3{x_cmd}{y_cmd}{z_cmd}{extra_cmd} I{i} J{j}{f_command}
+bezier_cubic: ''
+air_assist_on: M8
+air_assist_off: M9
+home_all: $H
+home_axis: $H{axis_letter}
+move_to: $J=G90 G21 F{speed} X{x} Y{y}
+jog: $J=G91 G21 F{speed}
+clear_alarm: $X
+set_wcs_offset: G10 L2 P{p_num} X{x} Y{y} Z{z}
+probe_cycle: G38.2 {axis_letter}{max_travel} F{feed_rate}
+dwell: G4 P{seconds:.3f}
+preamble:
+- G21 ;Set units to mm
+- G90 ;Absolute positioning
+postscript:
+- M5 ;Ensure laser is off
+- G0 X0 Y0 ;Return to origin
+inject_wcs_after_preamble: true
+can_g0_with_speed: false
+omit_unchanged_coords: true
+continuous_laser_mode: false
+modal_feedrate: false


### PR DESCRIPTION
Hello,

A patch to add the Scupfun C1 engraver to the list of known devices (this is this one: https://www.sculpfun.com/collections/laser-engraver/products/sculpfun-c1-mini-laser-engraver-3w).

I duplicated the `sculpfun-s30` file structure, and filed with what the software found when I added the machine manually (by copying only the relevant data saved in `~/.var/app/org.rayforge.rayforge/config/rayforge/dialects` + `~/.var/app/org.rayforge.rayforge/config/rayforge/machines`).