### PR TITLE
Fix pipeline stress test: stale completions and busy state

### DIFF
--- a/rayforge/pipeline/pipeline.py
+++ b/rayforge/pipeline/pipeline.py
@@ -305,6 +305,21 @@ class Pipeline:
                 self._data_stale_flag = True
                 self.data_stale.send(self)
 
+    def _busy_reason(self) -> str:
+        if self._reconciliation_timer is not None:
+            return "reconciliation_timer"
+        if self._removal_timer is not None:
+            return "removal_timer"
+        if self._scheduler.has_pending_work():
+            nodes = self._scheduler.graph.get_all_nodes()
+            proc = [
+                n.key for n in nodes if n.state.value == "processing"
+            ]
+            return f"pending_work(processing={proc})"
+        if self._task_manager.has_tasks():
+            return "has_tasks"
+        return "none"
+
     @property
     def is_busy(self) -> bool:
         """
@@ -315,7 +330,15 @@ class Pipeline:
         1. A reconciliation timer is pending, OR
         2. A removal timer is pending, OR
         3. The scheduler has pending work (PROCESSING nodes), OR
-        4. Any context (active or inactive) has active tasks
+        4. The task manager has active tasks
+
+        Both checks 3 and 4 are needed because they can diverge:
+        ``artifact_created`` events can set DAG nodes to VALID before
+        the worker has sent its final "done" message, causing
+        ``has_pending_work()`` to return False while tasks are still
+        live in the TaskManager.  Conversely, a cancelled task is
+        removed from the TaskManager immediately but its DAG node may
+        still appear as PROCESSING until the cancellation propagates.
         """
         if self._reconciliation_timer is not None:
             return True
@@ -323,9 +346,11 @@ class Pipeline:
             return True
         if self._scheduler.has_pending_work():
             return True
-        for ctx in self._contexts.values():
-            if ctx.has_active_tasks():
-                return True
+        if self._task_manager.has_tasks():
+            return True
+        active_ctx = self._active_context
+        if active_ctx is not None and active_ctx.has_active_tasks():
+            return True
         return False
 
     def _check_and_update_processing_state(self) -> None:
@@ -913,6 +938,14 @@ class Pipeline:
         if self._is_shutting_down:
             return
 
+        if generation_id < self._data_generation_id:
+            logger.debug(
+                f"Ignoring stale workpiece completion for "
+                f"generation {generation_id} "
+                f"(current: {self._data_generation_id})"
+            )
+            return
+
         if handle is not None:
             self.workpiece_artifact_ready.send(
                 self,
@@ -923,7 +956,17 @@ class Pipeline:
             )
 
         if task_status != "canceled":
+            had_timer = self._reconciliation_timer is not None
             self._scheduler.process_graph()
+            if (
+                self._reconciliation_timer is not None
+                and not had_timer
+            ):
+                logger.debug(
+                    f"Completion of gen {generation_id} triggered new "
+                    f"invalidation — process_graph work will be handled "
+                    f"by debounced reconciliation."
+                )
 
         if not self.is_busy and self._reconciliation_timer is None:
             self._task_manager.schedule_on_main_thread(

--- a/rayforge/pipeline/stage/step_stage.py
+++ b/rayforge/pipeline/stage/step_stage.py
@@ -146,12 +146,20 @@ class StepPipelineStage(PipelineStage):
             self._artifact_manager.release_handle(handle)
 
         task_status = task.get_status()
-        logger.debug(f"[{ledger_key}] Task status is '{task_status}'.")
+        is_current = self._artifact_manager.is_generation_current(
+            ledger_key, task_generation_id
+        )
+        logger.debug(
+            f"[{ledger_key}] Task status is '{task_status}', "
+            f"is_current={is_current}."
+        )
 
         if task_status == "canceled":
             with self._artifact_manager.report_cancellation(
                 ledger_key, task_generation_id
             ):
+                if is_current:
+                    self._emit_node_state(ledger_key, NodeState.DIRTY)
                 self.generation_finished.send(
                     self, step=step, generation_id=task_generation_id
                 )
@@ -172,7 +180,8 @@ class StepPipelineStage(PipelineStage):
                     self, step=step, generation_id=task_generation_id
                 )
         else:
-            self._emit_node_state(ledger_key, NodeState.ERROR)
+            if is_current:
+                self._emit_node_state(ledger_key, NodeState.ERROR)
             with self._artifact_manager.report_failure(
                 ledger_key, task_generation_id
             ):

--- a/rayforge/pipeline/stage/workpiece_stage.py
+++ b/rayforge/pipeline/stage/workpiece_stage.py
@@ -205,12 +205,20 @@ class WorkPiecePipelineStage(PipelineStage):
             context.task_did_finish(key)
 
         task_status = task.get_status()
-        logger.debug(f"[{key}] Task status is '{task_status}'.")
+        is_current = self._artifact_manager.is_generation_current(
+            key, generation_id
+        )
+        logger.debug(
+            f"[{key}] Task status is '{task_status}', "
+            f"is_current={is_current}."
+        )
 
         if task_status == "canceled":
             with self._artifact_manager.report_cancellation(
                 key, generation_id
             ) as handle:
+                if is_current:
+                    self._emit_node_state(key, NodeState.DIRTY)
                 self.generation_finished.send(
                     self,
                     step=step,
@@ -247,7 +255,8 @@ class WorkPiecePipelineStage(PipelineStage):
                 f"Ops generation for '{step.name}' on '{wp_name}' failed."
             )
             logger.warning(f"[{key}] {error_msg}")
-            self._emit_node_state(key, NodeState.ERROR)
+            if is_current:
+                self._emit_node_state(key, NodeState.ERROR)
             with self._artifact_manager.report_failure(
                 key, generation_id
             ) as handle:

--- a/tests/pipeline/test_pipeline_context.py
+++ b/tests/pipeline/test_pipeline_context.py
@@ -242,10 +242,10 @@ class TestPipelineBusyState:
         assert not pipeline._scheduler.has_pending_work()
         assert not pipeline.is_busy
 
-    def test_is_busy_true_with_inactive_context_tasks(
+    def test_is_busy_false_when_tasks_only_in_inactive_context(
         self, doc, mock_task_mgr
     ):
-        """Test is_busy is True when inactive context has active tasks."""
+        """Test is_busy is False when only inactive context has tasks."""
         pipeline = Pipeline(
             doc=doc,
             task_manager=mock_task_mgr,
@@ -261,7 +261,7 @@ class TestPipelineBusyState:
         pipeline._contexts[2] = pipeline._active_context
 
         assert not pipeline._scheduler.has_pending_work()
-        assert pipeline.is_busy
+        assert not pipeline.is_busy
 
     def test_is_busy_false_when_inactive_context_empty(
         self, doc, mock_task_mgr
@@ -295,8 +295,8 @@ class TestPipelineBusyState:
 
         assert pipeline.is_busy
 
-    def test_is_busy_checks_all_inactive_contexts(self, doc, mock_task_mgr):
-        """Test is_busy checks all inactive contexts for active tasks."""
+    def test_is_busy_ignores_inactive_contexts(self, doc, mock_task_mgr):
+        """Test is_busy only checks the active context for tasks."""
         pipeline = Pipeline(
             doc=doc,
             task_manager=mock_task_mgr,
@@ -316,7 +316,7 @@ class TestPipelineBusyState:
         pipeline._contexts[3] = ctx3
         pipeline._active_context = ctx3
 
-        assert pipeline.is_busy
+        assert not pipeline.is_busy
 
     def test_is_busy_active_context_tasks_included(self, doc, mock_task_mgr):
         """Test is_busy includes active tasks in the active context."""

--- a/tests/pipeline/test_stress_pipeline.py
+++ b/tests/pipeline/test_stress_pipeline.py
@@ -151,9 +151,34 @@ class StressTestController:
         """
         start = time.monotonic()
         timeout = self.config.max_settle_wait_sec
+        last_log = start
         while time.monotonic() - start < timeout:
-            if not self.pipeline.is_busy and not self.task_mgr.has_tasks():
+            if not self.pipeline.is_busy:
                 return True
+            now = time.monotonic()
+            if now - last_log >= 2.0:
+                reason = self.pipeline._busy_reason()
+                scheduler = self.pipeline._scheduler
+                graph = scheduler.graph
+                nodes = graph.get_all_nodes()
+                states = {}
+                for n in nodes:
+                    states.setdefault(n.state.value, []).append(
+                        n.key.id[:8]
+                    )
+                active_ctx = self.pipeline._active_context
+                ctx_tasks = (
+                    active_ctx.active_tasks if active_ctx else set()
+                )
+                logger.error(
+                    f"Settle stuck at +{now - start:.1f}s: "
+                    f"busy_reason={reason}, "
+                    f"has_tasks={self.task_mgr.has_tasks()}, "
+                    f"gen_id={self.pipeline._data_generation_id}, "
+                    f"nodes={states}, "
+                    f"ctx_tasks={len(ctx_tasks)}"
+                )
+                last_log = now
             await asyncio.sleep(0.1)
         return False
 

--- a/tests/pipeline/test_stress_pipeline.py
+++ b/tests/pipeline/test_stress_pipeline.py
@@ -147,10 +147,20 @@ class StressTestController:
         """
         Wait for pipeline to reach idle state.
 
+        Polls ``pipeline.is_busy`` until it returns ``False``, which
+        covers reconciliation/removal timers, in-flight scheduler work,
+        and live tasks in the task manager.  On previous versions the
+        condition also checked ``task_mgr.has_tasks()`` independently,
+        but that is now redundant because ``is_busy`` already includes
+        that check.
+
         Returns True if settled within timeout, False if timeout exceeded.
         """
         start = time.monotonic()
         timeout = self.config.max_settle_wait_sec
+        # Log diagnostic details every 2 s so that a stuck settle
+        # produces a useful trail (busy reason, node states, active
+        # context tasks) instead of silently timing out.
         last_log = start
         while time.monotonic() - start < timeout:
             if not self.pipeline.is_busy:
@@ -161,6 +171,7 @@ class StressTestController:
                 scheduler = self.pipeline._scheduler
                 graph = scheduler.graph
                 nodes = graph.get_all_nodes()
+                # Bucket nodes by state to keep the log line compact.
                 states = {}
                 for n in nodes:
                     states.setdefault(n.state.value, []).append(


### PR DESCRIPTION
## Summary

Extracted pipeline-only fixes from #278 that address the `test_pipeline_stress_random_invalidations` stress test failures.

- **Gate `_emit_node_state` on `is_generation_current()`** — prevents stale task completions from corrupting DAG node state (both `step_stage.py` and `workpiece_stage.py`)
- **Check both `has_pending_work()` and `has_tasks()` in `is_busy`** — `artifact_created` events can set DAG nodes to VALID before the worker sends its final "done" message, causing `has_pending_work()` to return False while tasks are still live
- **Skip `process_graph()` for stale generation completions** — avoids processing work from outdated data generations
- **Add `_busy_reason()` diagnostic** — logs why the pipeline reports busy during settle phase, for easier debugging
- **Update `test_pipeline_context.py`** — reflects the new `is_busy` semantics (active context only, not all contexts)

Tested: stress test passes locally (~2min), all pipeline context tests pass.

Note: the full stress test reliability also depends on the tasker/worker pool changes in #278 (stuck worker detection, early cancel). This PR contains the pipeline-side fixes that are independent and useful on their own.