### PR TITLE
Fix machine settings not applying until restart

### DIFF
--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -386,6 +386,7 @@ class Machine:
         Callback when dialects are updated.
         Sends machine's changed signal to trigger recalculation.
         """
+        self._hydrated_dialect = None
         self.changed.send(self)
 
     def is_connected(self) -> bool:
@@ -416,6 +417,7 @@ class Machine:
 
         self.driver_name = new_driver_name
         self.driver_args = new_args
+        self.changed.send(self)
         task_mgr.add_coroutine(
             self.controller.rebuild_driver,
             key=(self.id, "rebuild-driver"),
@@ -427,6 +429,7 @@ class Machine:
             return
 
         self.driver_args = new_args
+        self.changed.send(self)
         task_mgr.add_coroutine(
             self.controller.rebuild_driver,
             key=(self.id, "rebuild-driver"),
@@ -473,6 +476,7 @@ class Machine:
         if self.dialect_uid == dialect_uid:
             return
         self.dialect_uid = dialect_uid
+        self._hydrated_dialect = None
         self.changed.send(self)
 
     def set_gcode_precision(self, precision: int):
@@ -493,7 +497,15 @@ class Machine:
         self.supports_curves = supports
         self.changed.send(self)
 
+    def set_supports_arcs(self, supports: bool):
+        if self.supports_arcs == supports:
+            return
+        self.supports_arcs = supports
+        self.changed.send(self)
+
     def set_home_on_start(self, home_on_start: bool = True):
+        if self.home_on_start == home_on_start:
+            return
         self.home_on_start = home_on_start
         self.changed.send(self)
 
@@ -510,14 +522,20 @@ class Machine:
         self.changed.send(self)
 
     def set_max_travel_speed(self, speed: int):
+        if self.max_travel_speed == speed:
+            return
         self.max_travel_speed = speed
         self.changed.send(self)
 
     def set_max_cut_speed(self, speed: int):
+        if self.max_cut_speed == speed:
+            return
         self.max_cut_speed = speed
         self.changed.send(self)
 
     def set_acceleration(self, acceleration: int):
+        if self.acceleration == acceleration:
+            return
         self.acceleration = acceleration
         self.changed.send(self)
 
@@ -632,7 +650,15 @@ class Machine:
         self._soft_limits = clamped
         self.changed.send(self)
 
+    def clear_soft_limits(self):
+        if self._soft_limits is None:
+            return
+        self._soft_limits = None
+        self.changed.send(self)
+
     def set_origin(self, origin: Origin):
+        if self.origin == origin:
+            return
         self.origin = origin
         self.changed.send(self)
 
@@ -747,6 +773,8 @@ class Machine:
 
     def set_soft_limits_enabled(self, enabled: bool):
         """Enable or disable soft limits for jog operations."""
+        if self.soft_limits_enabled == enabled:
+            return
         self.soft_limits_enabled = enabled
         self.changed.send(self)
 

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -1233,6 +1233,7 @@ class WorkSurface(WorldSurface):
             self._sync_camera_elements()
             self._sync_nogo_zone_elements()
             self._on_wcs_updated(machine)
+            self._update_pipeline_view_context()
 
     def reset_view(self):
         """

--- a/rayforge/ui_gtk/machine/advanced_preferences_page.py
+++ b/rayforge/ui_gtk/machine/advanced_preferences_page.py
@@ -116,9 +116,8 @@ class AdvancedPreferencesPage(TrackedPreferencesPage):
 
     def on_arcs_changed(self, switch_row, _param):
         """Update the machine's arcs support when the value changes."""
-        self.machine.supports_arcs = switch_row.get_active()
+        self.machine.set_supports_arcs(switch_row.get_active())
         self.arc_tolerance_row.set_sensitive(self.machine.supports_arcs)
-        self.machine.changed.send(self.machine)
 
     def on_arc_tolerance_changed(self, spinrow):
         """Update to machine's arc tolerance when value changes."""

--- a/rayforge/ui_gtk/machine/hardware_page.py
+++ b/rayforge/ui_gtk/machine/hardware_page.py
@@ -396,8 +396,7 @@ class HardwarePage(TrackedPreferencesPage):
             y_max = get_spinrow_float(self.soft_y_max_row)
             self.machine.set_soft_limits(x_min, y_min, x_max, y_max)
         else:
-            self.machine._soft_limits = None
-            self.machine.changed.send(self.machine)
+            self.machine.clear_soft_limits()
 
     def on_soft_limits_changed(self, _spinrow, _param):
         if not self.soft_limits_enabled_row.get_active():

--- a/rayforge/ui_gtk/machine/jog_widget.py
+++ b/rayforge/ui_gtk/machine/jog_widget.py
@@ -200,7 +200,6 @@ class JogWidget(Gtk.Widget):
         self, machine: Optional[Machine], machine_cmd: Optional[MachineCmd]
     ):
         """Set the machine this widget controls."""
-        # Disconnect from previous machine if any
         if self.machine:
             self.machine.state_changed.disconnect(
                 self._on_machine_state_changed
@@ -208,17 +207,22 @@ class JogWidget(Gtk.Widget):
             self.machine.connection_status_changed.disconnect(
                 self._on_connection_status_changed
             )
+            self.machine.changed.disconnect(self._on_machine_changed)
 
         self.machine = machine
         self.machine_cmd = machine_cmd
 
-        # Connect to state changes
         if self.machine:
             self.machine.state_changed.connect(self._on_machine_state_changed)
             self.machine.connection_status_changed.connect(
                 self._on_connection_status_changed
             )
+            self.machine.changed.connect(self._on_machine_changed)
 
+        self._update_button_sensitivity()
+        self._update_limit_status()
+
+    def _on_machine_changed(self, sender, **kwargs):
         self._update_button_sensitivity()
         self._update_limit_status()
 

--- a/rayforge/ui_gtk/machine/laser_preferences_page.py
+++ b/rayforge/ui_gtk/machine/laser_preferences_page.py
@@ -627,6 +627,13 @@ class LaserPreferencesPage(DebounceMixin, TrackedPreferencesPage):
             self.laser_list_editor.list_box, initial_row
         )
 
+        self.connect("destroy", self._on_destroy)
+
+    def _on_destroy(self, *args):
+        self.machine.changed.disconnect(
+            self.laser_list_editor._on_machine_changed
+        )
+
     def on_laserhead_selected(self, listbox, row):
         """Update the configuration panel when a Laser is selected."""
         has_selection = row is not None

--- a/tests/machine/models/test_machine_model.py
+++ b/tests/machine/models/test_machine_model.py
@@ -769,3 +769,327 @@ class TestRotaryAxisGcodeOutput:
         expected_deg = (10.0 / circumference) * 360.0
         formatted_deg = f"{expected_deg:.3f}".rstrip("0").rstrip(".")
         assert formatted_deg in gcode
+
+
+class TestSetSupportsArcs:
+    """Tests for the set_supports_arcs setter."""
+
+    def test_default_is_true(self, lite_context):
+        machine = Machine(lite_context)
+        assert machine.supports_arcs is True
+
+    def test_set_supports_arcs(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_supports_arcs(False)
+        assert machine.supports_arcs is False
+        machine.set_supports_arcs(True)
+        assert machine.supports_arcs is True
+
+    def test_signal_fired_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_supports_arcs(False)
+        assert len(signals) == 1
+
+    def test_no_signal_on_same_value(self, lite_context):
+        machine = Machine(lite_context)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_supports_arcs(True)
+        assert len(signals) == 0
+
+    def test_serialization_round_trip(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_supports_arcs(False)
+        data = machine.to_dict()
+        restored = Machine.from_dict(data, context=lite_context)
+        assert restored.supports_arcs is False
+
+
+class TestClearSoftLimits:
+    """Tests for the clear_soft_limits method."""
+
+    def test_clears_soft_limits(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_axis_extents(500, 500)
+        machine.set_soft_limits(10, 20, 300, 400)
+        assert machine.soft_limits is not None
+        machine.clear_soft_limits()
+        assert machine.soft_limits is None
+
+    def test_signal_fired_when_limits_exist(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_axis_extents(500, 500)
+        machine.set_soft_limits(10, 20, 300, 400)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.clear_soft_limits()
+        assert len(signals) == 1
+
+    def test_no_signal_when_already_none(self, lite_context):
+        machine = Machine(lite_context)
+        assert machine.soft_limits is None
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.clear_soft_limits()
+        assert len(signals) == 0
+
+
+class TestSetterEqualityGuards:
+    """Tests for equality guards on setters that previously lacked them."""
+
+    def test_set_home_on_start_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.home_on_start = True
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_home_on_start(True)
+        assert len(signals) == 0
+
+    def test_set_home_on_start_signal_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        machine.home_on_start = True
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_home_on_start(False)
+        assert len(signals) == 1
+
+    def test_set_max_travel_speed_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.max_travel_speed = 5000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_max_travel_speed(5000)
+        assert len(signals) == 0
+
+    def test_set_max_travel_speed_signal_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        machine.max_travel_speed = 5000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_max_travel_speed(6000)
+        assert len(signals) == 1
+
+    def test_set_max_cut_speed_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.max_cut_speed = 3000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_max_cut_speed(3000)
+        assert len(signals) == 0
+
+    def test_set_max_cut_speed_signal_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        machine.max_cut_speed = 3000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_max_cut_speed(4000)
+        assert len(signals) == 1
+
+    def test_set_acceleration_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.acceleration = 1000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_acceleration(1000)
+        assert len(signals) == 0
+
+    def test_set_acceleration_signal_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        machine.acceleration = 1000
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_acceleration(2000)
+        assert len(signals) == 1
+
+    def test_set_origin_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_origin(Origin.BOTTOM_LEFT)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_origin(Origin.BOTTOM_LEFT)
+        assert len(signals) == 0
+
+    def test_set_origin_signal_on_change(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_origin(Origin.BOTTOM_LEFT)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_origin(Origin.TOP_LEFT)
+        assert len(signals) == 1
+
+    def test_set_soft_limits_enabled_no_signal_on_same(
+        self, lite_context
+    ):
+        machine = Machine(lite_context)
+        machine.soft_limits_enabled = False
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_soft_limits_enabled(False)
+        assert len(signals) == 0
+
+    def test_set_soft_limits_enabled_signal_on_change(
+        self, lite_context
+    ):
+        machine = Machine(lite_context)
+        machine.soft_limits_enabled = False
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_soft_limits_enabled(True)
+        assert len(signals) == 1
+
+
+class TestHydratedDialectCache:
+    """Tests for _hydrated_dialect cache invalidation."""
+
+    def test_set_dialect_uid_clears_cache(self, lite_context):
+        machine = Machine(lite_context)
+        machine.hydrate()
+        assert machine._hydrated_dialect is not None
+        machine.set_dialect_uid("smoothieware")
+        assert machine._hydrated_dialect is None
+
+    def test_set_dialect_uid_no_clear_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        machine.set_dialect_uid("grbl")
+        machine.hydrate()
+        assert machine._hydrated_dialect is not None
+        machine.set_dialect_uid("grbl")
+        assert machine._hydrated_dialect is not None
+
+    def test_dialect_returns_fresh_after_uid_change(self, lite_context):
+        from rayforge.machine.models.dialect import (
+            GRBL_DIALECT,
+            SMOOTHIEWARE_DIALECT,
+        )
+
+        machine = Machine(lite_context)
+        assert machine.dialect == GRBL_DIALECT
+        machine.hydrate()
+        assert machine._hydrated_dialect == GRBL_DIALECT
+        machine.set_dialect_uid("smoothieware")
+        assert machine.dialect == SMOOTHIEWARE_DIALECT
+
+
+class TestSetDriverEmitsChanged:
+    """Tests for set_driver/set_driver_args emitting changed."""
+
+    def test_set_driver_emits_changed_signal(self, lite_context):
+        machine = Machine(lite_context)
+        lite_context.machine_mgr.add_machine(machine)
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        from rayforge.machine.driver.dummy import NoDeviceDriver
+
+        class TestDriver(NoDeviceDriver):
+            pass
+
+        machine.set_driver(TestDriver, {"port": "/dev/null"})
+        assert len(signals) >= 1
+
+    def test_set_driver_args_emits_changed_signal(
+        self, lite_context
+    ):
+        machine = Machine(lite_context)
+        lite_context.machine_mgr.add_machine(machine)
+        from rayforge.machine.driver.dummy import NoDeviceDriver
+
+        class TestDriver2(NoDeviceDriver):
+            pass
+
+        machine.set_driver(TestDriver2, {"port": "/dev/old"})
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_driver_args({"port": "/dev/new"})
+        assert len(signals) >= 1
+
+    def test_set_driver_no_signal_on_same(self, lite_context):
+        machine = Machine(lite_context)
+        lite_context.machine_mgr.add_machine(machine)
+        from rayforge.machine.driver.dummy import NoDeviceDriver
+
+        class TestDriver3(NoDeviceDriver):
+            pass
+
+        machine.set_driver(TestDriver3, {"port": "/dev/null"})
+        signals = []
+
+        def handler(sender):
+            signals.append(sender)
+
+        machine.changed.connect(handler)
+        machine.set_driver(TestDriver3, {"port": "/dev/null"})
+        assert len(signals) == 0


### PR DESCRIPTION
Closes #266

Several machine settings changes were not propagating to listeners until the app was restarted. This fixes multiple root causes:

### Critical Fixes
- **`set_driver()`/`set_driver_args()` emit `changed` synchronously** — These were the only setters that didn't emit `machine.changed`, relying solely on an async `rebuild_driver` callback. This meant pipeline recalculation, persistence, and UI updates were all delayed or lost if the async chain failed.
- **`_hydrated_dialect` cache cleared on dialect change** — Once hydrated, the `dialect` property returned a stale cached value even after the user changed the dialect in settings.

### UI Fixes
- **`JogWidget` now listens to `machine.changed`** — Jog button sensitivity, home button visibility, and soft limit warnings now update when machine settings change.
- **`WorkSurface` incremental update path calls `_update_pipeline_view_context()`** — Non-dimension changes (laser colors, margins) now render on the 2D canvas immediately instead of requiring a zoom/pan.

### Memory Leak Fix
- **`LaserListEditor` signal handler disconnected on dialog destroy** — Prevented GC of the editor and all its widgets on every dialog open/close cycle.

### API Improvements
- **Added `Machine.set_supports_arcs()` setter** — Replaces direct attribute mutation + manual `changed.send()` in the advanced preferences page.
- **Added `Machine.clear_soft_limits()` method** — Replaces direct `_soft_limits = None` access in the hardware page.
- **Added equality guards to 6 setters** — `set_home_on_start`, `set_max_travel_speed`, `set_max_cut_speed`, `set_acceleration`, `set_origin`, and `set_soft_limits_enabled` now skip unnecessary signals when the value hasn't changed.

### Files Changed
- `rayforge/machine/models/machine.py` — Core model fixes
- `rayforge/ui_gtk/machine/jog_widget.py` — Machine change listener
- `rayforge/ui_gtk/canvas2d/surface.py` — Pipeline view context update
- `rayforge/ui_gtk/machine/laser_preferences_page.py` — Signal leak fix
- `rayforge/ui_gtk/machine/advanced_preferences_page.py` — Use new setter
- `rayforge/ui_gtk/machine/hardware_page.py` — Use clear_soft_limits()