### PR TITLE
fix: avoid ValueError when removing the active machine (#280)

### DIFF
--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -191,6 +191,16 @@ class Machine:
         return self.context.machine_mgr.get_controller(self.id)
 
     @property
+    def has_controller(self) -> bool:
+        """
+        Returns whether a controller currently exists for this machine
+        without lazily creating one. This is ``False`` once the machine has
+        been removed and its controller torn down, allowing callers to skip
+        controller access that would otherwise raise.
+        """
+        return self.context.machine_mgr.has_controller(self.id)
+
+    @property
     def driver(self) -> "Driver":
         """Property to access the driver through the controller."""
         return self.controller.driver

--- a/rayforge/machine/models/manager.py
+++ b/rayforge/machine/models/manager.py
@@ -79,6 +79,15 @@ class MachineManager:
         self.controllers[machine_id] = controller
         return controller
 
+    def has_controller(self, machine_id: str) -> bool:
+        """
+        Returns whether a controller has already been instantiated for the
+        given machine. Unlike ``get_controller``, this never lazily creates
+        a controller and never raises, so it is safe to call for machines
+        that have already been removed.
+        """
+        return machine_id in self.controllers
+
     async def _rebuild_and_connect_machine(self, machine: "Machine"):
         """
         A single, sequenced task that rebuilds a machine's driver and then

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -1507,9 +1507,17 @@ class MainWindow(Adw.ApplicationWindow):
             self._current_machine.machine_hours.changed.disconnect(
                 self._on_machine_hours_changed
             )
-            self._current_machine.controller.laser_power_changed.disconnect(
-                self._on_laser_power_changed
-            )
+            # The controller signal is sourced directly from the controller
+            # object rather than proxied through the machine. When the active
+            # machine is removed, its controller is torn down before this
+            # handler runs, so accessing ``controller`` would lazily fail
+            # with a ValueError. Skip the disconnect in that case: the
+            # controller (and its signal) is already gone, so there is
+            # nothing left to detach.
+            if self._current_machine.has_controller:
+                self._current_machine.controller.laser_power_changed.disconnect(  # noqa: E501
+                    self._on_laser_power_changed
+                )
 
         self._current_machine = config.machine
 

--- a/tests/machine/models/test_machine_manager.py
+++ b/tests/machine/models/test_machine_manager.py
@@ -10,10 +10,13 @@ The MachineManager is responsible for managing the collection of
 machines and coordinating their lifecycle.
 """
 
+import asyncio
+
 import pytest
 
 from rayforge.machine.models.machine import Machine
 from rayforge.machine.models.manager import MachineManager
+from rayforge.shared.tasker.manager import TaskManager
 
 
 @pytest.mark.usefixtures("lite_context")
@@ -57,3 +60,49 @@ class TestMachineManager:
         assert hasattr(manager, "machine_added")
         assert hasattr(manager, "machine_removed")
         assert hasattr(manager, "machine_updated")
+
+    def test_has_controller_does_not_lazily_create(
+        self, lite_context, tmp_path
+    ):
+        """has_controller reports existence without lazily creating one."""
+        manager = MachineManager(tmp_path)
+        machine = Machine(lite_context)
+        manager.add_machine(machine)
+
+        # No controller has been instantiated yet.
+        assert manager.has_controller(machine.id) is False
+        assert machine.id not in manager.controllers
+
+        # It must also be safe (no raise) for unknown ids.
+        assert manager.has_controller("non-existent-id") is False
+
+        # Instantiating the controller flips the flag to True.
+        manager.get_controller(machine.id)
+        assert manager.has_controller(machine.id) is True
+
+    @pytest.mark.asyncio
+    async def test_removed_machine_reports_no_controller(
+        self, machine: Machine, task_mgr: TaskManager
+    ):
+        """
+        Regression for #280: removing the currently selected machine must
+        leave it without a live controller. Accessing ``machine.controller``
+        on a removed machine raises ValueError (the source of the crash), so
+        ``has_controller`` is what lets the UI safely skip the disconnect of
+        the controller's signals.
+        """
+        manager = machine.context.machine_mgr
+
+        # Force the controller into existence, mirroring the active machine
+        # whose laser_power_changed signal the UI has connected to.
+        manager.get_controller(machine.id)
+        assert machine.has_controller is True
+
+        manager.remove_machine(machine.id)
+        # Let the scheduled controller shutdown settle.
+        await asyncio.to_thread(task_mgr.wait_until_settled, 2000)
+
+        assert manager.has_controller(machine.id) is False
+        assert machine.has_controller is False
+        with pytest.raises(ValueError):
+            _ = machine.controller


### PR DESCRIPTION
## Summary

- Deleting the currently selected machine raised `ValueError: No machine found with ID ...` and left the UI stuck on the removed machine's settings until restart.
- Root cause: `MachineManager.remove_machine` tears down the controller before emitting `machine_removed`. The cascading config-changed handler in `MainWindow._on_machine_signals_changed` then accesses `self._current_machine.controller` (lazily re-resolving through the already-emptied manager) and raises — aborting the handler before the UI refreshes.

## Changes

- `rayforge/machine/models/manager.py`: add `has_controller(machine_id)` — checks `machine_id in self.controllers` without lazily creating one; safe to call for removed machines.
- `rayforge/machine/models/machine.py`: add `Machine.has_controller` property delegating to the manager.
- `rayforge/ui_gtk/mainwindow.py`: guard `laser_power_changed.disconnect(...)` with `if self._current_machine.has_controller:` so an already-torn-down controller is skipped instead of crashing.
- `tests/machine/models/test_machine_manager.py`: add `test_has_controller_does_not_lazily_create` and `test_removed_machine_reports_no_controller` (regression for #280 — asserts `.controller` raises `ValueError` without the guard, confirming the test is load-bearing).

Fixes #280