### PR TITLE
feat: add Full Sweep scan mode for faster raster engraving

### DIFF
--- a/debian/requirements-bundle.txt
+++ b/debian/requirements-bundle.txt
@@ -1,5 +1,5 @@
 asyncudp==0.11.0
 pyvips==3.0.0
-raygeo==0.6.1
+raygeo==0.6.2
 trimesh==4.6.8
 vtracer==0.6.11

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/__init__.py
@@ -13,7 +13,7 @@ from .material_test_grid_producer import (
     draw_material_test_preview,
     get_material_test_proportional_size,
 )
-from .raster_producer import DepthMode, Rasterizer
+from .raster_producer import DepthMode, Rasterizer, ScanMode
 from .shrinkwrap_producer import ShrinkWrapProducer
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "CutOrder",
     "Rasterizer",
     "DepthMode",
+    "ScanMode",
     "FrameProducer",
     "MaterialTestGridProducer",
     "MaterialTestGridType",

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/raster_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/raster_producer.py
@@ -8,6 +8,7 @@ import numpy as np
 from raygeo.image import compute_auto_levels, normalize_grayscale
 from raygeo.ops import Ops
 from raygeo.ops.raster import (
+    ScanMode,
     rasterize_mask_scan,
     rasterize_multi_pass,
     rasterize_power_modulation,
@@ -69,6 +70,7 @@ class Rasterizer(OpsProducer):
         self,
         scan_angle: float = 0.0,
         depth_mode: DepthMode = DepthMode.POWER_MODULATION,
+        scan_mode: ScanMode = ScanMode.Segmented,
         threshold: int = 128,
         dither_algorithm: Optional[
             DitherAlgorithm
@@ -90,6 +92,7 @@ class Rasterizer(OpsProducer):
     ):
         self.scan_angle = scan_angle
         self.depth_mode = depth_mode
+        self.scan_mode = scan_mode
         self.threshold = threshold
         self.dither_algorithm = dither_algorithm
         self.cross_hatch = cross_hatch
@@ -319,6 +322,7 @@ class Rasterizer(OpsProducer):
             step_power=step_power,
             num_power_levels=self.num_power_levels,
             angle=angle,
+            scan_mode=self.scan_mode,
         )
 
     def _run_constant_power(
@@ -360,6 +364,7 @@ class Rasterizer(OpsProducer):
             line_interval_mm,
             step_power=step_power,
             angle=angle,
+            scan_mode=self.scan_mode,
         )
 
     def _run_multi_pass(
@@ -381,6 +386,7 @@ class Rasterizer(OpsProducer):
             self.z_step_down,
             angle=angle,
             angle_increment=self.angle_increment,
+            scan_mode=self.scan_mode,
         )
 
     @staticmethod
@@ -405,6 +411,7 @@ class Rasterizer(OpsProducer):
             "params": {
                 "scan_angle": self.scan_angle,
                 "depth_mode": self.depth_mode.name,
+                "scan_mode": self.scan_mode.name,
                 "threshold": self.threshold,
                 "dither_algorithm": (
                     self.dither_algorithm.value
@@ -447,6 +454,7 @@ class Rasterizer(OpsProducer):
         valid_params = {
             "scan_angle",
             "depth_mode",
+            "scan_mode",
             "threshold",
             "dither_algorithm",
             "cross_hatch",
@@ -480,6 +488,17 @@ class Rasterizer(OpsProducer):
             init_args["depth_mode"] = DepthMode[depth_mode_str]
         except KeyError:
             init_args["depth_mode"] = DepthMode.POWER_MODULATION
+
+        scan_mode_str = init_args.pop("scan_mode", ScanMode.Segmented.name)
+        scan_mode_map = {
+            "Segmented": ScanMode.Segmented,
+            "FullSweep": ScanMode.FullSweep,
+            "SEGMENTED": ScanMode.Segmented,
+            "FULL_SWEEP": ScanMode.FullSweep,
+        }
+        init_args["scan_mode"] = scan_mode_map.get(
+            scan_mode_str, ScanMode.Segmented
+        )
 
         dither_algorithm_str = init_args.get("dither_algorithm")
         if dither_algorithm_str is not None:

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -18,7 +18,9 @@ from rayforge.ui_gtk.shared.direction_preview import DirectionPreview
 from rayforge.ui_gtk.shared.histogram_preview import HistogramPreview
 from rayforge.ui_gtk.shared.slider import create_slider, create_slider_row
 
-from ..producers import DepthMode, Rasterizer
+from ..producers import DepthMode, Rasterizer, ScanMode
+
+_SCAN_MODES = [ScanMode.Segmented, ScanMode.FullSweep]
 
 if TYPE_CHECKING:
     from rayforge.core.step import Step
@@ -309,6 +311,24 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         )
         group.add(self.cross_hatch_row)
 
+        scan_mode_choices = [
+            _("Segmented"),
+            _("Full Sweep"),
+        ]
+        self.scan_mode_row = Adw.ComboRow(
+            title=_("Scan Mode"),
+            subtitle=_(
+                "Segmented: moves between content regions. "
+                "Full Sweep: scans full width with laser toggling."
+            ),
+            model=Gtk.StringList.new(scan_mode_choices),
+        )
+        self.scan_mode_row.set_selected(_SCAN_MODES.index(producer.scan_mode))
+        self.scan_mode_row.connect(
+            "notify::selected", self._on_scan_mode_changed
+        )
+        group.add(self.scan_mode_row)
+
         line_interval_adj = Gtk.Adjustment(
             lower=0.001,
             upper=10.0,
@@ -526,6 +546,11 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
             self.angle_scale.get_value(), cross_hatch
         )
         self._on_param_changed("cross_hatch", cross_hatch)
+
+    def _on_scan_mode_changed(self, row, pspec):
+        selected_idx = row.get_selected()
+        selected_mode = _SCAN_MODES[selected_idx]
+        self._on_param_changed("scan_mode", selected_mode.name)
 
     def _update_power_labels(self, invert: bool):
         """Update min/max power labels based on invert setting."""

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_raster_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_raster_producer.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import cairo
 import pytest
-from laser_essentials.producers import DepthMode, Rasterizer
+from laser_essentials.producers import DepthMode, Rasterizer, ScanMode
 from raygeo.ops.types import CommandType, SectionType
 
 from rayforge.core.workpiece import WorkPiece
@@ -1150,6 +1150,377 @@ def test_constant_power_with_scan_angle(
 
     assert len(scan_indices_horizontal) >= 1
     assert len(scan_indices_angled) >= 1
+
+
+class TestScanMode:
+    """Tests for ScanMode parameter on Rasterizer."""
+
+    def test_default_is_segmented(self, producer: Rasterizer):
+        assert producer.scan_mode == ScanMode.Segmented
+
+    def test_full_sweep_construction(self):
+        r = Rasterizer(scan_mode=ScanMode.FullSweep)
+        assert r.scan_mode == ScanMode.FullSweep
+
+    def test_segmented_construction(self):
+        r = Rasterizer(scan_mode=ScanMode.Segmented)
+        assert r.scan_mode == ScanMode.Segmented
+
+
+class TestScanModeSerialization:
+    """Tests for serialization/deserialization of scan_mode."""
+
+    def test_to_dict_includes_scan_mode(self, producer: Rasterizer):
+        data = producer.to_dict()
+        assert "scan_mode" in data["params"]
+
+    def test_to_dict_default_is_segmented(self, producer: Rasterizer):
+        data = producer.to_dict()
+        assert data["params"]["scan_mode"] == "Segmented"
+
+    def test_to_dict_full_sweep(self):
+        r = Rasterizer(scan_mode=ScanMode.FullSweep)
+        data = r.to_dict()
+        assert data["params"]["scan_mode"] == "FullSweep"
+
+    def test_from_dict_with_scan_mode(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {"scan_mode": "FullSweep"},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.FullSweep
+
+    def test_from_dict_segmented(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {"scan_mode": "Segmented"},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.Segmented
+
+    def test_from_dict_default_scan_mode(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.Segmented
+
+    def test_from_dict_invalid_scan_mode(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {"scan_mode": "INVALID"},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.Segmented
+
+    def test_roundtrip_segmented(self):
+        original = Rasterizer(scan_mode=ScanMode.Segmented)
+        data = original.to_dict()
+        recreated = Rasterizer.from_dict(data)
+        assert recreated.scan_mode == ScanMode.Segmented
+
+    def test_roundtrip_full_sweep(self):
+        original = Rasterizer(scan_mode=ScanMode.FullSweep)
+        data = original.to_dict()
+        recreated = Rasterizer.from_dict(data)
+        assert recreated.scan_mode == ScanMode.FullSweep
+
+    def test_to_dict_roundtrip_preserves_all_params(self):
+        original = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            scan_angle=45.0,
+            depth_mode=DepthMode.POWER_MODULATION,
+            min_power=0.1,
+            max_power=0.9,
+        )
+        data = original.to_dict()
+        recreated = Rasterizer.from_dict(data)
+        assert recreated.scan_mode == ScanMode.FullSweep
+        assert recreated.scan_angle == 45.0
+        assert recreated.depth_mode == DepthMode.POWER_MODULATION
+
+    def test_backward_compat_segmented_upper(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {"scan_mode": "SEGMENTED"},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.Segmented
+
+    def test_backward_compat_full_sweep_upper(self):
+        data = {
+            "type": "Rasterizer",
+            "params": {"scan_mode": "FULL_SWEEP"},
+        }
+        r = Rasterizer.from_dict(data)
+        assert r.scan_mode == ScanMode.FullSweep
+
+
+def _make_striped_surface(
+    width: int, height: int, stripe_width: int
+) -> cairo.ImageSurface:
+    """Create a surface with alternating black/white vertical stripes."""
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+    ctx = cairo.Context(surface)
+    for x in range(0, width, stripe_width):
+        brightness = 0.0 if (x // stripe_width) % 2 == 0 else 1.0
+        ctx.set_source_rgb(brightness, brightness, brightness)
+        ctx.rectangle(x, 0, stripe_width, height)
+        ctx.fill()
+    return surface
+
+
+class TestPowerModulationFullSweep:
+    """Integration tests: POWER_MODULATION with Full Sweep."""
+
+    def test_full_sweep_fewer_scans_than_segmented(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        seg = Rasterizer(
+            scan_mode=ScanMode.Segmented,
+            depth_mode=DepthMode.POWER_MODULATION,
+        )
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.POWER_MODULATION,
+        )
+
+        art_seg = seg.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+        art_full = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scans_seg = len(art_seg.ops.indices_of(CommandType.SCAN_LINE))
+        scans_full = len(art_full.ops.indices_of(CommandType.SCAN_LINE))
+
+        assert scans_seg > 0
+        assert scans_full > 0
+        assert scans_full < scans_seg
+
+    def test_full_sweep_includes_zero_power_gaps(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.POWER_MODULATION,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scan_indices = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scan_indices) > 0
+
+        all_power_vals = []
+        for i in scan_indices:
+            all_power_vals.extend(art.ops.scanline_data(i))
+
+        has_zero = any(v == 0 for v in all_power_vals)
+        has_nonzero = any(v > 0 for v in all_power_vals)
+        assert has_zero, "Full sweep should have zero-power gaps"
+        assert has_nonzero, "Full sweep should have non-zero power values"
+
+    def test_full_sweep_uniform_image(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        ctx = cairo.Context(surface)
+        ctx.set_source_rgb(0, 0, 0)
+        ctx.paint()
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.POWER_MODULATION,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scan_indices = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scan_indices) > 0
+
+    def test_full_sweep_with_angle(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.POWER_MODULATION,
+            scan_angle=45.0,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scan_indices = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scan_indices) > 0
+
+
+class TestConstantPowerFullSweep:
+    """Integration tests: CONSTANT_POWER + DITHER with Full Sweep."""
+
+    def test_full_sweep_fewer_scans_than_segmented(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        seg = Rasterizer(
+            scan_mode=ScanMode.Segmented,
+            depth_mode=DepthMode.CONSTANT_POWER,
+            threshold=128,
+        )
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.CONSTANT_POWER,
+            threshold=128,
+        )
+
+        art_seg = seg.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+        art_full = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scans_seg = len(art_seg.ops.indices_of(CommandType.SCAN_LINE))
+        scans_full = len(art_full.ops.indices_of(CommandType.SCAN_LINE))
+
+        assert scans_seg > 0
+        assert scans_full > 0
+        assert scans_full < scans_seg
+
+    def test_full_sweep_empty_mask(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        ctx = cairo.Context(surface)
+        ctx.set_source_rgb(1, 1, 1)
+        ctx.paint()
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.CONSTANT_POWER,
+            threshold=128,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scans = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scans) == 0
+
+    def test_full_sweep_full_mask(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        ctx = cairo.Context(surface)
+        ctx.set_source_rgb(0, 0, 0)
+        ctx.paint()
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.CONSTANT_POWER,
+            threshold=128,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scans = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scans) > 0
+
+    def test_full_sweep_dither(self, laser: Laser, mock_workpiece: WorkPiece):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        ctx = cairo.Context(surface)
+        ctx.set_source_rgb(0.5, 0.5, 0.5)
+        ctx.paint()
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.DITHER,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        scans = art.ops.indices_of(CommandType.SCAN_LINE)
+        assert len(scans) > 0
+
+
+class TestMultiPassFullSweep:
+    """Integration tests: MULTI_PASS with Full Sweep."""
+
+    def test_full_sweep_fewer_lines_than_segmented(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        seg = Rasterizer(
+            scan_mode=ScanMode.Segmented,
+            depth_mode=DepthMode.MULTI_PASS,
+            num_depth_levels=1,
+        )
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.MULTI_PASS,
+            num_depth_levels=1,
+        )
+
+        art_seg = seg.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+        art_full = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        lines_seg = len(art_seg.ops.indices_of(CommandType.LINE_TO))
+        lines_full = len(art_full.ops.indices_of(CommandType.LINE_TO))
+
+        assert lines_seg > 0
+        assert lines_full > 0
+        assert lines_full < lines_seg
+
+    def test_full_sweep_with_angle_increment(
+        self, laser: Laser, mock_workpiece: WorkPiece
+    ):
+        surface = _make_striped_surface(10, 10, 2)
+        mock_workpiece.set_size(1.0, 1.0)
+
+        full = Rasterizer(
+            scan_mode=ScanMode.FullSweep,
+            depth_mode=DepthMode.MULTI_PASS,
+            num_depth_levels=2,
+            angle_increment=45.0,
+        )
+        art = full.run(
+            laser, surface, (10, 10), workpiece=mock_workpiece, generation_id=1
+        )
+
+        lines = art.ops.indices_of(CommandType.LINE_TO)
+        assert len(lines) > 0
+
+
+def test_initialization_defaults_includes_scan_mode(producer: Rasterizer):
+    """Verify scan_mode default is Segmented."""
+    assert producer.scan_mode == ScanMode.Segmented
 
 
 def test_power_modulation_with_scan_angle(

--- a/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_tabs_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_tabs_transformer.py
@@ -48,9 +48,7 @@ def _make_sectioned_mixed_ops():
 
 
 def _count_in_ops(ops, cmd_type):
-    return sum(
-        1 for i in range(ops.len()) if ops.command_type(i) == cmd_type
-    )
+    return sum(1 for i in range(ops.len()) if ops.command_type(i) == cmd_type)
 
 
 # ------------------------------------------------------------------
@@ -73,9 +71,7 @@ def test_bezier_gap_splits_into_two_beziers():
     ops.apply_tab_gaps(clips)
 
     bezier_count = _count_in_ops(ops, CommandType.BEZIER_TO)
-    assert bezier_count == 2, (
-        f"Expected 2 bezier segments, got {bezier_count}"
-    )
+    assert bezier_count == 2, f"Expected 2 bezier segments, got {bezier_count}"
 
 
 def test_bezier_gap_preserves_start_and_end():
@@ -186,7 +182,8 @@ def test_bezier_power_mode_no_overlap():
     assert bezier_count == 1
 
     bezier_idx = next(
-        i for i in range(ops.len())
+        i
+        for i in range(ops.len())
         if ops.command_type(i) == CommandType.BEZIER_TO
     )
     assert ops.endpoint(bezier_idx) == _P1

--- a/rayforge/simulator/op_player.py
+++ b/rayforge/simulator/op_player.py
@@ -28,9 +28,9 @@ class OpPlayer:
         self._prev_layer_uid: Optional[str] = None
         self.state = self._create_home_state()
         self.layer_changed = Signal()
-        self._snapshots: List[Tuple[
-            int, MachineState, Axis, Optional[Axis]
-        ]] = []
+        self._snapshots: List[
+            Tuple[int, MachineState, Axis, Optional[Axis]]
+        ] = []
         self._build_snapshots()
 
     def _build_snapshots(self):
@@ -43,12 +43,14 @@ class OpPlayer:
         interval = _SNAPSHOT_INTERVAL
         for target in range(interval, n, interval):
             temp_player.advance_to(target - 1)
-            self._snapshots.append((
-                target,
-                temp_player.state.copy(),
-                temp_player._source_axis,
-                temp_player._rotary_axis,
-            ))
+            self._snapshots.append(
+                (
+                    target,
+                    temp_player.state.copy(),
+                    temp_player._source_axis,
+                    temp_player._rotary_axis,
+                )
+            )
 
     @property
     def current_index(self) -> int:
@@ -102,9 +104,9 @@ class OpPlayer:
 
         snapshot_idx = self._find_snapshot(index)
         if snapshot_idx is not None:
-            snap_index, snap_state, snap_source, snap_rotary = (
-                self._snapshots[snapshot_idx]
-            )
+            snap_index, snap_state, snap_source, snap_rotary = self._snapshots[
+                snapshot_idx
+            ]
             self.state = snap_state.copy()
             self._current_index = snap_index - 1
             self._source_axis = snap_source
@@ -203,9 +205,7 @@ class _SnapshotBuilder:
         for i in range(self._current_index + 1, index + 1):
             ct = self.ops.command_type(i)
             if ct == CommandType.LAYER_START:
-                item = self._doc.find_descendant_by_uid(
-                    self.ops.layer_uid(i)
-                )
+                item = self._doc.find_descendant_by_uid(self.ops.layer_uid(i))
                 if isinstance(item, Layer):
                     module = (
                         self._machine.rotary_modules.get(


### PR DESCRIPTION
## Summary

- Adds a new **Scan Mode** option to the raster engraver with two choices: **Segmented** (default, existing behavior) and **Full Sweep** (new)
- **Full Sweep** scans the entire width of each scan line with laser power toggling on/off, instead of splitting into separate segments per content region. This dramatically reduces acceleration/deceleration moves for high-contrast images with many separate black regions.
- Works across all depth modes: Power Modulation, Constant Power, Dither, and Multi-Pass
- Includes UI toggle in the Engraving Pattern settings group, serialization with backward compatibility, and comprehensive tests

Closes #253

## Context

When engraving images with high contrast (many separate black regions per line), the segmented approach causes the laser to accel/decel for each region, resulting in 4x+ longer engraving times. Full Sweep trades slightly reduced sharpness (laser passes over white regions at zero power) for significantly faster engraving.