### PR TITLE
Fix Windows dev setup: add missing win_run.sh and clarify MINGW64 shell

### DIFF
--- a/scripts/win/win_run.sh
+++ b/scripts/win/win_run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Runs Rayforge from source in the configured MSYS2 environment.
+# Usage: win_run.sh [args passed to rayforge]
+set -e
+
+if [ ! -f .msys2_env ]; then
+    echo "FATAL: .msys2_env file not found. Please run 'bash scripts/win/win_setup.sh' first."
+    exit 1
+fi
+
+source .msys2_env
+
+exec python -m rayforge.app "$@"

--- a/website/src/components/InstallGuide.js
+++ b/website/src/components/InstallGuide.js
@@ -781,6 +781,9 @@ function WindowsDeveloperInstall() {
           <Admonition type="tip">
             <Translate id="install.msys2.defaultPath">
               Use the default installation path (C:\msys64) for best compatibility.
+              After installation, MSYS2 provides several shell shortcuts in the
+              Start Menu — always use the <strong>MINGW64</strong> shell for
+              Rayforge development. The other shells (MSYS2, UCRT64) will not work.
             </Translate>
           </Admonition>
         </div>


### PR DESCRIPTION
## Summary

- **Create `scripts/win/win_run.sh`** — The script was referenced in the docs (setup.md, InstallGuide.js, and all 6 translations) but never existed, making it impossible for developers to run Rayforge from source on Windows via `bash scripts/win/win_run.sh`.
- **Clarify MINGW64 shell requirement** — Added a tip in the InstallGuide.js Step 1 that MSYS2 provides multiple shells and only the **MINGW64** shell works for Rayforge development. The other shells (MSYS2, UCRT64) will not work.

Addresses the documentation issues reported in issue #273 comments.