### PR TITLE
Add raygeo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/raygeo"]
+	path = external/raygeo
+	url = https://github.com/barebaric/raygeo


### PR DESCRIPTION
Having Raygeo configured as a submodules prevents having dependency errors.

Noticed it because I couldn't run `pixi install` when following the developer documentation, with this change you only need to pull the submodule with  `git submodule update --init --recursive` after cloning the repository


 