### PR TITLE
Add device profile for Creality Falcon 10W

### DIFF
--- a/rayforge/resources/devices/creality-falcon-10w/device.yaml
+++ b/rayforge/resources/devices/creality-falcon-10w/device.yaml
@@ -1,0 +1,28 @@
+api_version: 1
+device:
+  name: Creality Falcon 10W
+  description: 10W diode laser engraver with 400x415mm work area
+machine:
+  driver: GrblSerialDriver
+  driver_args:
+    baudrate: '115200'
+    poll_status_while_running: false
+  gcode_precision: 3
+  supports_arcs: true
+  supports_curves: false
+  axis_extents:
+  - 400.0
+  - 415.0
+  origin: bottom_left
+  max_travel_speed: 10000
+  max_cut_speed: 10000
+  home_on_start: true
+  acceleration: 500
+  single_axis_homing_enabled: true
+  rotary_enabled_default: false
+  heads:
+  - max_power: 1000
+    frame_power_percent: 0.1
+    spot_size_mm:
+    - 0.1
+    - 0.1

--- a/rayforge/resources/devices/creality-falcon-10w/dialect.yaml
+++ b/rayforge/resources/devices/creality-falcon-10w/dialect.yaml
@@ -1,0 +1,29 @@
+laser_on: M4 S0
+laser_off: M5
+focus_laser_on: M3 S{power:.0f}
+tool_change: T{tool_number}
+set_speed: ''
+travel_move: G0{x_cmd}{y_cmd}{z_cmd}{extra_cmd}{f_command}{s_command}
+linear_move: G1{x_cmd}{y_cmd}{z_cmd}{extra_cmd}{f_command}{s_command}
+arc_cw: G2{x_cmd}{y_cmd}{z_cmd}{extra_cmd} I{i} J{j}{f_command}{s_command}
+arc_ccw: G3{x_cmd}{y_cmd}{z_cmd}{extra_cmd} I{i} J{j}{f_command}{s_command}
+bezier_cubic: ''
+air_assist_on: M8
+air_assist_off: M9
+home_all: $H
+home_axis: $H{axis_letter}
+move_to: $J=G90 G21 F{speed} X{x} Y{y}
+jog: $J=G91 G21 F{speed}
+clear_alarm: $X
+set_wcs_offset: G10 L2 P{p_num} X{x} Y{y} Z{z}
+probe_cycle: G38.2 {axis_letter}{max_travel} F{feed_rate}
+preamble:
+- G21 ;Set units to mm
+- G90 ;Absolute positioning
+postscript:
+- M5 ;Ensure laser is off
+- G0 X0 Y0 ;Return to origin
+can_g0_with_speed: true
+omit_unchanged_coords: true
+continuous_laser_mode: true
+modal_feedrate: true


### PR DESCRIPTION
## Summary

- Adds a device profile for the [Creality Falcon 10W](https://store.creality.com/mx/products/grabador-laser-falcon-de-10w) laser engraver
- Based on configuration shared by @thehamstermuffin in #266
- 10W diode laser with 400x415mm work area, GRBL-based firmware

Closes #266