### PR TITLE
feat: add air assist toggle to material test grid

### DIFF
--- a/rayforge/core/capability.py
+++ b/rayforge/core/capability.py
@@ -325,7 +325,15 @@ class MaterialTestCapability(Capability):
 
     @property
     def varset(self) -> VarSet:
-        return VarSet(vars=[])
+        return VarSet(
+            vars=[
+                BoolVar(
+                    key="air_assist",
+                    label=_("Air Assist"),
+                    default=False,
+                ),
+            ]
+        )
 
 
 class PWMCapability(Capability):

--- a/tests/core/test_capability.py
+++ b/tests/core/test_capability.py
@@ -110,7 +110,11 @@ def test_kerf_capability():
 def test_material_test_capability():
     assert isinstance(MATERIAL_TEST, MaterialTestCapability)
     assert MATERIAL_TEST.name == "MATERIAL_TEST"
-    assert list(MATERIAL_TEST.varset.vars) == []
+    var_keys = [v.key for v in MATERIAL_TEST.varset]
+    assert "air_assist" in var_keys
+    air_var = MATERIAL_TEST.varset["air_assist"]
+    assert isinstance(air_var, BoolVar)
+    assert air_var.default is False
 
 
 def test_capability_or_operator():


### PR DESCRIPTION
## Summary

Adds an air assist toggle to the material test grid settings. Previously the `MaterialTestCapability` had an empty varset, so there was no UI control for enabling air assist during material test jobs. Users had to manually send M8/M9 commands to the machine before and after generating a test grid.

The fix adds an `air_assist` `BoolVar` to the `MaterialTestCapability` varset, following the same pattern used by Cut, Engrave, and Score capabilities. The pipeline already handles air assist state via `_create_initial_ops()` when `settings['air_assist']` is present, so no changes to the producer or G-code generation are needed — the M8/M9 commands are automatically emitted by the encoder based on the air assist state.

Closes #304