### PR TITLE
Use adaptive deadlock timeouts based on per-command time estimates

### DIFF
--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -118,17 +118,15 @@ class MachineCmd:
                 await machine.driver.run(
                     encoded,
                     self._editor.doc,
+                    ops,
                     on_command_done=self._current_monitor.update_progress,
-                    ops=ops,
-                    machine=machine,
                 )
             else:
                 await machine.driver.run(
                     encoded,
                     self._editor.doc,
+                    ops,
                     on_command_done=None,
-                    ops=ops,
-                    machine=machine,
                 )
                 if self._current_monitor:
                     self._current_monitor.mark_as_complete()

--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -119,12 +119,16 @@ class MachineCmd:
                     encoded,
                     self._editor.doc,
                     on_command_done=self._current_monitor.update_progress,
+                    ops=ops,
+                    machine=machine,
                 )
             else:
                 await machine.driver.run(
                     encoded,
                     self._editor.doc,
                     on_command_done=None,
+                    ops=ops,
+                    machine=machine,
                 )
                 if self._current_monitor:
                     self._current_monitor.mark_as_complete()

--- a/rayforge/machine/driver/driver.py
+++ b/rayforge/machine/driver/driver.py
@@ -392,12 +392,10 @@ class Driver(ABC):
         self,
         encoded: "EncodedOutput",
         doc: "Doc",
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops: "Optional[Ops]" = None,
-        machine: "Optional['Machine']" = None,
     ) -> None:
         """
         Executes the given encoded output.
@@ -405,11 +403,9 @@ class Driver(ABC):
         Args:
             encoded: The encoded output containing machine code and op map
             doc: The document context
+            ops: The Ops object used to generate the encoded output.
             on_command_done: Optional sync or async callback called when each
                            command is done. Called with the op_index.
-            ops: The Ops object used to generate the encoded output.
-                Used for adaptive timeout computation.
-            machine: The Machine object. Used with ops for adaptive timeout.
         """
         pass
 

--- a/rayforge/machine/driver/driver.py
+++ b/rayforge/machine/driver/driver.py
@@ -21,6 +21,8 @@ from raygeo.ops.axis import Axis
 from ...context import RayforgeContext
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ...core.capability import Capability
     from ...core.doc import Doc
     from ...core.varset import VarSet
@@ -393,6 +395,9 @@ class Driver(ABC):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops: "Optional[Ops]" = None,
+        machine: "Optional['Machine']" = None,
     ) -> None:
         """
         Executes the given encoded output.
@@ -402,6 +407,9 @@ class Driver(ABC):
             doc: The document context
             on_command_done: Optional sync or async callback called when each
                            command is done. Called with the op_index.
+            ops: The Ops object used to generate the encoded output.
+                Used for adaptive timeout computation.
+            machine: The Machine object. Used with ops for adaptive timeout.
         """
         pass
 

--- a/rayforge/machine/driver/dummy.py
+++ b/rayforge/machine/driver/dummy.py
@@ -24,6 +24,8 @@ from ..transport import TransportStatus
 from .driver import DeviceStatus, Driver, Pos
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ...core.doc import Doc
     from ..models.laser import Laser
     from ..models.machine import Machine
@@ -116,7 +118,7 @@ class NoDeviceDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/dummy.py
+++ b/rayforge/machine/driver/dummy.py
@@ -116,12 +116,10 @@ class NoDeviceDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         """
         Dummy implementation that simulates command execution.

--- a/rayforge/machine/driver/dummy.py
+++ b/rayforge/machine/driver/dummy.py
@@ -119,6 +119,9 @@ class NoDeviceDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         """
         Dummy implementation that simulates command execution.

--- a/rayforge/machine/driver/grbl/grbl_network.py
+++ b/rayforge/machine/driver/grbl/grbl_network.py
@@ -358,6 +358,9 @@ class GrblNetworkDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         if not self.host:
             raise ConnectionError("Driver not configured with a host.")

--- a/rayforge/machine/driver/grbl/grbl_network.py
+++ b/rayforge/machine/driver/grbl/grbl_network.py
@@ -53,6 +53,8 @@ from .grbl_util import (
 )
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ....core.doc import Doc
     from ...device.profile import DeviceProfile
     from ...models.laser import Laser
@@ -355,7 +357,7 @@ class GrblNetworkDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/grbl/grbl_network.py
+++ b/rayforge/machine/driver/grbl/grbl_network.py
@@ -355,12 +355,10 @@ class GrblNetworkDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         if not self.host:
             raise ConnectionError("Driver not configured with a host.")

--- a/rayforge/machine/driver/grbl/grbl_serial.py
+++ b/rayforge/machine/driver/grbl/grbl_serial.py
@@ -901,25 +901,21 @@ class GrblSerialDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops: "Optional['Ops']" = None,
-        machine: "Optional['Machine']" = None,
     ) -> None:
         self._start_job(on_command_done)
 
         mapping = encoded.op_map.machine_code_to_op if encoded.op_map else None
         gcode_lines = encoded.text.splitlines()
 
-        command_times = None
-        if ops is not None and machine is not None:
-            command_times = ops.estimate_command_times(
-                default_cut_speed=machine.max_cut_speed,
-                default_travel_speed=machine.max_travel_speed,
-                acceleration=machine.acceleration,
-            )
+        command_times = ops.estimate_command_times(
+            default_cut_speed=self._machine.max_cut_speed,
+            default_travel_speed=self._machine.max_travel_speed,
+            acceleration=self._machine.acceleration,
+        )
 
         try:
             await self._stream_gcode(gcode_lines, mapping, command_times)

--- a/rayforge/machine/driver/grbl/grbl_serial.py
+++ b/rayforge/machine/driver/grbl/grbl_serial.py
@@ -63,6 +63,8 @@ from .grbl_util import (
 )
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ....core.doc import Doc
     from ...device.profile import DeviceProfile
     from ...models.laser import Laser
@@ -754,6 +756,7 @@ class GrblSerialDriver(Driver):
         self,
         gcode_lines: List[str],
         machine_code_to_op_map: Optional[Dict[int, int]] = None,
+        command_times: Optional[List[float]] = None,
     ):
         """
         The core G-code streaming logic using character-counting protocol.
@@ -765,12 +768,10 @@ class GrblSerialDriver(Driver):
         if not transport:
             raise ConnectionError("Transport not initialized")
         job_completed_successfully = False
-        if self._deadlock_detection:
-            deadlock_timeout = (
-                30.0 if not self._poll_status_while_running else 5.0
-            )
-        else:
-            deadlock_timeout = 30.0
+        min_timeout = 5.0
+        max_timeout = 120.0
+        safety_factor = 3.0
+        default_timeout = 30.0
         sent_count = 0
         try:
             for line_idx, line in enumerate(gcode_lines):
@@ -801,13 +802,26 @@ class GrblSerialDriver(Driver):
                 )
                 command_bytes = (line + "\n").encode("utf-8")
 
+                if (
+                    command_times is not None
+                    and op_index is not None
+                    and op_index < len(command_times)
+                ):
+                    estimated = command_times[op_index]
+                    timeout = min(
+                        max_timeout,
+                        max(min_timeout, estimated * safety_factor),
+                    )
+                else:
+                    timeout = default_timeout
+
                 try:
                     await self._send_gcode_line(
                         transport,
                         line,
                         command_bytes,
                         op_index,
-                        deadlock_timeout,
+                        timeout,
                     )
                 except BufferStallError:
                     if not self._job_exception:
@@ -831,7 +845,7 @@ class GrblSerialDriver(Driver):
                 logger.debug(
                     "All G-code sent. Waiting for all 'ok' responses."
                 )
-                await self._drain_pending_acks(transport, deadlock_timeout)
+                await self._drain_pending_acks(transport, default_timeout)
 
             if self._job_exception:
                 raise self._job_exception
@@ -890,14 +904,25 @@ class GrblSerialDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops: "Optional['Ops']" = None,
+        machine: "Optional['Machine']" = None,
     ) -> None:
         self._start_job(on_command_done)
 
         mapping = encoded.op_map.machine_code_to_op if encoded.op_map else None
         gcode_lines = encoded.text.splitlines()
 
+        command_times = None
+        if ops is not None and machine is not None:
+            command_times = ops.estimate_command_times(
+                default_cut_speed=machine.max_cut_speed,
+                default_travel_speed=machine.max_travel_speed,
+                acceleration=machine.acceleration,
+            )
+
         try:
-            await self._stream_gcode(gcode_lines, mapping)
+            await self._stream_gcode(gcode_lines, mapping, command_times)
         except DeviceConnectionError as e:
             # Catch the device error here to prevent it from propagating
             # up and tearing down the connection task. The error has

--- a/rayforge/machine/driver/marlin/marlin_serial.py
+++ b/rayforge/machine/driver/marlin/marlin_serial.py
@@ -48,6 +48,8 @@ from .marlin_util import (
 )
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ....core.doc import Doc
     from ...device.profile import DeviceProfile
     from ...models.laser import Laser
@@ -433,7 +435,7 @@ class MarlinSerialDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/marlin/marlin_serial.py
+++ b/rayforge/machine/driver/marlin/marlin_serial.py
@@ -436,6 +436,9 @@ class MarlinSerialDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         self._start_job(on_command_done)
 

--- a/rayforge/machine/driver/marlin/marlin_serial.py
+++ b/rayforge/machine/driver/marlin/marlin_serial.py
@@ -433,12 +433,10 @@ class MarlinSerialDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         self._start_job(on_command_done)
 

--- a/rayforge/machine/driver/octoprint/octoprint_driver.py
+++ b/rayforge/machine/driver/octoprint/octoprint_driver.py
@@ -542,12 +542,10 @@ class OctoPrintDriver(Driver):
         self,
         encoded: "EncodedOutput",
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         if not self.host:
             raise DeviceConnectionError(

--- a/rayforge/machine/driver/octoprint/octoprint_driver.py
+++ b/rayforge/machine/driver/octoprint/octoprint_driver.py
@@ -545,6 +545,9 @@ class OctoPrintDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         if not self.host:
             raise DeviceConnectionError(

--- a/rayforge/machine/driver/octoprint/octoprint_driver.py
+++ b/rayforge/machine/driver/octoprint/octoprint_driver.py
@@ -41,6 +41,8 @@ from ..driver import (
 )
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ....core.doc import Doc
     from ...models.laser import Laser
     from ...models.machine import Machine
@@ -542,7 +544,7 @@ class OctoPrintDriver(Driver):
         self,
         encoded: "EncodedOutput",
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/ruida/ruida_driver.py
+++ b/rayforge/machine/driver/ruida/ruida_driver.py
@@ -37,6 +37,8 @@ from .ruida_encoder import RuidaEncoder
 from .ruida_transport import RuidaTransport
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ....core.doc import Doc
     from ...models.laser import Laser
     from ...models.machine import Machine
@@ -388,7 +390,7 @@ class RuidaDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/ruida/ruida_driver.py
+++ b/rayforge/machine/driver/ruida/ruida_driver.py
@@ -391,6 +391,9 @@ class RuidaDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         binary_data = encoded.driver_data.get("binary", b"")
         text_lines = [

--- a/rayforge/machine/driver/ruida/ruida_driver.py
+++ b/rayforge/machine/driver/ruida/ruida_driver.py
@@ -388,12 +388,10 @@ class RuidaDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         binary_data = encoded.driver_data.get("binary", b"")
         text_lines = [

--- a/rayforge/machine/driver/smoothie.py
+++ b/rayforge/machine/driver/smoothie.py
@@ -213,12 +213,10 @@ class SmoothieDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
+        ops,
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
-        *,
-        ops=None,
-        machine=None,
     ) -> None:
         gcode_lines = encoded.text.splitlines()
         op_map = encoded.op_map

--- a/rayforge/machine/driver/smoothie.py
+++ b/rayforge/machine/driver/smoothie.py
@@ -31,6 +31,8 @@ from .driver import (
 from .grbl.grbl_util import parse_state
 
 if TYPE_CHECKING:
+    from raygeo.ops import Ops
+
     from ...core.doc import Doc
     from ..models.laser import Laser
     from ..models.machine import Machine
@@ -213,7 +215,7 @@ class SmoothieDriver(Driver):
         self,
         encoded: EncodedOutput,
         doc: "Doc",
-        ops,
+        ops: "Ops",
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,

--- a/rayforge/machine/driver/smoothie.py
+++ b/rayforge/machine/driver/smoothie.py
@@ -216,6 +216,9 @@ class SmoothieDriver(Driver):
         on_command_done: Optional[
             Callable[[int], Union[None, Awaitable[None]]]
         ] = None,
+        *,
+        ops=None,
+        machine=None,
     ) -> None:
         gcode_lines = encoded.text.splitlines()
         op_map = encoded.op_map

--- a/tests/machine/driver/grbl/test_grbl_serial_driver.py
+++ b/tests/machine/driver/grbl/test_grbl_serial_driver.py
@@ -217,7 +217,9 @@ class TestGrblSerialDriver:
         callback_mock = MagicMock()
 
         encoded = driver._machine.encode_ops(ops, doc)
-        run_task = asyncio.create_task(driver.run(encoded, doc, callback_mock))
+        run_task = asyncio.create_task(
+            driver.run(encoded, doc, ops, callback_mock)
+        )
 
         gcode_lines = [
             b"G0 X10 Y10\n",
@@ -779,7 +781,9 @@ class TestGrblSerialDriver:
         ops.line_to(30, 30, 0)
 
         encoded = driver._machine.encode_ops(ops, doc)
-        run_task = asyncio.create_task(driver.run(encoded, doc, callback_mock))
+        run_task = asyncio.create_task(
+            driver.run(encoded, doc, ops, callback_mock)
+        )
 
         await asyncio.sleep(0.01)
         mock_serial_transport.send.assert_any_call(b"G0 X10 Y10\n")

--- a/tests/machine/driver/marlin/test_marlin_serial_driver.py
+++ b/tests/machine/driver/marlin/test_marlin_serial_driver.py
@@ -410,7 +410,7 @@ class TestMarlinSerialDriverRealSerial:
         ops.line_to(20, 20, 0)
         doc = Doc()
         encoded = machine.encode_ops(ops, doc)
-        await asyncio.wait_for(driver.run(encoded, doc), timeout=5.0)
+        await asyncio.wait_for(driver.run(encoded, doc, ops), timeout=5.0)
         job_finished.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/machine/driver/ruida/test_ruida_driver.py
+++ b/tests/machine/driver/ruida/test_ruida_driver.py
@@ -515,7 +515,7 @@ async def test_run_with_machine_code(driver, ruida_simulator):
     sim.x = 0
     sim.y = 0
 
-    await driver.run(encoded, doc)
+    await driver.run(encoded, doc, ops)
     await asyncio.sleep(0.2)
 
     assert sim.x == 30000

--- a/tests/machine/driver/test_dummy_driver.py
+++ b/tests/machine/driver/test_dummy_driver.py
@@ -66,7 +66,7 @@ class TestDummyDriverCallback:
         """Test that run() works without providing a callback."""
         # Should not raise any exceptions
         encoded = machine.encode_ops(simple_ops, doc)
-        await driver.run(encoded, doc)
+        await driver.run(encoded, doc, simple_ops)
 
     @pytest.mark.asyncio
     async def test_run_with_callback(self, driver, machine, doc, simple_ops):
@@ -74,7 +74,7 @@ class TestDummyDriverCallback:
         callback_mock = MagicMock()
 
         encoded = machine.encode_ops(simple_ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, simple_ops, callback_mock)
 
         # Verify callback was called for each command
         assert callback_mock.call_count == len(simple_ops)
@@ -92,7 +92,7 @@ class TestDummyDriverCallback:
         callback_mock = AsyncMock()
 
         encoded = machine.encode_ops(simple_ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, simple_ops, callback_mock)
 
         # Verify callback was called for each command
         assert callback_mock.call_count == len(simple_ops)
@@ -113,7 +113,7 @@ class TestDummyDriverCallback:
             received_indices.append(op_index)
 
         encoded = machine.encode_ops(simple_ops, doc)
-        await driver.run(encoded, doc, collect_indices)
+        await driver.run(encoded, doc, simple_ops, collect_indices)
 
         # Verify we got a callback for all commands
         assert len(received_indices) == len(simple_ops)
@@ -128,7 +128,7 @@ class TestDummyDriverCallback:
         callback_mock = MagicMock()
 
         encoded = machine.encode_ops(empty_ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, empty_ops, callback_mock)
 
         # Callback should not be called for empty ops
         callback_mock.assert_not_called()
@@ -141,7 +141,7 @@ class TestDummyDriverCallback:
         callback_mock = MagicMock()
 
         encoded = machine.encode_ops(complex_ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, complex_ops, callback_mock)
 
         # Verify callback was called for each command
         assert callback_mock.call_count == len(complex_ops)
@@ -167,7 +167,7 @@ class TestDummyDriverCallback:
 
         # The driver should catch the exception and continue
         encoded = machine.encode_ops(simple_ops, doc)
-        await driver.run(encoded, doc, failing_callback)
+        await driver.run(encoded, doc, simple_ops, failing_callback)
 
         # Verify that the driver still attempted to call for all ops
         assert call_count == len(simple_ops)
@@ -182,8 +182,8 @@ class TestDummyDriverCallback:
 
         # Run two operations concurrently
         encoded = machine.encode_ops(simple_ops, doc)
-        task1 = driver.run(encoded, doc, callback_mock1)
-        task2 = driver.run(encoded, doc, callback_mock2)
+        task1 = driver.run(encoded, doc, simple_ops, callback_mock1)
+        task2 = driver.run(encoded, doc, simple_ops, callback_mock2)
 
         await asyncio.gather(task1, task2)
 
@@ -202,7 +202,7 @@ class TestDummyDriverCallback:
         callback_mock = MagicMock()
 
         encoded = machine.encode_ops(ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, ops, callback_mock)
 
         # Verify callback was called
         assert callback_mock.call_count == len(ops)

--- a/tests/machine/driver/test_smoothie_driver.py
+++ b/tests/machine/driver/test_smoothie_driver.py
@@ -317,7 +317,7 @@ class TestSmoothieDriver:
         callback_mock = MagicMock()
 
         encoded = driver._machine.encode_ops(ops, doc)
-        await driver.run(encoded, doc, callback_mock)
+        await driver.run(encoded, doc, ops, callback_mock)
 
         # Check that the server received the correct G-code
         received_str = smoothie_server.received_data.decode()

--- a/tests/machine/models/test_machine.py
+++ b/tests/machine/models/test_machine.py
@@ -691,7 +691,7 @@ class TestMachine:
 
         # --- Assert ---
         run_spy.assert_called_once()
-        encoded, received_doc = run_spy.call_args.args
+        encoded, received_doc, received_ops = run_spy.call_args.args
         assert isinstance(encoded, EncodedOutput)
         assert received_doc is doc
 
@@ -738,7 +738,7 @@ class TestMachine:
 
         # --- Assert ---
         run_spy.assert_called_once()
-        encoded, received_doc = run_spy.call_args.args
+        encoded, received_doc, received_ops = run_spy.call_args.args
         from rayforge.pipeline.encoder.base import EncodedOutput
 
         assert isinstance(encoded, EncodedOutput)


### PR DESCRIPTION
## Summary

Replaces the fixed `deadlock_timeout` (2s/10s/30s from PR #262) with per-gcode-line adaptive timeouts computed from `Ops.estimate_command_times()`.

**How it works:**

- `cmd.py` passes `ops` and `machine` to `driver.run()` (keyword-only, backward compatible)
- `GrblSerialDriver.run()` calls `ops.estimate_command_times(machine.max_cut_speed, ...)` to get a per-op duration array
- `_stream_gcode()` looks up each line's `op_index` in the array and computes: `timeout = clamp(estimated_time * 3, min=5s, max=120s)`
- Lines without an `op_index` (state commands, raw gcode) fall back to 30s default

**Example:** A 100mm move at F200 takes ~30s. Previous fixed timeout (10s) would trigger a false stall. New timeout: `30s * 3 = 90s`. A 1mm rapid at F3000 takes ~0.02s. New timeout: `max(5s, 0.02s * 3) = 5s`.

**Depends on:** barebaric/raygeo#4 (merged)

**Files changed:**
- `driver.py` — abstract `run()` gains keyword-only `ops`, `machine` params
- `grbl_serial.py` — adaptive timeout logic in `_stream_gcode()`
- `cmd.py` — passes `ops`, `machine` to `driver.run()`
- 5 other drivers — accept new params (ignored, for interface compatibility)