### PR TITLE
Add "Go to WCS Zero" button

### DIFF
--- a/rayforge/resources/icons/goto-origin-symbolic.svg
+++ b/rayforge/resources/icons/goto-origin-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24px"
+   viewBox="0 0 24 24"
+   width="24px"
+   fill="#000000"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="goto-origin-symbolic.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="36.916667"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="3840"
+     inkscape:window-height="2020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M 6 19 H 18 V 21 H 6 Z M 18 18 L 22 20 L 18 22 Z M 3 6 H 5 V 18 H 3 Z M 2 6 L 4 2 L 6 6 Z M 6 20 A 2 2 0 1 0 2 20 A 2 2 0 1 0 6 20 Z"
+     id="path1" />
+</svg>

--- a/rayforge/ui_gtk/doceditor/bottom_panel.py
+++ b/rayforge/ui_gtk/doceditor/bottom_panel.py
@@ -292,14 +292,14 @@ class BottomPanel(Gtk.Box):
             self.wcs_list = self.machine.supported_wcs
         else:
             self.wcs_list = []
-        wcs_model = Gtk.StringList.new(self.wcs_list)
+        self._wcs_model = Gtk.StringList.new(self.wcs_list)
 
         factory = Gtk.SignalListItemFactory()
         factory.connect("setup", self._on_wcs_factory_setup)
         factory.connect("bind", self._on_wcs_factory_bind)
 
         self.wcs_row = Adw.ComboRow(
-            model=wcs_model,
+            model=self._wcs_model,
             factory=factory,
             use_subtitle=True,
         )
@@ -681,6 +681,10 @@ class BottomPanel(Gtk.Box):
         self.wcs_row.set_subtitle(
             f"X: {off_x:.2f}   Y: {off_y:.2f}   Z: {off_z:.2f}"
         )
+
+        n = self._wcs_model.get_n_items()
+        for i in range(n):
+            self._wcs_model.items_changed(i, 1, 1)
 
         is_dummy = isinstance(self.machine.driver, NoDeviceDriver)
         is_connected = self.machine.is_connected()

--- a/rayforge/ui_gtk/doceditor/bottom_panel.py
+++ b/rayforge/ui_gtk/doceditor/bottom_panel.py
@@ -353,6 +353,19 @@ class BottomPanel(Gtk.Box):
         )
         position_button_box.append(self.move_ur_btn)
 
+        self.move_origin_btn = Gtk.Button(
+            child=get_icon("goto-origin-symbolic")
+        )
+        self.move_origin_btn.add_css_class("flat")
+        self.move_origin_btn.set_size_request(40, -1)
+        self.move_origin_btn.connect(
+            "clicked", self._on_move_to_wcs_zero
+        )
+        self.move_origin_btn.set_tooltip_text(
+            _("Move to Origin of Active WCS")
+        )
+        position_button_box.append(self.move_origin_btn)
+
         self.zero_row = Adw.ActionRow(title=_("Zero Axes"))
         self.wcs_group.add(self.zero_row)
 
@@ -532,6 +545,7 @@ class BottomPanel(Gtk.Box):
         self.move_ll_btn.set_sensitive(has_bounds and is_active)
         self.move_center_btn.set_sensitive(has_bounds and is_active)
         self.move_ur_btn.set_sensitive(has_bounds and is_active)
+        self.move_origin_btn.set_sensitive(is_active)
 
     def _on_move_to_position(self, button, position: str):
         if not self.machine or not self.machine_cmd:
@@ -564,6 +578,11 @@ class BottomPanel(Gtk.Box):
         self.machine_cmd.move_to(
             self.machine, machine_x - x_off, machine_y - y_off
         )
+
+    def _on_move_to_wcs_zero(self, button):
+        if not self.machine or not self.machine_cmd:
+            return
+        self.machine_cmd.move_to(self.machine, 0.0, 0.0)
 
     def _on_click_to_zero_toggled(self, button):
         self.set_click_to_zero_mode(not self._click_to_zero_mode)


### PR DESCRIPTION
## Summary

- Adds a 4th button to the "Current Position" section with an axis-origin icon that moves the machine to X0 Y0 of the currently active WCS
- Includes a new `goto-origin-symbolic.svg` icon (L-shaped axis marker with origin dot)
- The button is enabled whenever the machine is connected (no selection bounds required)

Closes #247