### PR TITLE
data: prefer Rayforge MIME types over ZIP detection

### DIFF
--- a/data/org.rayforge.rayforge.xml
+++ b/data/org.rayforge.rayforge.xml
@@ -3,11 +3,11 @@
   <mime-type type="application/x-rayforge-project">
     <comment>Rayforge project file</comment>
     <sub-class-of type="application/zip"/>
-    <glob pattern="*.ryp"/>
+    <glob pattern="*.ryp" weight="100"/>
   </mime-type>
   <mime-type type="application/x-rayforge-sketch">
     <comment>Rayforge sketch file</comment>
-    <glob pattern="*.rfs"/>
+    <glob pattern="*.rfs" weight="100"/>
   </mime-type>
   <mime-type type="application/x-ruida">
     <comment>Ruida laser cutter file</comment>


### PR DESCRIPTION
Fixes #257

Rayforge project files (.ryp) are ZIP-based containers. Without a high
glob weight, shared-mime-info may classify them as application/zip
instead of application/x-rayforge-project.

This prevents desktop environments from correctly associating .ryp files
with Rayforge.

This patch assigns a glob weight of 100 to the Rayforge MIME definitions.