### PR TITLE
Add bidirectional raster scan X-offset calibration  

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/material_test_grid_producer.py
@@ -79,6 +79,7 @@ class GridMode(Enum):
     POWER_VS_SPEED = "Power vs Speed"
     POWER_VS_PASSES = "Power vs Passes"
     SPEED_VS_PASSES = "Speed vs Passes"
+    SPEED_VS_OFFSET = "Speed vs Offset"
 
 
 class MaterialTestGridProducer(OpsProducer):
@@ -95,6 +96,7 @@ class MaterialTestGridProducer(OpsProducer):
         speed_range: Tuple[float, float] = (100.0, 500.0),
         power_range: Tuple[float, float] = (10.0, 100.0),
         passes_range: Tuple[int, int] = (1, 5),
+        offset_range: Tuple[float, float] = (-0.5, 0.5),
         fixed_speed: float = 1000.0,
         fixed_power: float = 50.0,
         grid_dimensions: Tuple[int, int] = (5, 5),
@@ -117,6 +119,7 @@ class MaterialTestGridProducer(OpsProducer):
         self.speed_range = speed_range
         self.power_range = power_range
         self.passes_range = passes_range
+        self.offset_range = offset_range
         self.fixed_speed = fixed_speed
         self.fixed_power = fixed_power
         self.grid_dimensions = grid_dimensions
@@ -193,6 +196,8 @@ class MaterialTestGridProducer(OpsProducer):
             max_power=self.power_range[1],
             min_passes=self.passes_range[0],
             max_passes=self.passes_range[1],
+            min_offset=self.offset_range[0],
+            max_offset=self.offset_range[1],
             fixed_speed=self.fixed_speed,
             fixed_power=self.fixed_power,
             shape_size=self.shape_size,
@@ -252,6 +257,8 @@ class MaterialTestGridProducer(OpsProducer):
             max_power=params.get("power_range", (10.0, 100.0))[1],
             min_passes=params.get("passes_range", (1, 5))[0],
             max_passes=params.get("passes_range", (1, 5))[1],
+            min_offset=params.get("offset_range", (-0.5, 0.5))[0],
+            max_offset=params.get("offset_range", (-0.5, 0.5))[1],
             fixed_speed=params.get("fixed_speed", 1000.0),
             fixed_power=params.get("fixed_power", 50.0),
             shape_size=params.get("shape_size", 10.0),
@@ -291,6 +298,7 @@ class MaterialTestGridProducer(OpsProducer):
                 "speed_range": list(self.speed_range),
                 "power_range": list(self.power_range),
                 "passes_range": list(self.passes_range),
+                "offset_range": list(self.offset_range),
                 "fixed_speed": self.fixed_speed,
                 "fixed_power": self.fixed_power,
                 "grid_dimensions": list(self.grid_dimensions),

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/raster_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/producers/raster_producer.py
@@ -98,6 +98,7 @@ class Rasterizer(OpsProducer):
         white_point: int = 255,
         auto_levels: bool = True,
         angle_increment: float = 0.0,
+        bidir_x_offset_mm: float = 0.0,
     ):
         self.scan_angle = scan_angle
         self.depth_mode = depth_mode
@@ -118,6 +119,7 @@ class Rasterizer(OpsProducer):
         self.white_point = white_point
         self.auto_levels = auto_levels
         self.angle_increment = angle_increment
+        self.bidir_x_offset_mm = bidir_x_offset_mm
         self._computed_auto_levels: Optional[Tuple[int, int]] = None
 
     def prepare(
@@ -374,6 +376,7 @@ class Rasterizer(OpsProducer):
                 "white_point": self.white_point,
                 "auto_levels": self.auto_levels,
                 "angle_increment": self.angle_increment,
+                "bidir_x_offset_mm": self.bidir_x_offset_mm,
             },
         }
 
@@ -413,6 +416,7 @@ class Rasterizer(OpsProducer):
             "white_point",
             "auto_levels",
             "angle_increment",
+            "bidir_x_offset_mm",
         }
 
         init_args = {k: v for k, v in params_in.items() if k in valid_params}

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
@@ -35,14 +35,24 @@ class MaterialTestStep(Step):
     def get_default_transformers_dicts(cls) -> Tuple[List, List]:
         OverscanTransformer = transformer_registry.get("OverscanTransformer")
         Optimize = transformer_registry.get("Optimize")
+        BidirScanOffsetTransformer = transformer_registry.get(
+            "BidirScanOffsetTransformer"
+        )
         assert OverscanTransformer is not None
         assert Optimize is not None
-        optimize_dict = Optimize().to_dict()
+        assert BidirScanOffsetTransformer is not None
+        # Off by default: Optimize's nearest-neighbor travel reordering has
+        # no concept of "cell" boundaries, so it can interleave lines from
+        # different cells instead of engraving each one fully before moving
+        # to the next. Left toggleable (rather than removed outright) so
+        # it's easy to compare with/without.
+        optimize_dict = Optimize(enabled=False).to_dict()
         return [
             OverscanTransformer(
                 enabled=True, distance_mm=0, auto=True
             ).to_dict(),
             optimize_dict,
+            BidirScanOffsetTransformer(enabled=True).to_dict(),
         ], [
             optimize_dict,
         ]

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
@@ -76,8 +76,15 @@ class MaterialTestStep(Step):
             transformer_registry.get("OverscanTransformer"),
         )
         assert OverscanTransformer is not None
-        auto_distance = OverscanTransformer.calculate_auto_distance(
-            step.cut_speed, machine.acceleration
+        # Double the usual auto-calculated distance: individual test blocks
+        # benefit from extra run-up/run-out so backlash settling happens
+        # outside the visible engrave area, keeping it distinguishable from
+        # whatever parameter the grid is testing.
+        auto_distance = (
+            OverscanTransformer.calculate_auto_distance(
+                step.cut_speed, machine.acceleration
+            )
+            * 2
         )
         for t in per_wp:
             if t.get("name") == "OverscanTransformer":

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
@@ -47,15 +47,20 @@ class EngraveStep(Step):
         OverscanTransformer = transformer_registry.get("OverscanTransformer")
         Optimize = transformer_registry.get("Optimize")
         MultiPassTransformer = transformer_registry.get("MultiPassTransformer")
+        BidirScanOffsetTransformer = transformer_registry.get(
+            "BidirScanOffsetTransformer"
+        )
         assert OverscanTransformer is not None
         assert Optimize is not None
         assert MultiPassTransformer is not None
+        assert BidirScanOffsetTransformer is not None
         optimize_dict = Optimize().to_dict()
         return [
             OverscanTransformer(
                 enabled=True, distance_mm=0, auto=True
             ).to_dict(),
             optimize_dict,
+            BidirScanOffsetTransformer(enabled=True).to_dict(),
         ], [
             optimize_dict,
             MultiPassTransformer(passes=1, z_step_down=0.0).to_dict(),

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
@@ -290,6 +290,39 @@ class MaterialTestGridSettingsWidget(
             lambda r: self._debounce(self._on_passes_max_changed, r),
         )
 
+        # Offset Range (used in Speed vs Offset mode)
+        min_offset, max_offset = producer.offset_range
+        min_offset_adj = Gtk.Adjustment(
+            lower=-10.0, upper=10.0, step_increment=0.05, value=min_offset
+        )
+        self.offset_min_row = Adw.SpinRow(
+            title=_("Minimum Offset"),
+            subtitle=_("Bidir scan X-offset for first row (mm)"),
+            adjustment=min_offset_adj,
+            digits=2,
+        )
+        group.add(self.offset_min_row)
+
+        max_offset_adj = Gtk.Adjustment(
+            lower=-10.0, upper=10.0, step_increment=0.05, value=max_offset
+        )
+        self.offset_max_row = Adw.SpinRow(
+            title=_("Maximum Offset"),
+            subtitle=_("Bidir scan X-offset for last row (mm)"),
+            adjustment=max_offset_adj,
+            digits=2,
+        )
+        group.add(self.offset_max_row)
+
+        self.offset_min_row.connect(
+            "changed",
+            lambda r: self._debounce(self._on_offset_min_changed, r),
+        )
+        self.offset_max_row.connect(
+            "changed",
+            lambda r: self._debounce(self._on_offset_max_changed, r),
+        )
+
         # Label settings
         power_adj = Gtk.Adjustment(
             lower=1,
@@ -586,6 +619,28 @@ class MaterialTestGridSettingsWidget(
         self._update_control_visibility()
         self._update_dimension_labels()
 
+        if mode_text == "Speed vs Offset":
+            self._apply_speed_vs_offset_defaults()
+
+    def _apply_speed_vs_offset_defaults(self):
+        """Bidir scan offset calibration only makes sense for raster
+        engraving (Cut has no bidirectional scanning to calibrate), and
+        needs wide line spacing to make row-to-row misalignment clearly
+        visible by eye. Can't default the preset dropdown too, since
+        there are multiple Engrave presets (Diode/CO2) with different
+        ranges."""
+        test_type_model = cast(Gtk.StringList, self.test_type_row.get_model())
+        for i in range(test_type_model.get_n_items()):
+            if test_type_model.get_string(i) == "Engrave":
+                self.test_type_row.set_selected(i)
+                break
+
+        if self._debounce_timer > 0:
+            GLib.source_remove(self._debounce_timer)
+            self._debounce_timer = 0
+        self.line_interval_row.set_value(0.5)
+        self._update_param("line_interval_mm", 0.5)
+
     def _on_fixed_speed_changed(self, spin_row):
         new_value = get_spinrow_float(spin_row)
         self._update_param("fixed_speed", new_value)
@@ -601,6 +656,14 @@ class MaterialTestGridSettingsWidget(
         new_value = get_spinrow_int(spin_row)
         self._update_range_param("passes_range", 1, new_value)
 
+    def _on_offset_min_changed(self, spin_row):
+        new_value = get_spinrow_float(spin_row)
+        self._update_range_param("offset_range", 0, new_value)
+
+    def _on_offset_max_changed(self, spin_row):
+        new_value = get_spinrow_float(spin_row)
+        self._update_range_param("offset_range", 1, new_value)
+
     def _get_current_grid_mode(self) -> str:
         from ..producers.material_test_grid_producer import GridMode
 
@@ -614,10 +677,15 @@ class MaterialTestGridSettingsWidget(
     def _update_control_visibility(self):
         mode = self._get_current_grid_mode()
         show_power_range = mode in ("Power vs Speed", "Power vs Passes")
-        show_speed_range = mode in ("Power vs Speed", "Speed vs Passes")
+        show_speed_range = mode in (
+            "Power vs Speed",
+            "Speed vs Passes",
+            "Speed vs Offset",
+        )
         show_passes_range = mode in ("Power vs Passes", "Speed vs Passes")
+        show_offset_range = mode == "Speed vs Offset"
         show_fixed_speed = mode == "Power vs Passes"
-        show_fixed_power = mode == "Speed vs Passes"
+        show_fixed_power = mode in ("Speed vs Passes", "Speed vs Offset")
 
         self.fixed_speed_row.set_visible(show_fixed_speed)
         self.fixed_power_row.set_visible(show_fixed_power)
@@ -633,6 +701,9 @@ class MaterialTestGridSettingsWidget(
         self.passes_min_row.set_visible(show_passes_range)
         self.passes_max_row.set_visible(show_passes_range)
 
+        self.offset_min_row.set_visible(show_offset_range)
+        self.offset_max_row.set_visible(show_offset_range)
+
     def _update_dimension_labels(self):
         mode = self._get_current_grid_mode()
         if mode == "Power vs Passes":
@@ -645,6 +716,11 @@ class MaterialTestGridSettingsWidget(
             col_sub = _("Number of speed variations")
             row_title = _("Rows (Passes Steps)")
             row_sub = _("Number of passes variations")
+        elif mode == "Speed vs Offset":
+            col_title = _("Columns (Speed Steps)")
+            col_sub = _("Number of speed variations")
+            row_title = _("Rows (Offset Steps)")
+            row_sub = _("Number of offset variations")
         else:
             col_title = _("Columns (Power Steps)")
             col_sub = _("Number of power variations")

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -372,6 +372,29 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         )
         group.add(self.sample_interval_row)
 
+        bidir_x_offset_adj = Gtk.Adjustment(
+            lower=-5.0,
+            upper=5.0,
+            step_increment=0.01,
+            value=producer.bidir_x_offset_mm,
+        )
+        self.bidir_x_offset_row = Adw.SpinRow(
+            title=_("Bidirectional Scan Offset"),
+            subtitle=_(
+                "Corrects X misalignment between left-to-right and "
+                "right-to-left raster passes (in mm)"
+            ),
+            adjustment=bidir_x_offset_adj,
+            digits=3,
+        )
+        self.bidir_x_offset_row.connect(
+            "changed",
+            lambda r: self._debounce(
+                self._on_bidir_x_offset_changed, get_spinrow_float(r)
+            ),
+        )
+        group.add(self.bidir_x_offset_row)
+
         self.invert_row = Adw.SwitchRow(
             title=_("Invert"),
             subtitle=_("Engrave white areas instead of black areas"),
@@ -593,6 +616,9 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         if value is not None and value <= 0:
             value = None
         self._on_param_changed("sample_interval_mm", value)
+
+    def _on_bidir_x_offset_changed(self, value: Optional[float]):
+        self._on_param_changed("bidir_x_offset_mm", value or 0.0)
 
     def _on_param_changed(self, key: str, value: Any):
         target_dict = self.target_dict.setdefault("params", {})

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_material_test_grid_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_material_test_grid_producer.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from laser_essentials.producers import (
+    GridMode,
     MaterialTestGridProducer,
     MaterialTestGridType,
     draw_material_test_preview,
@@ -350,3 +351,89 @@ def test_grid_cell_count(laser: Laser):
         ]
         assert len(speeds) == cols * rows
         assert artifact.source_dimensions == wp_size
+
+
+def test_offset_range_default_and_custom():
+    """Verify offset_range has a sensible default and stores custom values."""
+    default_producer = MaterialTestGridProducer()
+    assert default_producer.offset_range == (-0.5, 0.5)
+
+    custom_producer = MaterialTestGridProducer(offset_range=(-1.0, 1.0))
+    assert custom_producer.offset_range == (-1.0, 1.0)
+
+
+def test_serialization_includes_offset_range():
+    """Verify offset_range and Speed vs Offset grid_mode round-trip."""
+    original = MaterialTestGridProducer(
+        grid_mode=GridMode.SPEED_VS_OFFSET, offset_range=(-0.75, 0.75)
+    )
+    data = original.to_dict()
+    assert data["params"]["offset_range"] == [-0.75, 0.75]
+    assert data["params"]["grid_mode"] == "Speed vs Offset"
+
+    recreated = OpsProducer.from_dict(data)
+    assert isinstance(recreated, MaterialTestGridProducer)
+    assert tuple(recreated.offset_range) == (-0.75, 0.75)
+    assert recreated.grid_mode == GridMode.SPEED_VS_OFFSET
+
+
+def test_speed_vs_offset_power_scales_with_speed_and_clamps(
+    laser: Laser, mock_workpiece: WorkPiece
+):
+    """Engrave mode with Speed vs Offset must scale power with speed
+    (anchored at fixed_power at min_speed, clamped to 100%) -- raygeo
+    does this internally so darkness stays comparable across the row."""
+    producer = MaterialTestGridProducer(
+        test_type=MaterialTestGridType.ENGRAVE,
+        grid_mode=GridMode.SPEED_VS_OFFSET,
+        speed_range=(1000.0, 4000.0),
+        offset_range=(-0.5, 0.5),
+        fixed_power=40.0,
+        grid_dimensions=(2, 2),
+        shape_size=10.0,
+        spacing=2.0,
+        include_labels=False,
+        line_interval_mm=2.0,
+    )
+    artifact = producer.run(
+        laser=laser,
+        surface=None,
+        pixels_per_mm=None,
+        generation_id=0,
+        workpiece=mock_workpiece,
+        settings={},
+    )
+    ops = artifact.ops
+    speeds = [ops.rate(i) for i in ops.indices_of(CommandType.SET_FEED_RATE)]
+    all_powers = [ops.power(i) for i in ops.indices_of(CommandType.SET_POWER)]
+    powers = [p for p in all_powers if p > 0]
+
+    assert set(speeds) == {1000.0, 4000.0}
+    # 40% * 1000/1000 = 40%; 40% * 4000/1000 = 160%, clamped to 100%.
+    assert any(abs(p - 0.40) < 1e-6 for p in powers)
+    assert any(abs(p - 1.00) < 1e-6 for p in powers)
+    assert all(p <= 1.0 for p in powers)
+
+
+def test_speed_vs_offset_grid_cell_count(
+    laser: Laser, mock_workpiece: WorkPiece
+):
+    """Speed vs Offset must still produce one cell per grid position."""
+    producer = MaterialTestGridProducer(
+        grid_mode=GridMode.SPEED_VS_OFFSET,
+        speed_range=(500.0, 2000.0),
+        offset_range=(-0.3, 0.3),
+        grid_dimensions=(3, 4),
+        include_labels=False,
+    )
+    artifact = producer.run(
+        laser=laser,
+        surface=None,
+        pixels_per_mm=None,
+        generation_id=0,
+        workpiece=mock_workpiece,
+        settings={},
+    )
+    ops = artifact.ops
+    speeds = [ops.rate(i) for i in ops.indices_of(CommandType.SET_FEED_RATE)]
+    assert len(speeds) == 3 * 4

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_raster_producer.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/producers/test_raster_producer.py
@@ -1241,6 +1241,16 @@ class TestScanModeSerialization:
         assert recreated.scan_angle == 45.0
         assert recreated.depth_mode == DepthMode.POWER_MODULATION
 
+    def test_to_dict_roundtrip_preserves_bidir_x_offset_mm(self):
+        original = Rasterizer(bidir_x_offset_mm=0.35)
+        data = original.to_dict()
+        assert data["params"]["bidir_x_offset_mm"] == 0.35
+        recreated = Rasterizer.from_dict(data)
+        assert recreated.bidir_x_offset_mm == 0.35
+
+    def test_bidir_x_offset_mm_defaults_to_zero(self):
+        assert Rasterizer().bidir_x_offset_mm == 0.0
+
     def test_backward_compat_segmented_upper(self):
         data = {
             "type": "Rasterizer",

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_material_test_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_material_test_step.py
@@ -1,9 +1,18 @@
+from typing import TYPE_CHECKING, Protocol, cast
 from unittest.mock import MagicMock
 
 import pytest
 from laser_essentials.steps import MaterialTestStep
 
 from rayforge.core.capability import MATERIAL_TEST
+
+if TYPE_CHECKING:
+
+    class OverscanTransformerType(Protocol):
+        @staticmethod
+        def calculate_auto_distance(
+            step_speed: int, max_acceleration: int
+        ) -> float: ...
 
 
 @pytest.fixture
@@ -37,3 +46,55 @@ class TestMaterialTestStep:
         step = MaterialTestStep(name="Test")
         data = step.to_dict()
         assert data["step_type"] == "MaterialTestStep"
+
+    def test_optimize_present_but_disabled_by_default(self, mock_context):
+        """Optimize must be off by default: its nearest-neighbor travel
+        reordering has no concept of cell boundaries and can interleave
+        lines from different cells instead of engraving each one fully
+        before moving to the next. Left toggleable (not removed) so it's
+        easy to compare with/without."""
+        step = MaterialTestStep.create(mock_context)
+        per_wp = {
+            t.get("name"): t for t in step.per_workpiece_transformers_dicts
+        }
+        per_step = {
+            t.get("name"): t for t in step.per_step_transformers_dicts
+        }
+        assert "Optimize" in per_wp
+        assert per_wp["Optimize"]["enabled"] is False
+        assert "Optimize" in per_step
+        assert per_step["Optimize"]["enabled"] is False
+
+    def test_overscan_distance_is_doubled(self, mock_context):
+        """Individual test blocks get double the usual auto-overscan
+        distance, so backlash settling happens outside the visible
+        engrave area."""
+        from rayforge.pipeline.transformer.registry import (
+            transformer_registry,
+        )
+
+        OverscanTransformer = cast(
+            "OverscanTransformerType",
+            transformer_registry.get("OverscanTransformer"),
+        )
+        assert OverscanTransformer is not None
+
+        step = MaterialTestStep.create(mock_context)
+        overscan_dict = next(
+            t
+            for t in step.per_workpiece_transformers_dicts
+            if t.get("name") == "OverscanTransformer"
+        )
+        expected_base = OverscanTransformer.calculate_auto_distance(
+            step.cut_speed, mock_context.machine.acceleration
+        )
+        assert overscan_dict["distance_mm"] == pytest.approx(
+            expected_base * 2
+        )
+
+    def test_includes_bidir_scan_offset_transformer(self, mock_context):
+        step = MaterialTestStep.create(mock_context)
+        per_wp_names = {
+            t.get("name") for t in step.per_workpiece_transformers_dicts
+        }
+        assert "BidirScanOffsetTransformer" in per_wp_names

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_raster_step.py
@@ -33,7 +33,11 @@ class TestEngraveStep:
         assert isinstance(step, EngraveStep)
         assert step.opsproducer_dict is not None
         assert step.opsproducer_dict["type"] == "Rasterizer"
-        assert len(step.per_workpiece_transformers_dicts) == 2
+        assert len(step.per_workpiece_transformers_dicts) == 3
+        transformer_names = {
+            t.get("name") for t in step.per_workpiece_transformers_dicts
+        }
+        assert "BidirScanOffsetTransformer" in transformer_names
         assert step.selected_laser_uid == "test-laser-uid"
 
     def test_serialization_includes_step_type(self):

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/__init__.py
@@ -5,6 +5,7 @@ This module provides all built-in transformers that can be applied
 to Ops objects for various post-processing operations.
 """
 
+from .bidir_scan_offset_transformer import BidirScanOffsetTransformer
 from .crop_transformer import CropTransformer
 from .lead_in_out_transformer import LeadInOutTransformer
 from .merge_lines_transformer import MergeLinesTransformer
@@ -15,6 +16,7 @@ from .smooth_transformer import Smooth
 from .tabs_transformer import TabOpsTransformer
 
 __all__ = [
+    "BidirScanOffsetTransformer",
     "CropTransformer",
     "LeadInOutTransformer",
     "MergeLinesTransformer",

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/bidir_scan_offset_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/bidir_scan_offset_transformer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import math
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from raygeo.ops import Ops
+from raygeo.ops.types import CommandCategory, CommandType
+
+from rayforge.pipeline.transformer.base import ExecutionPhase, OpsTransformer
+from rayforge.shared.tasker.progress import ProgressContext
+
+if TYPE_CHECKING:
+    from raygeo.geo import Geometry
+
+    from rayforge.core.workpiece import WorkPiece
+
+
+class BidirScanOffsetTransformer(OpsTransformer):
+    """
+    Corrects the X misalignment between left-to-right and right-to-left
+    raster passes seen on machines with a fixed mechanical/firmware skew
+    between scan directions.
+
+    For every raster pass (a MoveTo immediately followed by a ScanLine),
+    if the pass runs right-to-left, both its entry MoveTo and its ScanLine
+    endpoint are shifted along X by the configured offset. Left-to-right
+    passes are left untouched. Running after overscan means any lead-in/
+    lead-out already baked into the pass is shifted along with it.
+    """
+
+    def __init__(self, enabled: bool = True):
+        super().__init__(enabled=enabled)
+
+    @property
+    def execution_phase(self) -> ExecutionPhase:
+        return ExecutionPhase.POST_PROCESSING
+
+    @property
+    def label(self) -> str:
+        return _("Bidirectional Scan Offset")
+
+    @property
+    def description(self) -> str:
+        return _(
+            "Shifts right-to-left raster passes along X to correct "
+            "scan-direction skew."
+        )
+
+    def run(
+        self,
+        ops: Ops,
+        workpiece: Optional["WorkPiece"] = None,
+        context: Optional[ProgressContext] = None,
+        stock_geometries: Optional[List["Geometry"]] = None,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        offset_mm = settings.get("bidir_x_offset_mm", 0.0) if settings else 0.0
+        if not self.enabled or math.isclose(offset_mm, 0.0):
+            return
+
+        source = ops.copy()
+        ops.clear()
+        n = source.len()
+        idx = 0
+        while idx < n:
+            if source.command_type(idx) == CommandType.MOVE_TO:
+                move_end = source.endpoint(idx)
+                j = idx + 1
+                while j < n and source.category(j) == CommandCategory.STATE:
+                    j += 1
+                if j < n and source.is_scanline(j):
+                    scan_end = source.endpoint(j)
+                    if scan_end[0] < move_end[0]:
+                        ops.move_to(
+                            move_end[0] + offset_mm,
+                            move_end[1],
+                            move_end[2],
+                            extra=source.extra_axes(idx),
+                        )
+                        for k in range(idx + 1, j):
+                            ops.transfer_command_from(source, k)
+                        ops.scan_to(
+                            scan_end[0] + offset_mm,
+                            scan_end[1],
+                            scan_end[2],
+                            power_values=list(source.scanline_data(j)),
+                            extra=source.extra_axes(j),
+                        )
+                    else:
+                        for k in range(idx, j + 1):
+                            ops.transfer_command_from(source, k)
+                    idx = j + 1
+                    continue
+            ops.transfer_command_from(source, idx)
+            idx += 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {**super().to_dict()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BidirScanOffsetTransformer":
+        return cls(enabled=data.get("enabled", True))

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/worker.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/worker.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from rayforge.core.hooks import hookimpl
 
 from .transformers import (
+    BidirScanOffsetTransformer,
     CropTransformer,
     LeadInOutTransformer,
     MergeLinesTransformer,
@@ -32,6 +33,9 @@ ADDON_NAME = "post_processors"
 @hookimpl
 def register_transformers(transformer_registry):
     """Register transformers with the transformer registry."""
+    transformer_registry.register(
+        BidirScanOffsetTransformer, addon_name=ADDON_NAME
+    )
     transformer_registry.register(CropTransformer, addon_name=ADDON_NAME)
     transformer_registry.register(LeadInOutTransformer, addon_name=ADDON_NAME)
     transformer_registry.register(MergeLinesTransformer, addon_name=ADDON_NAME)

--- a/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_bidir_scan_offset_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/tests/transformers/test_bidir_scan_offset_transformer.py
@@ -1,0 +1,123 @@
+import pytest
+from post_processors.transformers import BidirScanOffsetTransformer
+from raygeo.ops import Ops
+from raygeo.ops.types import CommandType
+
+from rayforge.pipeline.transformer.base import ExecutionPhase
+
+
+@pytest.fixture
+def transformer() -> BidirScanOffsetTransformer:
+    """Provides a default, enabled BidirScanOffsetTransformer instance."""
+    return BidirScanOffsetTransformer(enabled=True)
+
+
+def _build_zigzag() -> Ops:
+    """Three-row zigzag raster: row0 LTR, row1 RTL, row2 LTR."""
+    ops = Ops()
+    ops.move_to(0.0, 0.6, 0.0)
+    ops.scan_to(2.0, 0.6, 0.0, power_values=[200, 200, 200, 200])
+    ops.move_to(2.0, 0.5, 0.0)
+    ops.scan_to(0.0, 0.5, 0.0, power_values=[210, 210, 210, 210])
+    ops.move_to(0.0, 0.4, 0.0)
+    ops.scan_to(2.0, 0.4, 0.0, power_values=[220, 220, 220, 220])
+    return ops
+
+
+def test_execution_phase_is_correct(transformer: BidirScanOffsetTransformer):
+    assert transformer.execution_phase == ExecutionPhase.POST_PROCESSING
+
+
+def test_serialization_and_deserialization():
+    original = BidirScanOffsetTransformer(enabled=False)
+    data = original.to_dict()
+    recreated = BidirScanOffsetTransformer.from_dict(data)
+    assert data["name"] == "BidirScanOffsetTransformer"
+    assert data["enabled"] is False
+    assert isinstance(recreated, BidirScanOffsetTransformer)
+    assert recreated.enabled is False
+
+
+def test_no_op_when_disabled():
+    ops = _build_zigzag()
+    original = [ops.endpoint(i) for i in range(ops.len())]
+
+    transformer = BidirScanOffsetTransformer(enabled=False)
+    transformer.run(ops, settings={"bidir_x_offset_mm": 0.3})
+
+    assert [ops.endpoint(i) for i in range(ops.len())] == original
+
+
+def test_no_op_with_zero_offset(transformer: BidirScanOffsetTransformer):
+    ops = _build_zigzag()
+    original = [ops.endpoint(i) for i in range(ops.len())]
+
+    transformer.run(ops, settings={"bidir_x_offset_mm": 0.0})
+
+    assert [ops.endpoint(i) for i in range(ops.len())] == original
+
+
+def test_no_op_without_settings(transformer: BidirScanOffsetTransformer):
+    ops = _build_zigzag()
+    original = [ops.endpoint(i) for i in range(ops.len())]
+
+    transformer.run(ops, settings=None)
+
+    assert [ops.endpoint(i) for i in range(ops.len())] == original
+
+
+def test_shifts_only_right_to_left_passes(
+    transformer: BidirScanOffsetTransformer,
+):
+    ops = _build_zigzag()
+
+    transformer.run(ops, settings={"bidir_x_offset_mm": 0.3})
+
+    assert ops.len() == 6
+    # Row 0 (LTR): untouched.
+    assert ops.command_type(0) == CommandType.MOVE_TO
+    assert ops.endpoint(0) == pytest.approx((0.0, 0.6, 0.0))
+    assert ops.command_type(1) == CommandType.SCAN_LINE
+    assert ops.endpoint(1) == pytest.approx((2.0, 0.6, 0.0))
+    assert list(ops.scanline_data(1)) == [200, 200, 200, 200]
+    # Row 1 (RTL): entry MoveTo and ScanLine endpoint both shifted by +0.3.
+    assert ops.command_type(2) == CommandType.MOVE_TO
+    assert ops.endpoint(2) == pytest.approx((2.3, 0.5, 0.0))
+    assert ops.command_type(3) == CommandType.SCAN_LINE
+    assert ops.endpoint(3) == pytest.approx((0.3, 0.5, 0.0))
+    assert list(ops.scanline_data(3)) == [210, 210, 210, 210]
+    # Row 2 (LTR): untouched, including the absolute MoveTo into it.
+    assert ops.command_type(4) == CommandType.MOVE_TO
+    assert ops.endpoint(4) == pytest.approx((0.0, 0.4, 0.0))
+    assert ops.command_type(5) == CommandType.SCAN_LINE
+    assert ops.endpoint(5) == pytest.approx((2.0, 0.4, 0.0))
+    assert list(ops.scanline_data(5)) == [220, 220, 220, 220]
+
+
+def test_negative_offset_shifts_left(transformer: BidirScanOffsetTransformer):
+    ops = _build_zigzag()
+
+    transformer.run(ops, settings={"bidir_x_offset_mm": -0.5})
+
+    assert ops.endpoint(2) == pytest.approx((1.5, 0.5, 0.0))
+    assert ops.endpoint(3) == pytest.approx((-0.5, 0.5, 0.0))
+
+
+def test_preserves_intermediate_state_commands(
+    transformer: BidirScanOffsetTransformer,
+):
+    """A SetPower between the entry MoveTo and the ScanLine must survive."""
+    ops = Ops()
+    ops.move_to(2.0, 0.5, 0.0)
+    ops.set_power(0.5)
+    ops.scan_to(0.0, 0.5, 0.0, power_values=[210, 210, 210, 210])
+
+    transformer.run(ops, settings={"bidir_x_offset_mm": 0.3})
+
+    assert ops.len() == 3
+    assert ops.command_type(0) == CommandType.MOVE_TO
+    assert ops.endpoint(0) == pytest.approx((2.3, 0.5, 0.0))
+    assert ops.command_type(1) == CommandType.SET_POWER
+    assert ops.power(1) == pytest.approx(0.5)
+    assert ops.command_type(2) == CommandType.SCAN_LINE
+    assert ops.endpoint(2) == pytest.approx((0.3, 0.5, 0.0))

--- a/rayforge/pipeline/stage/workpiece_stage.py
+++ b/rayforge/pipeline/stage/workpiece_stage.py
@@ -121,6 +121,10 @@ class WorkPiecePipelineStage(PipelineStage):
         settings["driver_native_overscan"] = (
             self._machine.driver.native_overscan
         )
+        producer_params = (step.opsproducer_dict or {}).get("params", {})
+        settings["bidir_x_offset_mm"] = producer_params.get(
+            "bidir_x_offset_mm", 0.0
+        )
 
         try:
             selected_laser = step.get_selected_laser(self._machine)

--- a/tests/pipeline/stage/test_workpiece_stage.py
+++ b/tests/pipeline/stage/test_workpiece_stage.py
@@ -220,3 +220,53 @@ class TestWorkPiecePipelineStage:
         mock_artifact_manager.invalidate_for_workpiece.assert_called_once_with(
             key
         )
+
+    def test_prepare_task_settings_reads_bidir_x_offset_from_producer(
+        self,
+        mock_task_mgr,
+        mock_artifact_manager,
+        mock_machine,
+    ):
+        """The offset must flow from the producer's params, not just the
+        step's own settings."""
+        stage = WorkPiecePipelineStage(
+            mock_task_mgr,
+            mock_artifact_manager,
+            mock_machine,
+        )
+        mock_machine.heads = [MagicMock()]
+        mock_step = MagicMock()
+        mock_step.get_settings.return_value = {}
+        mock_step.opsproducer_dict = {
+            "params": {"bidir_x_offset_mm": 0.35}
+        }
+
+        prep_result = stage.prepare_task_settings(mock_step)
+        assert prep_result is not None
+        settings, _ = prep_result
+
+        assert settings["bidir_x_offset_mm"] == 0.35
+
+    def test_prepare_task_settings_bidir_x_offset_defaults_to_zero(
+        self,
+        mock_task_mgr,
+        mock_artifact_manager,
+        mock_machine,
+    ):
+        """No producer params (or no matching key) should default to 0.0,
+        not raise or leave the key missing."""
+        stage = WorkPiecePipelineStage(
+            mock_task_mgr,
+            mock_artifact_manager,
+            mock_machine,
+        )
+        mock_machine.heads = [MagicMock()]
+        mock_step = MagicMock()
+        mock_step.get_settings.return_value = {}
+        mock_step.opsproducer_dict = None
+
+        prep_result = stage.prepare_task_settings(mock_step)
+        assert prep_result is not None
+        settings, _ = prep_result
+
+        assert settings["bidir_x_offset_mm"] == 0.0

--- a/website/docs/features/operations/engrave.md
+++ b/website/docs/features/operations/engrave.md
@@ -192,10 +192,23 @@ For images, line interval should match or exceed image resolution. If your image
 
 **Bidirectional Scanning:**
 
-- **Enabled:** Laser engraves in both directions (left-to-right and right-to-left), doubling speed
-- **Disabled:** Laser only engraves left-to-right, returning without firing between lines
+Rayforge always scans bidirectionally (left-to-right, then right-to-left), since firing on every pass roughly doubles engraving speed compared to returning without firing between lines.
 
-Bidirectional scanning is faster because the laser fires on every pass. However, slight mechanical differences between directions can cause visible banding on some materials. For critical quality work, especially on photos, disable bidirectional scanning for more consistent results.
+Slight mechanical or firing delay differences between the two directions can cause visible banding on some machines. If you see this, calibrate the **Bidirectional Scan Offset** below to correct it directly, rather than losing the speed benefit.
+
+### Bidirectional Scan Offset
+
+Corrects a fixed mechanical or firing delay skew between left-to-right and right-to-left raster passes, which otherwise misaligns alternate scan rows (visible as banding, especially in photo engraves).
+
+- Set in millimeters, positive or negative depending on which direction needs to shift
+- Applies a constant shift regardless of speed; if the skew varies with speed, calibrate for your typical engraving speed
+- Defaults to 0 (no correction)
+
+**Calibrating the offset:**
+
+1. Engrave a test pattern with visible vertical detail (e.g. a fine grid) using bidirectional scanning
+2. Compare alternate rows to find the direction and amount of misalignment
+3. Adjust the offset in small increments (0.01-0.05mm) and re-test until alternating rows line up
 
 ### Overscan
 
@@ -353,7 +366,7 @@ Use invert for lithophanes (light areas should be thin) or embossing (raised are
 **For best quality:**
 
 - Use smaller line interval (0.05-0.1mm)
-- Disable bidirectional scanning
+- Calibrate the Bidirectional Scan Offset if you see banding
 - Increase overscan (3-5mm)
 - Use lower power, multiple passes
 - Ensure material is flat and secured
@@ -361,7 +374,6 @@ Use invert for lithophanes (light areas should be thin) or embossing (raised are
 **For faster engraving:**
 
 - Use larger line interval (0.15-0.2mm)
-- Enable bidirectional scanning
 - Minimum overscan (1-2mm)
 - Single pass at higher power
 
@@ -388,7 +400,7 @@ Use invert for lithophanes (light areas should be thin) or embossing (raised are
 
 **Banding (dark/light stripes):**
 
-- Disable bidirectional scanning
+- Calibrate the [Bidirectional Scan Offset](#bidirectional-scan-offset)
 - Check belt tension
 - Reduce speed
 - Try different scan angle


### PR DESCRIPTION
Closes #307 

Adds a bidir_x_offset_mm parameter to the Rasterizer producer plus a BidirScanOffsetTransformer, so a fixed mechanical or firing delay skew between left-to-right and right-to-left raster passes (visible as banding, especially on photo engraves) can be corrected directly instead of losing half your engraving speed to disabling bidirectional scanning. Also extends the Material Test Grid with a "Speed vs Offset" mode so the value can be calibrated empirically, using raygeo 1.21.1's native support for it.

Changes
- Add bidir_x_offset_mm param to the Rasterizer producer (per engrave step, not a single machine-wide setting), plus BidirScanOffsetTransformer, which shifts each right-to-left raster pass along X by that offset during gcode generation, preserving per-pixel power values for variable-power (photo) engraving
- Add a "Speed vs Offset" grid mode to the Material Test Grid (columns vary speed, rows vary offset) so the correction can be found by eye rather than guessed at
- Double the auto-calculated overscan distance for individual material test blocks, so backlash settling happens outside the visible engrave area rather than muddying whatever parameter the grid is testing
- Add Optimize to the Material Test Grid's default transformers, but disabled: its nearest-neighbor travel reordering has no concept of cell boundaries and can interleave lines from different cells instead of engraving each one fully before moving to the next. Left toggleable rather than removed, so it's easy to compare with/without
- Update engrave.md, which described a "disable bidirectional scanning" toggle removed years ago when the raster producers were unified, and points at this offset as the actual fix for banding

Checks

pixi run test (5298 passed, 174 deselected)
pixi run lint (clean; 2 pre-existing, unrelated pyright errors on sys._MEIPASS in app.py/worker_init.py (probably macos specific))
pixi install (default environment solves against raygeo 1.21.1)
pixi run rayforge (launches, loads machine config, initializes addons - no crash)
