### PR TITLE
Allow finer raster line spacing (0.001 mm) for microfabrication

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -309,7 +309,7 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         group.add(self.cross_hatch_row)
 
         line_interval_adj = Gtk.Adjustment(
-            lower=0.01,
+            lower=0.001,
             upper=10.0,
             step_increment=0.01,
             value=producer.line_interval_mm or 0.1,
@@ -318,7 +318,7 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
             title=_("Line Spacing"),
             subtitle=_("Distance between scan lines"),
             adjustment=line_interval_adj,
-            digits=2,
+            digits=3,
         )
         self.line_interval_row.connect(
             "changed",


### PR DESCRIPTION
## Summary

- Lowers the minimum raster line spacing from `0.01` mm to `0.001` mm and increases decimal precision from 2 to 3 digits in the Line Spacing `Adw.SpinRow`
- This enables sub-10µm pitch work for microfabrication and precision lithography workflows
- The backend (`raster_util.py`) already supports finer resolutions — this was purely a UI constraint

## Changes

**File:** `rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py`

- `line_interval_adj`: `lower=0.01` → `lower=0.001`
- `line_interval_row`: `digits=2` → `digits=3`

Closes #252