### PR TITLE
Fix manual laser control routing

### DIFF
--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -369,7 +369,12 @@ class MachineCmd:
             key=f"macro-{macro_uid}",
         )
 
-    def set_power(self, head: "Laser", percent: float):
+    def set_power(
+        self,
+        head: "Laser",
+        percent: float,
+        machine: Optional["Machine"] = None,
+    ):
         """
         Adds a task to set the laser power to a specific percentage.
 
@@ -377,14 +382,20 @@ class MachineCmd:
             head: The laser head to control
             percent: Power percentage (0-1.0). 0 disables power.
         """
-        config = get_context().config
-        machine = config.machine
+        if machine is None:
+            config = get_context().config
+            machine = config.machine
         if machine:
             self._editor.task_manager.add_coroutine(
                 lambda ctx: machine.set_power(head, percent)
             )
 
-    def set_focus_power(self, head: "Laser", percent: float):
+    def set_focus_power(
+        self,
+        head: "Laser",
+        percent: float,
+        machine: Optional["Machine"] = None,
+    ):
         """
         Adds a task to set the laser power for focus mode.
 
@@ -392,8 +403,9 @@ class MachineCmd:
             head: The laser head to control
             percent: Power percentage (0-1.0). 0 disables power.
         """
-        config = get_context().config
-        machine = config.machine
+        if machine is None:
+            config = get_context().config
+            machine = config.machine
         if machine:
             self._editor.task_manager.add_coroutine(
                 lambda ctx: machine.set_focus_power(head, percent)

--- a/rayforge/ui_gtk/machine/laser_control_widget.py
+++ b/rayforge/ui_gtk/machine/laser_control_widget.py
@@ -246,7 +246,7 @@ class LaserControlWidget(Gtk.Box):
             return
 
         percent = self._power_adj.get_value() / 100.0
-        self.machine_cmd.set_focus_power(head, percent)
+        self.machine_cmd.set_focus_power(head, percent, self.machine)
 
         self._is_on = True
         self._update_toggle_ui()
@@ -264,7 +264,7 @@ class LaserControlWidget(Gtk.Box):
         head = self._get_selected_head()
         if head and self.machine and self.machine.is_connected():
             if self.machine_cmd:
-                self.machine_cmd.set_focus_power(head, 0)
+                self.machine_cmd.set_focus_power(head, 0, self.machine)
         self._is_on = False
         self._update_toggle_ui()
         self._update_sensitivity()

--- a/tests/machine/test_machine_cmd.py
+++ b/tests/machine/test_machine_cmd.py
@@ -258,3 +258,37 @@ class TestMachineCmdJog:
         # --- Assert ---
         # Verify call arguments to Machine.jog
         jog_mock.assert_called_once_with(deltas, 1500)
+
+
+class TestMachineCmdLaserPower:
+    """Test suite for manual laser power commands."""
+
+    @pytest.mark.asyncio
+    async def test_set_focus_power_uses_explicit_machine(
+        self, machine_cmd, machine, mocker, task_mgr
+    ):
+        head = machine.get_default_head()
+        set_focus_power_mock = mocker.patch.object(
+            machine, "set_focus_power", new_callable=mocker.AsyncMock
+        )
+
+        machine_cmd.set_focus_power(head, 0.25, machine)
+
+        await wait_for_tasks_to_finish(task_mgr)
+
+        set_focus_power_mock.assert_called_once_with(head, 0.25)
+
+    @pytest.mark.asyncio
+    async def test_set_power_uses_explicit_machine(
+        self, machine_cmd, machine, mocker, task_mgr
+    ):
+        head = machine.get_default_head()
+        set_power_mock = mocker.patch.object(
+            machine, "set_power", new_callable=mocker.AsyncMock
+        )
+
+        machine_cmd.set_power(head, 0.5, machine)
+
+        await wait_for_tasks_to_finish(task_mgr)
+
+        set_power_mock.assert_called_once_with(head, 0.5)


### PR DESCRIPTION
Description
Fixes the manual laser control widget so laser on/off commands are sent to the machine currently assigned to the widget, instead of relying on the globally active config machine.

Previously, clicking the manual laser button could enqueue set_focus_power() against the wrong machine context, which meant the selected laser did not turn on from the widget.

Changes

  - Allow MachineCmd.set_power() and MachineCmd.set_focus_power() to accept an explicit machine.
  - Update LaserControlWidget to pass its assigned machine when turning the laser on or off.
  - Add focused tests for explicit machine routing in MachineCmd.

Verification

  - python3 -m compileall passed for changed files.
  - git diff --check passed.
  - Could not run pixi run lint or targeted pytest locally because pixi and pytest are not available in this environment.
