### PR TITLE
skip overscan transformer for drivers with native overscan

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/overscan_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/overscan_transformer.py
@@ -118,6 +118,8 @@ class OverscanTransformer(OpsTransformer):
     ) -> None:
         if not self.enabled or math.isclose(self.distance_mm, 0.0):
             return
+        if settings and settings.get("driver_native_overscan"):
+            return
 
         ops.apply_overscan(self.distance_mm)
 

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/widgets/overscan_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/widgets/overscan_widget.py
@@ -47,6 +47,15 @@ class OverscanSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         if machine:
             machine.changed.connect(self._on_machine_changed)
 
+        # Banner shown when the driver applies overscan itself.
+        self.native_banner = Adw.Banner(
+            title=_(
+                "This machine adds overscan automatically; the setting "
+                "has no effect."
+            )
+        )
+        super().add(self.native_banner)
+
         # Auto mode toggle
         self.auto_row = Adw.SwitchRow(
             title=_("Automatic Distance"),
@@ -89,6 +98,19 @@ class OverscanSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
             lambda w, _: self._update_sensitivity(),
         )
 
+        self._update_sensitivity()
+
+    def _is_native_overscan(self) -> bool:
+        """Whether the active machine's driver applies overscan itself."""
+        machine = get_context().machine
+        return bool(machine and machine.driver.native_overscan)
+
+    def is_unsupported(self) -> bool:
+        """Enabled overscan that the driver handles itself."""
+        if self.enable_switch is None or not self.enable_switch.get_active():
+            return False
+        return self._is_native_overscan()
+
     def _set_step_param(self, key, new_value, name):
         """Helper method to set a step parameter with standard callback."""
         self.editor.step.set_step_param(
@@ -105,9 +127,13 @@ class OverscanSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         enabled = self.enable_switch.get_active()
         auto = self.auto_row.get_active()
 
+        native = self._is_native_overscan()
+        self.native_banner.set_revealed(native)
+
         # Use the stored references to the rows
-        self.auto_row.set_sensitive(enabled)
-        self.distance_row.set_sensitive(enabled and not auto)
+        self.enable_switch.set_sensitive(not native)
+        self.auto_row.set_sensitive(enabled and not auto and not native)
+        self.distance_row.set_sensitive(enabled and not auto and not native)
 
     def _on_auto_toggled(self, row, pspec):
         new_value = row.get_active()
@@ -149,6 +175,10 @@ class OverscanSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         """
         Handle machine updates (e.g. acceleration) to recalculate overscan.
         """
+        if self._is_native_overscan():
+            self._update_sensitivity()
+            return
+        self._update_sensitivity()
         if self.target_dict.get("auto", True):
             self._recalculate_distance()
 

--- a/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_overscan_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_overscan_transformer.py
@@ -55,6 +55,19 @@ def test_no_op_when_disabled(transformer: OverscanTransformer):
     assert ops.len() == original_len
 
 
+def test_no_op_with_native_overscan(transformer: OverscanTransformer):
+    """Verify the transformer is skipped when the driver does overscan."""
+    ops = Ops()
+    ops.ops_section_start(SectionType.RASTER_FILL, "wp_123")
+    ops.move_to(10, 10, 0)
+    ops.ops_section_end(SectionType.RASTER_FILL)
+    original_len = ops.len()
+
+    transformer.run(ops, settings={"driver_native_overscan": True})
+
+    assert ops.len() == original_len
+
+
 def test_no_op_with_zero_distance(transformer: OverscanTransformer):
     """Verify the run method does nothing if the distance is zero."""
     ops = Ops()

--- a/rayforge/machine/driver/driver.py
+++ b/rayforge/machine/driver/driver.py
@@ -189,6 +189,9 @@ class Driver(ABC):
     uses_gcode: bool = True
     maturity: DriverMaturity = DriverMaturity.STABLE
     supports_probing: bool = False
+    # When True, the firmware applies its own overscan, so Rayforge's
+    # OverscanTransformer would double it up and should be skipped.
+    native_overscan: bool = False
 
     @property
     @abstractmethod

--- a/rayforge/machine/driver/ruida/ruida_driver.py
+++ b/rayforge/machine/driver/ruida/ruida_driver.py
@@ -61,6 +61,7 @@ class RuidaDriver(Driver):
     reports_granular_progress = False
     uses_gcode = False
     maturity = DriverMaturity.KNOWN_BUGGY
+    native_overscan = True
     CONNECTION_TIMEOUT = 2.0
     RECONNECT_INTERVAL = 5.0
     KEEPALIVE_INTERVAL = 1.0

--- a/rayforge/pipeline/stage/workpiece_stage.py
+++ b/rayforge/pipeline/stage/workpiece_stage.py
@@ -117,6 +117,9 @@ class WorkPiecePipelineStage(PipelineStage):
         settings["machine_supports_arcs"] = self._machine.supports_arcs
         settings["machine_supports_curves"] = self._machine.supports_curves
         settings["arc_tolerance"] = self._machine.arc_tolerance
+        settings["driver_native_overscan"] = (
+            self._machine.driver.native_overscan
+        )
 
         try:
             selected_laser = step.get_selected_laser(self._machine)

--- a/rayforge/ui_gtk/doceditor/step_settings/base.py
+++ b/rayforge/ui_gtk/doceditor/step_settings/base.py
@@ -90,6 +90,16 @@ class StepComponentSettingsWidget(Adw.PreferencesGroup):
         for row in self._rows[1:]:
             row.set_sensitive(enabled)
 
+    def is_unsupported(self) -> bool:
+        """
+        Whether this component is enabled but cannot take effect on the
+        active machine (e.g. the driver handles the feature itself).
+
+        Subclasses override this to flag expander-level warnings. Returns
+        False by default.
+        """
+        return False
+
     @property
     def target_dict(self) -> Dict[str, Any]:
         """

--- a/rayforge/ui_gtk/doceditor/step_settings_dialog.py
+++ b/rayforge/ui_gtk/doceditor/step_settings_dialog.py
@@ -19,6 +19,7 @@ from ..shared.patched_dialog_window import PatchedDialogWindow
 from ..shared.preferences_page import TrackedPreferencesPage
 from ..varset.varsetwidget import VarSetWidget
 from .recipe_control_widget import RecipeControlWidget
+from .step_settings.base import StepComponentSettingsWidget
 from .step_settings.placeholder import PlaceholderSettingsWidget
 
 if TYPE_CHECKING:
@@ -292,6 +293,17 @@ class PostProcessingSettingsView(TrackedPreferencesPage):
             expander.set_subtitle(subtitle)
         expander.set_expanded(False)
 
+        warning_icon = get_icon("warning-symbolic")
+        warning_icon.set_valign(Gtk.Align.CENTER)
+        expander.add_prefix(warning_icon)
+
+        def _update_warning_icon(grp=group, ico=warning_icon):
+            unsupported = (
+                isinstance(grp, StepComponentSettingsWidget)
+                and grp.is_unsupported()
+            )
+            ico.set_visible(unsupported)
+
         enable_switch_row = None
         for row in rows:
             if isinstance(row, Adw.SwitchRow) and enable_switch_row is None:
@@ -312,9 +324,18 @@ class PostProcessingSettingsView(TrackedPreferencesPage):
                         sw.set_active(r.get_active())
 
                 row.connect("notify::active", _on_orig_toggled)
+                row.connect(
+                    "notify::active",
+                    lambda *_: _update_warning_icon(),
+                )
             else:
                 expander.add_row(row)
 
+        machine = get_context().machine
+        if machine:
+            machine.changed.connect(lambda *_: _update_warning_icon())
+
+        _update_warning_icon()
         self._main_group.add(expander)
         self._has_expanders = True
 


### PR DESCRIPTION
Ruida firmware applies its own overscan, so Rayforge's OverscanTransformer would double it up.

- Add `native_overscan` driver capability flag (True on RuidaDriver, False by default)
- Inject `driver_native_overscan` into production settings dict in `prepare_task_settings`
- Early-return in `OverscanTransformer.run` when the flag is set
- Show a banner and disable the overscan widget controls in the UI when the driver handles it
- Add a warning icon to the post-processing expander header when an enabled overscan setting is unsupported (visible without unfolding)
- Add `is_unsupported()` method to `StepComponentSettingsWidget` base for extensibility

Closes the overscan portion of the driver feature gaps design.