### PR TITLE
Fix GRBL network disconnect with MKS DLC32

### DIFF
--- a/rayforge/machine/transport/websocket.py
+++ b/rayforge/machine/transport/websocket.py
@@ -57,6 +57,7 @@ class WebSocketTransport(Transport):
                 self._websocket = await websockets.connect(
                     self.uri,
                     origin=self._origin,
+                    ping_interval=None,
                     additional_headers=(
                         ("Connection", "Upgrade"),
                         ("Upgrade", "websocket"),


### PR DESCRIPTION
## Summary

Fixes #273

- Disables client-side WebSocket ping/pong keepalive by setting `ping_interval=None` in `websockets.connect()`

## Problem

The MKS DLC32 board's WebSocket server sends incorrectly masked response frames. When the `websockets` library sends its default keepalive ping (every 20 seconds), the server's response triggers a protocol error:

```
> CLOSE 1002 (protocol error) incorrect masking
```

This causes the connection to drop every 20-30 seconds, making machine controls gray out until auto-reconnect completes.

## Why this is safe

The client-side ping is redundant because:
- The MKS DLC32 server already sends its own WebSocket pings (`< PING '' [0 bytes]`)
- The HTTP transport polls status every 0.5 seconds, providing a secondary keepalive
- For other GRBL network devices that don't send pings, the HTTP polling still ensures connection liveness is monitored

## Testing

- Verified with flake8 lint (no issues)
- Existing test suite references `GrblNetworkDriver` in `test_machine.py` (no new tests needed for a one-line transport parameter change)