### PR TITLE
fix: settings-widget sensitivity/default-value bugs in step popups

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/contour_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/contour_step.py
@@ -181,15 +181,6 @@ class ContourStep(Step):
         if not optimize:
             per_wp = [t for t in per_wp if t.get("name") != "Optimize"]
 
-        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
-        if LeadInOutTransformer:
-            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
-            auto_distance = calc(machine.max_cut_speed, machine.acceleration)
-            for t in per_wp:
-                if t.get("name") == "LeadInOutTransformer":
-                    t["lead_in_mm"] = auto_distance
-                    t["lead_out_mm"] = auto_distance
-
         step.per_workpiece_transformers_dicts = per_wp
         step.per_step_transformers_dicts = per_step
         step.selected_laser_uid = default_head.uid
@@ -199,4 +190,15 @@ class ContourStep(Step):
         for cap in machine.get_laser_capabilities(default_head):
             for var in cap.varset:
                 setattr(step, var.key, var.default)
+
+        # step.cut_speed is only final after the loop above.
+        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
+        if LeadInOutTransformer:
+            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
+            auto_distance = calc(step.cut_speed, machine.acceleration)
+            for t in per_wp:
+                if t.get("name") == "LeadInOutTransformer":
+                    t["lead_in_mm"] = auto_distance
+                    t["lead_out_mm"] = auto_distance
+
         return step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/frame_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/frame_step.py
@@ -150,15 +150,6 @@ class FrameStep(Step):
         step = cls(name=name)
         per_wp, per_step = cls.get_default_transformers_dicts()
 
-        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
-        if LeadInOutTransformer:
-            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
-            auto_distance = calc(machine.max_cut_speed, machine.acceleration)
-            for t in per_wp:
-                if t.get("name") == "LeadInOutTransformer":
-                    t["lead_in_mm"] = auto_distance
-                    t["lead_out_mm"] = auto_distance
-
         step.per_workpiece_transformers_dicts = per_wp
         step.per_step_transformers_dicts = per_step
         step.selected_laser_uid = default_head.uid
@@ -168,4 +159,15 @@ class FrameStep(Step):
         for cap in machine.get_laser_capabilities(default_head):
             for var in cap.varset:
                 setattr(step, var.key, var.default)
+
+        # step.cut_speed is only final after the loop above.
+        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
+        if LeadInOutTransformer:
+            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
+            auto_distance = calc(step.cut_speed, machine.acceleration)
+            for t in per_wp:
+                if t.get("name") == "LeadInOutTransformer":
+                    t["lead_in_mm"] = auto_distance
+                    t["lead_out_mm"] = auto_distance
+
         return step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
@@ -341,18 +341,6 @@ class EngraveStep(Step):
         step = cls(name=name)
         per_wp, per_step = cls.get_default_transformers_dicts()
 
-        OverscanTransformer = cast(
-            "OverscanTransformerType",
-            transformer_registry.get("OverscanTransformer"),
-        )
-        assert OverscanTransformer is not None
-        auto_distance = OverscanTransformer.calculate_auto_distance(
-            machine.max_cut_speed, machine.acceleration
-        )
-        for t in per_wp:
-            if t.get("name") == "OverscanTransformer":
-                t["distance_mm"] = auto_distance
-
         step.per_workpiece_transformers_dicts = per_wp
         step.per_step_transformers_dicts = per_step
         step.selected_laser_uid = default_head.uid
@@ -361,4 +349,18 @@ class EngraveStep(Step):
         for cap in machine.get_laser_capabilities(default_head):
             for var in cap.varset:
                 setattr(step, var.key, var.default)
+
+        # step.cut_speed is only final after the loop above.
+        OverscanTransformer = cast(
+            "OverscanTransformerType",
+            transformer_registry.get("OverscanTransformer"),
+        )
+        assert OverscanTransformer is not None
+        auto_distance = OverscanTransformer.calculate_auto_distance(
+            step.cut_speed, machine.acceleration
+        )
+        for t in per_wp:
+            if t.get("name") == "OverscanTransformer":
+                t["distance_mm"] = auto_distance
+
         return step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/shrinkwrap_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/shrinkwrap_step.py
@@ -180,15 +180,6 @@ class ShrinkWrapStep(Step):
         step = cls(name=name)
         per_wp, per_step = cls.get_default_transformers_dicts()
 
-        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
-        if LeadInOutTransformer:
-            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
-            auto_distance = calc(machine.max_cut_speed, machine.acceleration)
-            for t in per_wp:
-                if t.get("name") == "LeadInOutTransformer":
-                    t["lead_in_mm"] = auto_distance
-                    t["lead_out_mm"] = auto_distance
-
         step.per_workpiece_transformers_dicts = per_wp
         step.per_step_transformers_dicts = per_step
         step.selected_laser_uid = default_head.uid
@@ -198,4 +189,15 @@ class ShrinkWrapStep(Step):
         for cap in machine.get_laser_capabilities(default_head):
             for var in cap.varset:
                 setattr(step, var.key, var.default)
+
+        # step.cut_speed is only final after the loop above.
+        LeadInOutTransformer = transformer_registry.get("LeadInOutTransformer")
+        if LeadInOutTransformer:
+            calc = getattr(LeadInOutTransformer, "calculate_auto_distance")
+            auto_distance = calc(step.cut_speed, machine.acceleration)
+            for t in per_wp:
+                if t.get("name") == "LeadInOutTransformer":
+                    t["lead_in_mm"] = auto_distance
+                    t["lead_out_mm"] = auto_distance
+
         return step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/material_test_grid_widget.py
@@ -443,11 +443,17 @@ class MaterialTestGridSettingsWidget(
             "changed", lambda r: self._debounce(self._on_spacing_changed, r)
         )
 
+        laser = self.get_selected_laser()
+        default_line_interval_mm = laser.spot_size_mm[1] if laser else 0.1
         line_interval_adj = Gtk.Adjustment(
             lower=0.01,
             upper=10.0,
             step_increment=0.01,
-            value=self.step.line_interval_mm or 0.1,
+            value=(
+                self.step.line_interval_mm
+                if self.step.line_interval_mm is not None
+                else default_line_interval_mm
+            ),
         )
         self.line_interval_row = Adw.SpinRow(
             title=_("Line Interval"),

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -323,11 +323,19 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         )
         group.add(self.scan_mode_row)
 
+        laser = self.get_selected_laser()
+        default_line_interval_mm = laser.spot_size_mm[1] if laser else 0.1
+        default_sample_interval_mm = laser.spot_size_mm[0] if laser else 0.1
+
         line_interval_adj = Gtk.Adjustment(
             lower=0.001,
             upper=10.0,
             step_increment=0.01,
-            value=self.step.line_interval_mm or 0.1,
+            value=(
+                self.step.line_interval_mm
+                if self.step.line_interval_mm is not None
+                else default_line_interval_mm
+            ),
         )
         self.line_interval_row = Adw.SpinRow(
             title=_("Line Spacing"),
@@ -347,7 +355,11 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
             lower=0.01,
             upper=10.0,
             step_increment=0.01,
-            value=self.step.sample_interval_mm or 0.1,
+            value=(
+                self.step.sample_interval_mm
+                if self.step.sample_interval_mm is not None
+                else default_sample_interval_mm
+            ),
         )
         self.sample_interval_row = Adw.SpinRow(
             title=_("Sample Interval"),

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/wavefront_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/wavefront_widget.py
@@ -32,7 +32,13 @@ class WavefrontSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
             **kwargs,
         )
 
-        step_over = step.step_over_mm or 0.1
+        laser = self.get_selected_laser()
+        default_step_over_mm = laser.spot_size_mm[0] if laser else 0.1
+        step_over = (
+            step.step_over_mm
+            if step.step_over_mm is not None
+            else default_step_over_mm
+        )
         self._add_spin_row(
             label=_("Step Over"),
             subtitle=_("Lateral step-over between wavefront passes (mm)"),

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/widgets/overscan_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/widgets/overscan_widget.py
@@ -132,7 +132,7 @@ class OverscanSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
 
         # Use the stored references to the rows
         self.enable_switch.set_sensitive(not native)
-        self.auto_row.set_sensitive(enabled and not auto and not native)
+        self.auto_row.set_sensitive(enabled and not native)
         self.distance_row.set_sensitive(enabled and not auto and not native)
 
     def _on_auto_toggled(self, row, pspec):

--- a/rayforge/ui_gtk/doceditor/step_settings/base.py
+++ b/rayforge/ui_gtk/doceditor/step_settings/base.py
@@ -8,6 +8,7 @@ from rayforge.pipeline.transformer.base import OpsTransformer
 
 if TYPE_CHECKING:
     from ....doceditor.editor import DocEditor
+    from ....machine.models.laser import Laser
 
 
 class StepComponentSettingsWidget(Adw.PreferencesGroup):
@@ -88,6 +89,16 @@ class StepComponentSettingsWidget(Adw.PreferencesGroup):
         enabled = self.enable_switch.get_active()
         for row in self._rows[1:]:
             row.set_sensitive(enabled)
+
+    def get_selected_laser(self) -> Optional["Laser"]:
+        """Selected Laser for this step, or None if unavailable."""
+        machine = self.editor.context.machine
+        if machine is None:
+            return None
+        try:
+            return self.step.get_selected_laser(machine)
+        except ValueError:
+            return None
 
     def is_unsupported(self) -> bool:
         """


### PR DESCRIPTION

### Summary

- The Line Spacing, Sample Interval, Line Interval (Material Test Grid), and
  Step Over sliders displayed a hardcoded `0.1mm` whenever the underlying
  step property was unset, instead of the laser-spot-size-derived value
  actually used at generation time — so the slider never reflected what was
  really going to be generated until the user manually touched it.
- Overscan's "Automatic Distance" switch was permanently greyed out:
  `_update_sensitivity()` computed the row's own sensitivity from its own
  active state (`enabled and not auto and not native`), and `auto` defaults
  to `True`, so the switch disabled itself from the moment it existed.
- Auto-calculated Overscan/Lead-In-Out distance silently shrank when
  disabling Auto and re-enabling it: `EngraveStep`/`ContourStep`/
  `ShrinkWrapStep`/`FrameStep` all seeded the initial distance from
  `machine.max_cut_speed`, but the widgets' own recalculation on re-enable
  uses `step.cut_speed` — typically far lower, and distance scales with
  speed².

### Changes

- `rayforge/ui_gtk/doceditor/step_settings/base.py`: add
  `get_selected_laser()` helper for widgets to compute real fallback values.
- `raster_widget.py`, `material_test_grid_widget.py`, `wavefront_widget.py`:
  use the actual selected laser's spot size as the displayed default
  instead of a hardcoded `0.1`.
- `overscan_widget.py`: `auto_row`'s sensitivity no longer depends on its
  own active state.
- `raster_step.py`, `contour_step.py`, `shrinkwrap_step.py`, `frame_step.py`:
  compute the initial auto distance from `step.cut_speed` (after the
  per-laser-capability defaults loop, which can itself set it), matching
  what the widgets recompute on toggle.

### Checks

- `pixi run test`: 5286 passed, 300 deselected
- `pixi run lint`: clean (2 pre-existing, unrelated pyright errors on
  `sys._MEIPASS` in `app.py`/`worker_init.py`)
- Manually verified in the running app.
