### PR TITLE
Delegate image processing to raygeo.image, keep only Cairo wrappers

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -6,9 +6,9 @@ from gi.repository import Adw, GObject, Gtk
 
 from rayforge.image.dither import DitherAlgorithm
 from rayforge.image.util import (
-    compute_auto_levels,
     get_visible_grayscale_values,
 )
+from raygeo.image import compute_auto_levels
 from rayforge.shared.util.glib import DebounceMixin
 from rayforge.ui_gtk.doceditor.step_settings.base import (
     StepComponentSettingsWidget,

--- a/rayforge/image/dither.py
+++ b/rayforge/image/dither.py
@@ -3,8 +3,12 @@
 from enum import Enum
 
 import numpy as np
-
-from .util.srgb import linear_to_srgb, srgb_to_linear
+from raygeo.image import (
+    apply_bayer_dither,
+    apply_floyd_steinberg_dither,
+    apply_minimum_run_length,
+    rgba_to_grayscale,
+)
 
 
 class DitherAlgorithm(Enum):
@@ -36,123 +40,6 @@ BAYER_MATRICES = {
 }
 
 
-def apply_floyd_steinberg_dither(
-    grayscale: np.ndarray, invert: bool
-) -> np.ndarray:
-    """
-    Apply Floyd-Steinberg error diffusion dithering to a grayscale image.
-
-    Args:
-        grayscale: 2D array of grayscale values (0-255).
-        invert: If True, invert the output (engrave light areas).
-
-    Returns:
-        Binary image where 1 represents areas to engrave.
-    """
-    height, width = grayscale.shape
-    linear = srgb_to_linear(np.clip(grayscale, 0, 255).astype(np.uint8))
-    dithered = linear.astype(np.float32).copy()
-
-    for y in range(height):
-        for x in range(width):
-            old_pixel = dithered[y, x]
-            new_pixel = 0.0 if old_pixel < 0.5 else 1.0
-            dithered[y, x] = new_pixel
-            quant_error = old_pixel - new_pixel
-
-            if x + 1 < width:
-                dithered[y, x + 1] += quant_error * 7.0 / 16.0
-            if y + 1 < height:
-                if x > 0:
-                    dithered[y + 1, x - 1] += quant_error * 3.0 / 16.0
-                dithered[y + 1, x] += quant_error * 5.0 / 16.0
-                if x + 1 < width:
-                    dithered[y + 1, x + 1] += quant_error * 1.0 / 16.0
-
-    if invert:
-        return (dithered >= 0.5).astype(np.uint8)
-    else:
-        return (dithered < 0.5).astype(np.uint8)
-
-
-def apply_minimum_run_length(
-    binary: np.ndarray, min_run_length: int
-) -> np.ndarray:
-    """
-    Ensure all runs of 1s are at least min_run_length pixels long.
-
-    Short runs are removed (set to 0). This prevents the laser from
-    attempting to engrave features smaller than its spot size.
-
-    Args:
-        binary: 2D binary array.
-        min_run_length: Minimum run length in pixels.
-
-    Returns:
-        Binary array with short runs removed.
-    """
-    if min_run_length <= 1:
-        return binary
-
-    result = binary.copy()
-    height, width = binary.shape
-
-    for y in range(height):
-        row = result[y, :]
-        x = 0
-        while x < width:
-            if row[x] == 1:
-                run_start = x
-                while x < width and row[x] == 1:
-                    x += 1
-                run_length = x - run_start
-                if run_length < min_run_length:
-                    row[run_start:x] = 0
-            else:
-                x += 1
-
-    return result
-
-
-def apply_bayer_dither(
-    grayscale: np.ndarray,
-    bayer_matrix: np.ndarray,
-    invert: bool,
-    cell_size: int = 1,
-) -> np.ndarray:
-    """
-    Apply ordered dithering using a Bayer matrix.
-
-    Args:
-        grayscale: 2D array of grayscale values (0-255).
-        bayer_matrix: Bayer threshold matrix.
-        invert: If True, invert the output (engrave light areas).
-        cell_size: Size of each dither cell in pixels. Values > 1 create
-            larger threshold regions suitable for coarser laser resolution.
-
-    Returns:
-        Binary image where 1 represents areas to engrave.
-    """
-    height, width = grayscale.shape
-    matrix_size = bayer_matrix.shape[0]
-
-    normalized_matrix = (bayer_matrix / (matrix_size * matrix_size)) * 255.0
-
-    result = np.zeros((height, width), dtype=np.uint8)
-
-    for y in range(height):
-        for x in range(width):
-            cell_x = (x // cell_size) % matrix_size
-            cell_y = (y // cell_size) % matrix_size
-            threshold = normalized_matrix[cell_y, cell_x]
-            if invert:
-                result[y, x] = 1 if grayscale[y, x] > threshold else 0
-            else:
-                result[y, x] = 1 if grayscale[y, x] < threshold else 0
-
-    return result
-
-
 def surface_to_dithered_array(
     surface,
     dither_algorithm: DitherAlgorithm,
@@ -166,48 +53,17 @@ def surface_to_dithered_array(
         surface: Cairo surface in ARGB32 format.
         dither_algorithm: The dithering algorithm to use.
         invert: If True, invert the output (engrave light areas).
-        min_feature_px: Minimum feature size in pixels. Ensures dithered
-            patterns have features no smaller than this size, suitable
-            for the laser's spot size.
+        min_feature_px: Minimum feature size in pixels.
 
     Returns:
         Binary image where 1 represents areas to engrave.
     """
     width = surface.get_width()
     height = surface.get_height()
-    stride = surface.get_stride()
+    stride_px = surface.get_stride() // 4
+    buf = np.frombuffer(surface.get_data(), dtype=np.uint8).copy()
 
-    buf = surface.get_data()
-    data_with_padding = np.ndarray(
-        shape=(height, stride // 4, 4), dtype=np.uint8, buffer=buf
-    )
-    data = data_with_padding[:, :width, :]
-
-    blue = data[:, :, 0].astype(np.float32)
-    green = data[:, :, 1].astype(np.float32)
-    red = data[:, :, 2].astype(np.float32)
-    alpha = data[:, :, 3].astype(np.float32)
-
-    alpha_safe = np.maximum(alpha, 1e-6)
-
-    red_unpremult = np.clip(red * 255.0 / alpha_safe, 0, 255)
-    green_unpremult = np.clip(green * 255.0 / alpha_safe, 0, 255)
-    blue_unpremult = np.clip(blue * 255.0 / alpha_safe, 0, 255)
-
-    red_linear = srgb_to_linear(red_unpremult.astype(np.uint8))
-    green_linear = srgb_to_linear(green_unpremult.astype(np.uint8))
-    blue_linear = srgb_to_linear(blue_unpremult.astype(np.uint8))
-
-    alpha_normalized = alpha / 255.0
-    red_blended = 1.0 - (1.0 - red_linear) * alpha_normalized
-    green_blended = 1.0 - (1.0 - green_linear) * alpha_normalized
-    blue_blended = 1.0 - (1.0 - blue_linear) * alpha_normalized
-
-    gray_linear = (
-        0.2989 * red_blended + 0.5870 * green_blended + 0.1140 * blue_blended
-    )
-
-    grayscale = linear_to_srgb(gray_linear).astype(np.float32)
+    grayscale, _ = rgba_to_grayscale(buf, width, height, stride_px)
 
     if dither_algorithm == DitherAlgorithm.FLOYD_STEINBERG:
         bw_image = apply_floyd_steinberg_dither(grayscale, invert)
@@ -218,5 +74,4 @@ def surface_to_dithered_array(
             grayscale, bayer_matrix, invert, cell_size=min_feature_px
         )
 
-    bw_image[alpha == 0] = 0
     return bw_image

--- a/rayforge/image/util/__init__.py
+++ b/rayforge/image/util/__init__.py
@@ -9,12 +9,12 @@ This module provides utilities for:
 - Unit conversion and layout (unit module)
 """
 
+from raygeo.image import compute_auto_levels, normalize_grayscale
+
 from .cairo_util import rgba_to_cairo_surface
 from .grayscale import (
-    compute_auto_levels,
     convert_surface_to_grayscale_inplace,
     get_visible_grayscale_values,
-    normalize_grayscale,
     surface_to_binary,
     surface_to_grayscale,
 )

--- a/rayforge/image/util/grayscale.py
+++ b/rayforge/image/util/grayscale.py
@@ -2,98 +2,28 @@
 Grayscale and binary image conversion utilities for Cairo surfaces.
 """
 
-from typing import Tuple
-
 import cairo
-import numpy
-
-from .srgb import linear_to_srgb, srgb_to_linear
-
-
-def compute_auto_levels(
-    gray_image: numpy.ndarray,
-    clip_percent: float = 1.0,
-) -> Tuple[int, int]:
-    """
-    Compute black and white points automatically using percentile clipping.
-
-    Uses a heuristic that clips a percentage of pixels at both ends of the
-    histogram to automatically determine the black and white points.
-
-    Args:
-        gray_image: uint8 numpy array with grayscale values (0-255).
-        clip_percent: Percentage of pixels to clip at each end (0-100).
-            Default is 1.0, meaning the bottom 1% and top 1% are clipped.
-
-    Returns:
-        Tuple of (black_point, white_point) as integers in range 0-255.
-        black_point will be at least 1 less than white_point.
-    """
-    if gray_image.size == 0:
-        return 0, 255
-
-    flat = gray_image.flatten()
-    if flat.size == 0:
-        return 0, 255
-
-    lower_percentile = clip_percent
-    upper_percentile = 100.0 - clip_percent
-
-    black_point = int(numpy.percentile(flat, lower_percentile))
-    white_point = int(numpy.percentile(flat, upper_percentile))
-
-    black_point = max(0, min(253, black_point))
-    white_point = max(black_point + 2, min(255, white_point))
-
-    return black_point, white_point
+import numpy as np
+from raygeo.image import (
+    rgba_to_binary,
+    rgba_to_grayscale,
+    rgba_to_grayscale_inplace,
+)
 
 
-def normalize_grayscale(
-    gray_image: numpy.ndarray,
-    black_point: int = 0,
-    white_point: int = 255,
-) -> numpy.ndarray:
-    """
-    Normalize grayscale values based on black and white points.
-
-    Stretches the histogram so that:
-    - Values at or below black_point become 0 (black)
-    - Values at or above white_point become 255 (white)
-    - Values in between are linearly interpolated
-
-    Args:
-        gray_image: uint8 numpy array with grayscale values (0-255).
-        black_point: Input value that maps to black (0). Default 0.
-        white_point: Input value that maps to white (255). Default 255.
-
-    Returns:
-        Normalized uint8 numpy array with values 0-255.
-
-    Raises:
-        ValueError: If black_point >= white_point.
-    """
-    if black_point >= white_point:
-        raise ValueError(
-            f"black_point ({black_point}) must be less than "
-            f"white_point ({white_point})"
-        )
-
-    clipped = numpy.clip(gray_image, black_point, white_point).astype(
-        numpy.float32
-    )
-    normalized = (clipped - black_point) / (white_point - black_point) * 255.0
-
-    return normalized.astype(numpy.uint8)
+def _extract_rgba(surface: cairo.ImageSurface) -> tuple:
+    width = surface.get_width()
+    height = surface.get_height()
+    stride_px = surface.get_stride() // 4
+    buf = np.frombuffer(surface.get_data(), dtype=np.uint8).copy()
+    return buf, width, height, stride_px
 
 
 def surface_to_grayscale(
     surface: cairo.ImageSurface,
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Convert a Cairo ARGB32 surface to a grayscale array with alpha handling.
-
-    Performs proper unpremultiplication of alpha and blends to white
-    background for grayscale calculation.
 
     Args:
         surface: Cairo ImageSurface in FORMAT_ARGB32 format.
@@ -103,88 +33,24 @@ def surface_to_grayscale(
         grayscale_array: uint8 array with values 0-255.
         alpha_array: float32 array with values 0.0-1.0.
     """
-    width_px = surface.get_width()
-    height_px = surface.get_height()
-    stride = surface.get_stride()
-    buf = surface.get_data()
-    data_with_padding = numpy.ndarray(
-        shape=(height_px, stride // 4, 4), dtype=numpy.uint8, buffer=buf
-    )
-    data = data_with_padding[:, :width_px, :]
-
-    alpha = data[:, :, 3].astype(numpy.float32) / 255.0
-
-    r = data[:, :, 2].astype(numpy.float32)
-    g = data[:, :, 1].astype(numpy.float32)
-    b = data[:, :, 0].astype(numpy.float32)
-
-    alpha_safe = numpy.maximum(alpha, 1e-6)
-
-    r_unpremult = r / alpha_safe
-    g_unpremult = g / alpha_safe
-    b_unpremult = b / alpha_safe
-
-    r_unpremult = numpy.clip(r_unpremult, 0, 255)
-    g_unpremult = numpy.clip(g_unpremult, 0, 255)
-    b_unpremult = numpy.clip(b_unpremult, 0, 255)
-
-    r_linear = srgb_to_linear(r_unpremult.astype(numpy.uint8))
-    g_linear = srgb_to_linear(g_unpremult.astype(numpy.uint8))
-    b_linear = srgb_to_linear(b_unpremult.astype(numpy.uint8))
-
-    r_blended = 1.0 - (1.0 - r_linear) * alpha
-    g_blended = 1.0 - (1.0 - g_linear) * alpha
-    b_blended = 1.0 - (1.0 - b_linear) * alpha
-
-    gray_linear = 0.2989 * r_blended + 0.5870 * g_blended + 0.1140 * b_blended
-
-    gray_image = linear_to_srgb(gray_linear)
-
-    return gray_image, alpha
-
-
-def get_visible_grayscale_values(
-    surface: cairo.ImageSurface,
-    invert: bool = False,
-) -> numpy.ndarray:
-    """
-    Extract grayscale values for visible pixels from a Cairo ARGB32 surface.
-
-    Args:
-        surface: Cairo ImageSurface in FORMAT_ARGB32 format.
-        invert: If True, invert grayscale values for visible pixels.
-
-    Returns:
-        1D uint8 numpy array containing grayscale values (0-255) for pixels
-        with alpha > 0. Returns empty array if no visible pixels.
-    """
-    gray_image, alpha = surface_to_grayscale(surface)
-
-    if invert:
-        alpha_mask = alpha > 0
-        gray_image[alpha_mask] = 255 - gray_image[alpha_mask]
-
-    return gray_image[alpha > 0]
+    buf, width, height, stride = _extract_rgba(surface)
+    return rgba_to_grayscale(buf, width, height, stride)
 
 
 def surface_to_binary(
     surface: cairo.ImageSurface,
     threshold: int = 128,
     invert: bool = False,
-) -> numpy.ndarray:
+) -> np.ndarray:
     """
     Convert a Cairo ARGB32 surface to a binary array using thresholding.
 
-    Converts the surface to grayscale and applies a threshold to produce
-    a binary (0 or 1) output. Transparent pixels are always treated as
-    white (0).
+    Transparent pixels are always treated as white (0).
 
     Args:
         surface: Cairo ImageSurface in FORMAT_ARGB32 format.
-        threshold: Brightness value (0-255) for binarization. Pixels with
-            grayscale value below this threshold become black (1).
-        invert: If True, invert the binarization logic. Pixels above the
-            threshold become black (1).
+        threshold: Brightness value (0-255) for binarization.
+        invert: If True, pixels above threshold become black (1).
 
     Returns:
         2D numpy array with values 0 (white/transparent) or 1 (black).
@@ -194,34 +60,8 @@ def surface_to_binary(
     """
     if surface.get_format() != cairo.FORMAT_ARGB32:
         raise ValueError("Unsupported Cairo surface format")
-
-    width = surface.get_width()
-    height = surface.get_height()
-    data = numpy.frombuffer(surface.get_data(), dtype=numpy.uint8)
-    data = data.reshape((height, width, 4))
-
-    blue = data[:, :, 0]
-    green = data[:, :, 1]
-    red = data[:, :, 2]
-    alpha = data[:, :, 3]
-
-    red_linear = srgb_to_linear(red)
-    green_linear = srgb_to_linear(green)
-    blue_linear = srgb_to_linear(blue)
-
-    gray_linear = (
-        0.2989 * red_linear + 0.5870 * green_linear + 0.1140 * blue_linear
-    )
-
-    grayscale = linear_to_srgb(gray_linear).astype(numpy.float32)
-
-    if invert:
-        binary = (grayscale > threshold).astype(numpy.uint8)
-    else:
-        binary = (grayscale < threshold).astype(numpy.uint8)
-
-    binary[alpha == 0] = 0
-    return binary
+    buf, width, height, stride = _extract_rgba(surface)
+    return rgba_to_binary(buf, width, height, stride, threshold, invert)
 
 
 def convert_surface_to_grayscale_inplace(
@@ -229,9 +69,6 @@ def convert_surface_to_grayscale_inplace(
 ) -> None:
     """
     Convert a Cairo ARGB32 surface to grayscale in place.
-
-    Modifies the surface directly, converting RGB channels to grayscale
-    while preserving the alpha channel.
 
     Args:
         surface: Cairo ImageSurface in FORMAT_ARGB32 format.
@@ -241,25 +78,29 @@ def convert_surface_to_grayscale_inplace(
     """
     if surface.get_format() != cairo.FORMAT_ARGB32:
         raise ValueError("Unsupported Cairo surface format")
+    width = surface.get_width()
+    height = surface.get_height()
+    stride_px = surface.get_stride() // 4
+    buf = np.frombuffer(surface.get_data(), dtype=np.uint8)
+    rgba_to_grayscale_inplace(buf, width, height, stride_px)
 
-    width, height = surface.get_width(), surface.get_height()
-    data = surface.get_data()
-    data_array = numpy.frombuffer(data, dtype=numpy.uint8).reshape(
-        (height, width, 4)
-    )
 
-    red = data_array[:, :, 2]
-    green = data_array[:, :, 1]
-    blue = data_array[:, :, 0]
+def get_visible_grayscale_values(
+    surface: cairo.ImageSurface,
+    invert: bool = False,
+) -> np.ndarray:
+    """
+    Extract grayscale values for visible pixels from a Cairo ARGB32 surface.
 
-    red_linear = srgb_to_linear(red)
-    green_linear = srgb_to_linear(green)
-    blue_linear = srgb_to_linear(blue)
+    Args:
+        surface: Cairo ImageSurface in FORMAT_ARGB32 format.
+        invert: If True, invert grayscale values for visible pixels.
 
-    gray_linear = (
-        0.2989 * red_linear + 0.5870 * green_linear + 0.1140 * blue_linear
-    )
-
-    gray = linear_to_srgb(gray_linear)
-
-    data_array[:, :, :3] = gray[:, :, None]
+    Returns:
+        1D uint8 numpy array of grayscale values for pixels with alpha > 0.
+    """
+    gray_image, alpha = surface_to_grayscale(surface)
+    if invert:
+        alpha_mask = alpha > 0
+        gray_image[alpha_mask] = 255 - gray_image[alpha_mask]
+    return gray_image[alpha > 0]

--- a/rayforge/image/util/srgb.py
+++ b/rayforge/image/util/srgb.py
@@ -1,85 +1,16 @@
 """
 sRGB <-> linear light conversion utilities.
 
-Implements the sRGB transfer function defined in IEC 61966-2-1 using
-precomputed lookup tables for fast vectorized conversion with NumPy.
+Pure-array conversions delegate to raygeo.image. The remaining
+functions (create_lut_from_color, resize_linear_nd) have no raygeo
+equivalents and are kept in Python.
 """
 
 from typing import Tuple
 
 import cv2
 import numpy as np
-
-_SRGB_TO_LINEAR = np.empty(256, dtype=np.float32)
-for _i in range(256):
-    _s = _i / 255.0
-    if _s <= 0.04045:
-        _SRGB_TO_LINEAR[_i] = _s / 12.92
-    else:
-        _SRGB_TO_LINEAR[_i] = ((_s + 0.055) / 1.055) ** 2.4
-
-_FRAC_BITS = 15
-_SCALE = 1 << _FRAC_BITS
-_INV_TABLE_SIZE = _SCALE + 1
-
-_LINEAR_TO_SRGB = np.empty(_INV_TABLE_SIZE, dtype=np.uint8)
-for _i in range(_INV_TABLE_SIZE):
-    _lin = _i / _SCALE
-    if _lin <= 0.0031308:
-        _s = 12.92 * _lin
-    else:
-        _s = 1.055 * (_lin ** (1.0 / 2.4)) - 0.055
-    _LINEAR_TO_SRGB[_i] = min(255, max(0, round(_s * 255.0)))
-
-
-def srgb_to_linear(array: np.ndarray) -> np.ndarray:
-    """
-    Convert sRGB uint8 values to linear float [0.0, 1.0].
-
-    Uses a 256-entry lookup table for vectorized conversion.
-
-    Args:
-        array: uint8 numpy array with sRGB values (0-255).
-
-    Returns:
-        float32 numpy array with linear values in [0.0, 1.0].
-    """
-    return _SRGB_TO_LINEAR[np.clip(array, 0, 255).astype(np.uint8)]
-
-
-def linear_to_srgb(
-    array: np.ndarray,
-    dither: bool = False,
-    rng: np.random.Generator | None = None,
-) -> np.ndarray:
-    """
-    Convert linear float values to sRGB uint8.
-
-    Uses an inverse lookup table indexed by fixed-point linear values
-    (15 fractional bits) for fast conversion.
-
-    Args:
-        array: float numpy array with linear values in [0.0, 1.0].
-            Values outside this range are clamped.
-        dither: If True, add uniform noise before quantization to
-            reduce banding in gradients.
-        rng: Optional NumPy random generator instance. If None and
-            dither is True, a default generator is created.
-
-    Returns:
-        uint8 numpy array with sRGB values (0-255).
-    """
-    clipped = np.clip(array, 0.0, 1.0)
-    fixed = clipped * _SCALE
-
-    if dither:
-        if rng is None:
-            rng = np.random.default_rng()
-        noise = rng.uniform(-0.5, 0.5, fixed.shape)
-        fixed = np.clip(fixed + noise, 0, _SCALE)
-
-    indices = np.round(fixed).astype(np.intp)
-    return _LINEAR_TO_SRGB[indices]
+from raygeo.image import linear_to_srgb, srgb_to_linear
 
 
 def create_lut_from_color(

--- a/rayforge/image/util/srgb.py
+++ b/rayforge/image/util/srgb.py
@@ -76,6 +76,7 @@ def resize_linear_nd(
     for c in range(n_channels):
         ch_linear = srgb_to_linear(image[:, :, c]).astype(np.float32)
         ch_resized = cv2.resize(ch_linear, size, interpolation=interpolation)
-        result[:, :, c] = linear_to_srgb(np.clip(ch_resized, 0, 1))
+        ch_clipped = np.clip(ch_resized, 0, 1).astype(np.float32)
+        result[:, :, c] = linear_to_srgb(ch_clipped)
 
     return result[:, :, 0] if ndim == 2 else result

--- a/tests/image/test_dither.py
+++ b/tests/image/test_dither.py
@@ -4,10 +4,9 @@ import numpy as np
 from rayforge.image.dither import (
     BAYER_MATRICES,
     DitherAlgorithm,
-    apply_bayer_dither,
-    apply_floyd_steinberg_dither,
     surface_to_dithered_array,
 )
+from raygeo.image import apply_bayer_dither, apply_floyd_steinberg_dither
 
 
 def test_bayer_matrices_shape_and_values():
@@ -34,7 +33,7 @@ def test_bayer_matrices_shape_and_values():
 
 def test_bayer2_matrix_expected_values():
     """Tests that the 2x2 Bayer matrix has expected values."""
-    expected = np.array([[0, 2], [3, 1]], dtype=np.float32)
+    expected = np.array([[0, 2], [3, 1]], dtype=np.uint8)
     np.testing.assert_array_equal(
         BAYER_MATRICES[DitherAlgorithm.BAYER2], expected
     )
@@ -78,7 +77,7 @@ def test_bayer8_matrix_expected_values():
 
 def test_floyd_steinberg_dither_all_white():
     """Tests Floyd-Steinberg dithering with all white image."""
-    white = np.full((10, 10), 255, dtype=np.float32)
+    white = np.full((10, 10), 255, dtype=np.uint8)
     result = apply_floyd_steinberg_dither(white, invert=False)
     assert result.shape == (10, 10)
     assert result.dtype == np.uint8
@@ -87,7 +86,7 @@ def test_floyd_steinberg_dither_all_white():
 
 def test_floyd_steinberg_dither_all_black():
     """Tests Floyd-Steinberg dithering with all black image."""
-    black = np.full((10, 10), 0, dtype=np.float32)
+    black = np.full((10, 10), 0, dtype=np.uint8)
     result = apply_floyd_steinberg_dither(black, invert=False)
     assert result.shape == (10, 10)
     assert result.dtype == np.uint8
@@ -96,7 +95,7 @@ def test_floyd_steinberg_dither_all_black():
 
 def test_floyd_steinberg_dither_invert():
     """Tests that invert parameter flips the output."""
-    gray = np.full((10, 10), 128, dtype=np.float32)
+    gray = np.full((10, 10), 128, dtype=np.uint8)
     result_normal = apply_floyd_steinberg_dither(gray, invert=False)
     result_inverted = apply_floyd_steinberg_dither(gray, invert=True)
     assert np.array_equal(result_normal, 1 - result_inverted)
@@ -104,7 +103,7 @@ def test_floyd_steinberg_dither_invert():
 
 def test_floyd_steinberg_dither_gradient():
     """Tests Floyd-Steinberg dithering with a horizontal gradient."""
-    gradient = np.linspace(0, 255, 100).reshape(10, 10).astype(np.float32)
+    gradient = np.linspace(0, 255, 100).reshape(10, 10).astype(np.uint8)
     result = apply_floyd_steinberg_dither(gradient, invert=False)
     assert result.shape == (10, 10)
     assert result.dtype == np.uint8
@@ -113,7 +112,7 @@ def test_floyd_steinberg_dither_gradient():
 
 def test_floyd_steinberg_dither_single_pixel():
     """Tests Floyd-Steinberg dithering with a single pixel."""
-    single = np.array([[127]], dtype=np.float32)
+    single = np.array([[127]], dtype=np.uint8)
     result = apply_floyd_steinberg_dither(single, invert=False)
     assert result.shape == (1, 1)
     assert result.dtype == np.uint8
@@ -121,7 +120,7 @@ def test_floyd_steinberg_dither_single_pixel():
 
 def test_floyd_steinberg_dither_error_diffusion():
     """Tests that error is properly diffused to neighboring pixels."""
-    img = np.array([[100, 100], [100, 100]], dtype=np.float32)
+    img = np.array([[100, 100], [100, 100]], dtype=np.uint8)
     result = apply_floyd_steinberg_dither(img, invert=False)
     assert result.shape == (2, 2)
     assert result.dtype == np.uint8
@@ -129,7 +128,7 @@ def test_floyd_steinberg_dither_error_diffusion():
 
 def test_bayer_dither_all_white():
     """Tests Bayer dithering with all white image."""
-    white = np.full((10, 10), 255, dtype=np.float32)
+    white = np.full((10, 10), 255, dtype=np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -144,7 +143,7 @@ def test_bayer_dither_all_white():
 
 def test_bayer_dither_all_black():
     """Tests Bayer dithering with all black image."""
-    black = np.full((10, 10), 0, dtype=np.float32)
+    black = np.full((10, 10), 0, dtype=np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -159,7 +158,7 @@ def test_bayer_dither_all_black():
 
 def test_bayer_dither_invert():
     """Tests that invert parameter flips the output for Bayer dither."""
-    gray = np.full((10, 10), 128, dtype=np.float32)
+    gray = np.full((10, 10), 128, dtype=np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -173,7 +172,7 @@ def test_bayer_dither_invert():
 
 def test_bayer_dither_pattern_consistency():
     """Tests that Bayer dither produces consistent patterns."""
-    gray = np.full((16, 16), 128, dtype=np.float32)
+    gray = np.full((16, 16), 128, dtype=np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -187,7 +186,7 @@ def test_bayer_dither_pattern_consistency():
 
 def test_bayer_dither_tiling_pattern():
     """Tests that Bayer dither pattern tiles correctly across image."""
-    gray = np.full((16, 16), 128, dtype=np.float32)
+    gray = np.full((16, 16), 128, dtype=np.uint8)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER2]
     result = apply_bayer_dither(gray, matrix, invert=False)
     assert result.shape == (16, 16)
@@ -196,7 +195,7 @@ def test_bayer_dither_tiling_pattern():
 
 def test_bayer_dither_single_pixel():
     """Tests Bayer dithering with a single pixel."""
-    single = np.array([[127]], dtype=np.float32)
+    single = np.array([[127]], dtype=np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -211,7 +210,7 @@ def test_bayer_dither_single_pixel():
 def test_dither_output_alignment_floyd_steinberg():
     """Tests that Floyd-Steinberg dither output aligns with input."""
     original = np.random.rand(50, 50) * 255
-    original = original.astype(np.float32)
+    original = original.astype(np.uint8)
     result = apply_floyd_steinberg_dither(original, invert=False)
     assert result.shape == original.shape
 
@@ -219,7 +218,7 @@ def test_dither_output_alignment_floyd_steinberg():
 def test_dither_output_alignment_bayer():
     """Tests that Bayer dither output aligns with input."""
     original = np.random.rand(50, 50) * 255
-    original = original.astype(np.float32)
+    original = original.astype(np.uint8)
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
         DitherAlgorithm.BAYER4,
@@ -232,7 +231,7 @@ def test_dither_output_alignment_bayer():
 
 def test_dither_preserves_dark_regions():
     """Tests that dark regions remain dark after dithering."""
-    dark = np.full((10, 10), 30, dtype=np.float32)
+    dark = np.full((10, 10), 30, dtype=np.uint8)
     result_fs = apply_floyd_steinberg_dither(dark, invert=False)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER4]
     result_bayer = apply_bayer_dither(dark, matrix, invert=False)
@@ -242,7 +241,7 @@ def test_dither_preserves_dark_regions():
 
 def test_dither_preserves_light_regions():
     """Tests that light regions remain light after dithering."""
-    light = np.full((10, 10), 225, dtype=np.float32)
+    light = np.full((10, 10), 225, dtype=np.uint8)
     result_fs = apply_floyd_steinberg_dither(light, invert=False)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER4]
     result_bayer = apply_bayer_dither(light, matrix, invert=False)
@@ -461,7 +460,7 @@ def test_surface_to_dithered_array_blue_channel():
 def test_dither_result_is_binary():
     """Tests that dithering results are strictly binary (0 or 1)."""
     random_img = np.random.rand(20, 20) * 255
-    random_img = random_img.astype(np.float32)
+    random_img = random_img.astype(np.uint8)
 
     result_fs = apply_floyd_steinberg_dither(random_img, invert=False)
     assert np.all(np.isin(result_fs, [0, 1]))
@@ -478,7 +477,7 @@ def test_dither_result_is_binary():
 
 def test_dither_edge_case_mid_gray():
     """Tests dithering behavior at exactly mid-gray (128)."""
-    mid_gray = np.full((10, 10), 128.0, dtype=np.float32)
+    mid_gray = np.full((10, 10), 128.0, dtype=np.uint8)
     result_fs = apply_floyd_steinberg_dither(mid_gray, invert=False)
     assert result_fs.shape == (10, 10)
     assert result_fs.dtype == np.uint8
@@ -486,8 +485,8 @@ def test_dither_edge_case_mid_gray():
 
 def test_dither_edge_case_threshold_boundary():
     """Tests dithering at the threshold boundary (127 vs 128)."""
-    below = np.full((10, 10), 127.0, dtype=np.float32)
-    above = np.full((10, 10), 128.0, dtype=np.float32)
+    below = np.full((10, 10), 127.0, dtype=np.uint8)
+    above = np.full((10, 10), 128.0, dtype=np.uint8)
 
     result_below = apply_floyd_steinberg_dither(below, invert=False)
     result_above = apply_floyd_steinberg_dither(above, invert=False)
@@ -499,7 +498,7 @@ def test_dither_edge_case_threshold_boundary():
 def test_dither_preserves_input():
     """Tests that dithering does not modify the input array."""
     original = np.random.rand(10, 10) * 255
-    original = original.astype(np.float32)
+    original = original.astype(np.uint8)
     original_copy = original.copy()
 
     apply_floyd_steinberg_dither(original, invert=False)
@@ -514,7 +513,7 @@ def test_dither_preserves_input():
 def test_dither_consistency_same_input():
     """Tests that same input produces same output."""
     fixed_input = np.random.rand(10, 10) * 255
-    fixed_input = fixed_input.astype(np.float32)
+    fixed_input = fixed_input.astype(np.uint8)
 
     result1 = apply_floyd_steinberg_dither(fixed_input.copy(), invert=False)
     result2 = apply_floyd_steinberg_dither(fixed_input.copy(), invert=False)
@@ -533,7 +532,7 @@ def test_dither_consistency_same_input():
 
 def test_dither_checkerboard_pattern():
     """Tests dithering with a checkerboard pattern."""
-    checkerboard = np.zeros((10, 10), dtype=np.float32)
+    checkerboard = np.zeros((10, 10), dtype=np.uint8)
     checkerboard[::2, ::2] = 255
     checkerboard[1::2, 1::2] = 255
 
@@ -552,7 +551,7 @@ def test_dither_checkerboard_pattern():
 
 def test_dither_vertical_gradient():
     """Tests dithering with a vertical gradient."""
-    gradient = np.linspace(0, 255, 100).reshape(100, 1).astype(np.float32)
+    gradient = np.linspace(0, 255, 100).reshape(100, 1).astype(np.uint8)
     gradient = np.tile(gradient, (1, 10))
 
     result_fs = apply_floyd_steinberg_dither(gradient, invert=False)
@@ -571,7 +570,7 @@ def test_dither_vertical_gradient():
 def test_dither_diagonal_gradient():
     """Tests dithering with a diagonal gradient."""
     size = 50
-    diagonal = np.zeros((size, size), dtype=np.float32)
+    diagonal = np.zeros((size, size), dtype=np.uint8)
     for i in range(size):
         for j in range(size):
             diagonal[i, j] = (i + j) * 255 / (2 * size)
@@ -612,19 +611,19 @@ def test_surface_stride_handling():
 def test_dither_non_square_images():
     """Tests dithering with non-square images."""
     wide = np.random.rand(10, 20) * 255
-    wide = wide.astype(np.float32)
+    wide = wide.astype(np.uint8)
     result = apply_floyd_steinberg_dither(wide, invert=False)
     assert result.shape == (10, 20)
 
     tall = np.random.rand(20, 10) * 255
-    tall = tall.astype(np.float32)
+    tall = tall.astype(np.uint8)
     result = apply_floyd_steinberg_dither(tall, invert=False)
     assert result.shape == (20, 10)
 
 
 def test_pixel_probing_corner_alignment():
     """Tests that corner pixels are correctly aligned in output."""
-    img = np.full((10, 10), 30, dtype=np.float32)
+    img = np.full((10, 10), 30, dtype=np.uint8)
     img[0, 0] = 0
     img[0, 9] = 0
     img[9, 0] = 0
@@ -640,7 +639,7 @@ def test_pixel_probing_corner_alignment():
 
 def test_pixel_probing_center_pixel():
     """Tests that center pixel is correctly processed."""
-    img = np.full((11, 11), 200.0, dtype=np.float32)
+    img = np.full((11, 11), 200.0, dtype=np.uint8)
     img[5, 5] = 0
 
     result = apply_floyd_steinberg_dither(img, invert=False)
@@ -652,7 +651,7 @@ def test_pixel_probing_center_pixel():
 
 def test_pixel_probing_bayer_threshold_boundaries():
     """Tests Bayer dithering at exact threshold boundaries."""
-    gray = np.full((8, 8), 128.0, dtype=np.float32)
+    gray = np.full((8, 8), 128.0, dtype=np.uint8)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER4]
     result = apply_bayer_dither(gray, matrix, invert=False)
 
@@ -665,7 +664,7 @@ def test_pixel_probing_bayer_threshold_boundaries():
 
 def test_pixel_probing_error_propagation():
     """Tests that error propagates correctly to adjacent pixels."""
-    img = np.full((3, 3), 127.0, dtype=np.float32)
+    img = np.full((3, 3), 127.0, dtype=np.uint8)
     img[0, 0] = 0
 
     result = apply_floyd_steinberg_dither(img, invert=False)
@@ -675,7 +674,7 @@ def test_pixel_probing_error_propagation():
 
 def test_xor_invert_produces_complement():
     """Tests that inverting produces bitwise complement via XOR."""
-    gray = np.full((10, 10), 128, dtype=np.float32)
+    gray = np.full((10, 10), 128, dtype=np.uint8)
 
     result_normal = apply_floyd_steinberg_dither(gray, invert=False)
     result_inverted = apply_floyd_steinberg_dither(gray, invert=True)
@@ -686,7 +685,7 @@ def test_xor_invert_produces_complement():
 
 def test_xor_bayer_invert_complement():
     """Tests that Bayer invert produces bitwise complement via XOR."""
-    gray = np.full((10, 10), 128, dtype=np.float32)
+    gray = np.full((10, 10), 128, dtype=np.uint8)
 
     for matrix_enum in [
         DitherAlgorithm.BAYER2,
@@ -703,7 +702,7 @@ def test_xor_bayer_invert_complement():
 
 def test_xor_pattern_tiling_consistency():
     """Tests Bayer pattern tiles consistently using XOR comparison."""
-    gray = np.full((16, 16), 100, dtype=np.float32)
+    gray = np.full((16, 16), 100, dtype=np.uint8)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER4]
     result = apply_bayer_dither(gray, matrix, invert=False)
 
@@ -724,7 +723,7 @@ def test_xor_pattern_tiling_consistency():
 
 def test_xor_gradient_monotonicity():
     """Tests gradient dithering produces monotonic pattern changes."""
-    gradient = np.linspace(0, 255, 20).reshape(4, 5).astype(np.float32)
+    gradient = np.linspace(0, 255, 20).reshape(4, 5).astype(np.uint8)
     result = apply_floyd_steinberg_dither(gradient, invert=False)
 
     for col in range(4):
@@ -752,7 +751,7 @@ def test_xor_surface_conversion_alignment():
 
 def test_pixel_probing_edge_pixel_error_diffusion():
     """Tests error diffusion at image edges doesn't overflow."""
-    img = np.zeros((5, 5), dtype=np.float32)
+    img = np.zeros((5, 5), dtype=np.uint8)
     img[0, :] = 200
     img[4, :] = 200
     img[:, 0] = 200
@@ -766,7 +765,7 @@ def test_pixel_probing_edge_pixel_error_diffusion():
 def test_xor_binary_output_verification():
     """Tests all dithering produces strictly binary output via XOR."""
     random_img = np.random.rand(15, 15) * 255
-    random_img = random_img.astype(np.float32)
+    random_img = random_img.astype(np.uint8)
 
     result_fs = apply_floyd_steinberg_dither(random_img, invert=False)
     xor_fs = np.bitwise_xor(result_fs, result_fs)
@@ -785,7 +784,7 @@ def test_xor_binary_output_verification():
 
 def test_pixel_probing_specific_bayer_values():
     """Tests specific Bayer threshold values at known positions."""
-    img = np.full((4, 4), 128.0, dtype=np.float32)
+    img = np.full((4, 4), 128.0, dtype=np.uint8)
     matrix = BAYER_MATRICES[DitherAlgorithm.BAYER4]
 
     result = apply_bayer_dither(img, matrix, invert=False)

--- a/tests/image/util/test_grayscale.py
+++ b/tests/image/util/test_grayscale.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from rayforge.image.util import grayscale
+from raygeo.image import compute_auto_levels, normalize_grayscale
 
 
 def test_surface_to_grayscale_black_surface():
@@ -182,77 +183,65 @@ def test_convert_surface_to_grayscale_inplace_preserves_alpha():
 
 def test_normalize_grayscale_default_params_no_change():
     gray = np.array([[0, 128, 255]], dtype=np.uint8)
-    result = grayscale.normalize_grayscale(gray)
+    result = normalize_grayscale(gray)
     np.testing.assert_array_equal(result, gray)
 
 
 def test_normalize_grayscale_stretches_contrast():
     gray = np.array([[50, 100, 150]], dtype=np.uint8)
-    result = grayscale.normalize_grayscale(
-        gray, black_point=50, white_point=150
-    )
+    result = normalize_grayscale(gray, black_point=50, white_point=150)
     assert result[0, 0] == 0
-    assert result[0, 1] == 127
+    assert result[0, 1] == 128
     assert result[0, 2] == 255
 
 
 def test_normalize_grayscale_clips_below_black_point():
     gray = np.array([[0, 25, 50]], dtype=np.uint8)
-    result = grayscale.normalize_grayscale(
-        gray, black_point=50, white_point=200
-    )
+    result = normalize_grayscale(gray, black_point=50, white_point=200)
     np.testing.assert_array_equal(result[0, :2], [0, 0])
 
 
 def test_normalize_grayscale_clips_above_white_point():
     gray = np.array([[200, 225, 255]], dtype=np.uint8)
-    result = grayscale.normalize_grayscale(
-        gray, black_point=0, white_point=200
-    )
+    result = normalize_grayscale(gray, black_point=0, white_point=200)
     np.testing.assert_array_equal(result[0, :], [255, 255, 255])
 
 
 def test_normalize_grayscale_raises_for_invalid_points():
     gray = np.array([[128]], dtype=np.uint8)
     with pytest.raises(ValueError, match="must be less than"):
-        grayscale.normalize_grayscale(gray, black_point=128, white_point=128)
+        normalize_grayscale(gray, black_point=128, white_point=128)
 
     with pytest.raises(ValueError, match="must be less than"):
-        grayscale.normalize_grayscale(gray, black_point=200, white_point=100)
+        normalize_grayscale(gray, black_point=200, white_point=100)
 
 
 def test_normalize_grayscale_preserves_shape():
     gray = np.random.randint(0, 256, (10, 20), dtype=np.uint8)
-    result = grayscale.normalize_grayscale(
-        gray, black_point=30, white_point=200
-    )
+    result = normalize_grayscale(gray, black_point=30, white_point=200)
     assert result.shape == gray.shape
 
 
 def test_normalize_grayscale_extreme_stretch():
     gray = np.array([[100]], dtype=np.uint8)
-    result = grayscale.normalize_grayscale(
-        gray, black_point=100, white_point=101
-    )
+    result = normalize_grayscale(gray, black_point=100, white_point=101)
     assert result[0, 0] == 0
 
     gray2 = np.array([[101]], dtype=np.uint8)
-    result2 = grayscale.normalize_grayscale(
-        gray2, black_point=100, white_point=101
-    )
+    result2 = normalize_grayscale(gray2, black_point=100, white_point=101)
     assert result2[0, 0] == 255
 
 
 def test_compute_auto_levels_uniform_image():
     gray = np.full((10, 10), 128, dtype=np.uint8)
-    black_pt, white_pt = grayscale.compute_auto_levels(gray)
+    black_pt, white_pt = compute_auto_levels(gray)
     assert black_pt == 128
     assert white_pt == 130
 
 
 def test_compute_auto_levels_full_range():
     gray = np.array([[0, 255]], dtype=np.uint8)
-    black_pt, white_pt = grayscale.compute_auto_levels(gray)
+    black_pt, white_pt = compute_auto_levels(gray)
     assert 0 <= black_pt <= 253
     assert black_pt < white_pt
     assert white_pt <= 255
@@ -260,14 +249,14 @@ def test_compute_auto_levels_full_range():
 
 def test_compute_auto_levels_empty_array():
     gray = np.array([], dtype=np.uint8)
-    black_pt, white_pt = grayscale.compute_auto_levels(gray)
+    black_pt, white_pt = compute_auto_levels(gray)
     assert black_pt == 0
     assert white_pt == 255
 
 
 def test_compute_auto_levels_with_clip_percent():
     gray = np.arange(256, dtype=np.uint8).reshape(1, 256)
-    black_pt, white_pt = grayscale.compute_auto_levels(gray, clip_percent=5.0)
+    black_pt, white_pt = compute_auto_levels(gray, clip_percent=5.0)
     assert 5 <= black_pt <= 20
     assert 235 <= white_pt <= 250
     assert black_pt < white_pt
@@ -275,7 +264,7 @@ def test_compute_auto_levels_with_clip_percent():
 
 def test_compute_auto_levels_returns_valid_range():
     gray = np.random.randint(0, 256, (100, 100), dtype=np.uint8)
-    black_pt, white_pt = grayscale.compute_auto_levels(gray)
+    black_pt, white_pt = compute_auto_levels(gray)
     assert 0 <= black_pt <= 253
     assert 2 <= white_pt <= 255
     assert black_pt < white_pt

--- a/tests/image/util/test_srgb.py
+++ b/tests/image/util/test_srgb.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 
 from rayforge.image.util.srgb import (
-    _LINEAR_TO_SRGB,
-    _SRGB_TO_LINEAR,
     create_lut_from_color,
     linear_to_srgb,
     resize_linear_nd,
@@ -89,17 +87,15 @@ class TestLinearToSrgb:
         assert result.shape == (1, 3)
 
     def test_dithering_produces_valid_output(self):
-        rng = np.random.default_rng(42)
         arr = np.linspace(0.0, 1.0, 1000, dtype=np.float32)
-        result = linear_to_srgb(arr, dither=True, rng=rng)
+        result = linear_to_srgb(arr, dither=True)
         assert result.dtype == np.uint8
         assert np.all(result >= 0)
         assert np.all(result <= 255)
 
     def test_dithering_preserves_endpoints(self):
-        rng = np.random.default_rng(42)
         arr = np.array([0.0, 1.0])
-        result = linear_to_srgb(arr, dither=True, rng=rng)
+        result = linear_to_srgb(arr, dither=True)
         assert result[0] == 0
         assert result[1] == 255
 
@@ -116,22 +112,6 @@ class TestRoundTrip:
         linear = srgb_to_linear(srgb_in)
         srgb_out = linear_to_srgb(linear)
         np.testing.assert_array_equal(srgb_out, srgb_in)
-
-
-class TestLutProperties:
-    def test_forward_lut_size(self):
-        assert len(_SRGB_TO_LINEAR) == 256
-
-    def test_inverse_lut_size(self):
-        assert len(_LINEAR_TO_SRGB) == 32769
-
-    def test_forward_lut_bounds(self):
-        assert _SRGB_TO_LINEAR[0] == pytest.approx(0.0)
-        assert _SRGB_TO_LINEAR[255] == pytest.approx(1.0)
-
-    def test_inverse_lut_bounds(self):
-        assert _LINEAR_TO_SRGB[0] == 0
-        assert _LINEAR_TO_SRGB[-1] == 255
 
 
 class TestResizeLinearNd:
@@ -191,7 +171,7 @@ class TestCreateLutFromColor:
 
     def test_midpoint_matches_srgb_roundtrip(self):
         lut = create_lut_from_color((1.0, 1.0, 1.0, 1.0))
-        linear_mid = _SRGB_TO_LINEAR[255] * 0.5
+        linear_mid = 1.0 * 0.5
         expected_srgb = linear_to_srgb(np.array([linear_mid]))[0] / 255.0
         assert lut[128, 0] == pytest.approx(expected_srgb, abs=1 / 255)
 


### PR DESCRIPTION
## Summary

Stripped-down version of #278 containing only the image processing delegation to `raygeo.image` Rust functions.

- Replaces all pure-Python image processing implementations with calls to `raygeo.image` Rust functions
- `surface_to_*` functions remain as thin Cairo surface buffer extraction wrappers
- Removes 525 lines of Python image processing code

## Changes by file

| File | Change |
|------|--------|
| `grayscale.py` | `surface_to_grayscale/binary/inplace` → extract Cairo buffer, call `raygeo.image.rgba_to_*`. Removed `compute_auto_levels`, `normalize_grayscale` (now from `raygeo.image`) |
| `srgb.py` | `srgb_to_linear`/`linear_to_srgb` now delegate to `raygeo.image`. Retains `create_lut_from_color` and `resize_linear_nd` (no Rust equivalents) |
| `dither.py` | `apply_floyd_steinberg_dither`/`apply_bayer_dither`/`apply_minimum_run_length` removed, imported from `raygeo.image`. `surface_to_dithered_array` uses `raygeo.image.rgba_to_grayscale` + Rust dither |
| `__init__.py` | `compute_auto_levels`/`normalize_grayscale` re-exported from `raygeo.image` |
| `raster_widget.py` | Imports `compute_auto_levels` from `raygeo.image` directly |
| Tests | Updated imports, fixed dtype (`float32` → `uint8`), adjusted rounding expectations |

## Not included (compared to #278)

- Pipeline changes (already merged to main in #282)
- Task manager / worker pool changes (to be addressed separately)