### PR TITLE
feat: Add dot width correction for raster engraving

### DIFF
--- a/debian/requirements-bundle.txt
+++ b/debian/requirements-bundle.txt
@@ -1,5 +1,5 @@
 asyncudp==0.11.0
 pyvips==3.0.0
-raygeo==1.23.0
+raygeo==1.24.0
 trimesh==4.6.8
 vtracer==0.6.11

--- a/pixi.lock
+++ b/pixi.lock
@@ -475,6 +475,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/da/72f7caabd94652e6eb7e92ed2d3da818626e70b4f2b15a854ef60bf501ec/websockets-14.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/09/5fce0cd652bb00a16f81ad5a3f0b777221ee32fe0985e7666fd54250cbff/raygeo-1.24.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
@@ -493,7 +494,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/4c/c73f828fdbcd37eaf21d08fa852544a3ca7c2dbb3ea76873d64f2ea413d1/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/27/8802509305b953fd06602d832d8b5cf450bffc6c49365b0f56b1aa47d46b/raygeo-1.23.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -683,7 +683,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/fe/77f4a24264e728fd95542e53f026a91249b51d1611087b8c82d3a033ea97/asyncudp-0.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1f/6c/5abf3bfec39e3d90e29538a7ed9496e84ab4c4b5009b0af08bfe67f066ff/raygeo-1.23.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
@@ -698,6 +697,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/67/48/816bd4aaae93dbf9e408c58598bc32f4a8c65f4b86ab560864cb3ee60adb/cairosvg-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/2c/e20cd4710b6bfc40546db91db11be62460b8ce51cc52f6f8e81a0eb68001/raygeo-1.24.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/0e/9f526bc1d49d8082eff0d1547a69d541a0c5a052e71da625559efaba46a6/pymupdf-1.27.2.2-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl
@@ -4370,7 +4370,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -8965,7 +8965,7 @@ packages:
 - pypi: ./
   name: rayforge
   requires_dist:
-  - raygeo==1.23.0
+  - raygeo==1.24.0
   - aiohttp==3.14.1
   - asyncudp==0.11.0
   - blinker==1.9.0
@@ -9177,26 +9177,6 @@ packages:
   - mypy>=1.11.2 ; extra == 'all'
   - pytest>=8.3.2 ; extra == 'all'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/1f/6c/5abf3bfec39e3d90e29538a7ed9496e84ab4c4b5009b0af08bfe67f066ff/raygeo-1.23.0-cp311-abi3-macosx_11_0_arm64.whl
-  name: raygeo
-  version: 1.23.0
-  sha256: 737f176ab2bc8877fbc83586c40099727b60efc6f3b38733d383a8270842abf0
-  requires_dist:
-  - msgpack
-  - numpy>=1.20.0
-  - matplotlib ; extra == 'cli'
-  - matplotlib ; extra == 'docs'
-  - mdformat ; extra == 'docs'
-  - mdformat-frontmatter ; extra == 'docs'
-  - mdformat-tables ; extra == 'docs'
-  - pillow ; extra == 'docs'
-  - pycairo ; extra == 'test'
-  - pytest ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - streamlit ; extra == 'test'
-  - streamlit ; extra == 'visual'
-  - matplotlib ; extra == 'visual'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
   name: gitpython
   version: 3.1.50
@@ -9445,6 +9425,26 @@ packages:
   - flake8 ; extra == 'test'
   - isort ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/69/2c/e20cd4710b6bfc40546db91db11be62460b8ce51cc52f6f8e81a0eb68001/raygeo-1.24.0-cp311-abi3-macosx_11_0_arm64.whl
+  name: raygeo
+  version: 1.24.0
+  sha256: 212bffd159fd667d7c71a8ec6dad234a7ea640a4c7643db0354a726f6983a725
+  requires_dist:
+  - msgpack
+  - numpy>=1.20.0
+  - matplotlib ; extra == 'cli'
+  - matplotlib ; extra == 'docs'
+  - mdformat ; extra == 'docs'
+  - mdformat-frontmatter ; extra == 'docs'
+  - mdformat-tables ; extra == 'docs'
+  - pillow ; extra == 'docs'
+  - pycairo ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - streamlit ; extra == 'test'
+  - streamlit ; extra == 'visual'
+  - matplotlib ; extra == 'visual'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: frozenlist
   version: 1.8.0
@@ -9568,6 +9568,26 @@ packages:
   sha256: 716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea
   requires_dist:
   - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/88/09/5fce0cd652bb00a16f81ad5a3f0b777221ee32fe0985e7666fd54250cbff/raygeo-1.24.0.tar.gz
+  name: raygeo
+  version: 1.24.0
+  sha256: b63ffe60a4707fc4540b0deb4ec073dff4b37afb232d64a572b38fd2975cd3b4
+  requires_dist:
+  - msgpack
+  - numpy>=1.20.0
+  - pycairo ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - streamlit ; extra == 'test'
+  - streamlit ; extra == 'visual'
+  - matplotlib ; extra == 'visual'
+  - matplotlib ; extra == 'docs'
+  - mdformat ; extra == 'docs'
+  - mdformat-frontmatter ; extra == 'docs'
+  - mdformat-tables ; extra == 'docs'
+  - pillow ; extra == 'docs'
+  - matplotlib ; extra == 'cli'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
   name: nodeenv
@@ -9854,26 +9874,6 @@ packages:
   - numpy<2.0 ; python_full_version < '3.9'
   - numpy>=2 ; python_full_version >= '3.9'
   requires_python: '>=3.6'
-- pypi: https://files.pythonhosted.org/packages/d2/27/8802509305b953fd06602d832d8b5cf450bffc6c49365b0f56b1aa47d46b/raygeo-1.23.0.tar.gz
-  name: raygeo
-  version: 1.23.0
-  sha256: 386cf160f7cffd11e6c89dc546025fb80c4ea10b63e960c79334cb1b54e58078
-  requires_dist:
-  - msgpack
-  - numpy>=1.20.0
-  - pycairo ; extra == 'test'
-  - pytest ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - streamlit ; extra == 'test'
-  - streamlit ; extra == 'visual'
-  - matplotlib ; extra == 'visual'
-  - matplotlib ; extra == 'docs'
-  - mdformat ; extra == 'docs'
-  - mdformat-frontmatter ; extra == 'docs'
-  - mdformat-tables ; extra == 'docs'
-  - pillow ; extra == 'docs'
-  - matplotlib ; extra == 'cli'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl
   name: pycodestyle
   version: 2.14.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,7 @@ rust = "*"
 patchelf = "*"
 
 [feature.app.pypi-dependencies]
-raygeo = "==1.23.0"
+raygeo = "==1.24.0"
 rayforge = { editable = true, path = "." }
 aiohttp = "==3.14.1"
 asyncudp = "==0.11.0"

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
@@ -66,6 +66,7 @@ class EngraveStep(Step):
         self.threshold = 128
         self.line_interval_mm = None
         self.sample_interval_mm = None
+        self.dot_width_correction_mm = None
         self.min_power = 0.0
         self.max_power = 1.0
         self.num_power_levels = 25
@@ -102,6 +103,7 @@ class EngraveStep(Step):
             "mode": DepthMode[self.depth_mode].raygeo_name,
             "line_interval_mm": line_interval,
             "sample_interval_mm": self.sample_interval_mm,
+            "dot_width_correction_mm": self.dot_width_correction_mm,
             "min_power": self.min_power,
             "max_power": self.max_power,
             "step_power": step_power,
@@ -127,6 +129,7 @@ class EngraveStep(Step):
         result["threshold"] = self.threshold
         result["line_interval_mm"] = self.line_interval_mm
         result["sample_interval_mm"] = self.sample_interval_mm
+        result["dot_width_correction_mm"] = self.dot_width_correction_mm
         result["min_power"] = self.min_power
         result["max_power"] = self.max_power
         result["num_power_levels"] = self.num_power_levels
@@ -155,6 +158,9 @@ class EngraveStep(Step):
         step.threshold = data.get("threshold", 128)
         step.line_interval_mm = data.get("line_interval_mm", None)
         step.sample_interval_mm = data.get("sample_interval_mm", None)
+        step.dot_width_correction_mm = data.get(
+            "dot_width_correction_mm", None
+        )
         step.min_power = data.get("min_power", 0.0)
         step.max_power = data.get("max_power", 1.0)
         step.num_power_levels = data.get("num_power_levels", 25)
@@ -262,6 +268,11 @@ class EngraveStep(Step):
         sample_interval_mm = (
             rp.get("sample_interval_mm") or laser.spot_size_mm[0]
         )
+        dot_width_correction_mm = (
+            rp.get("dot_width_correction_mm")
+            if rp.get("dot_width_correction_mm") is not None
+            else laser.spot_size_mm[0] / 2.0
+        )
         step_power = machine_defaults.step_power
         alpha_arr = (
             (alpha * 255).astype(np.uint8) if alpha is not None else None
@@ -286,6 +297,7 @@ class EngraveStep(Step):
             num_depth_levels=rp.get("num_depth_levels", 1),
             z_step_down=rp.get("z_step_down", 0.0),
             angle_increment=rp.get("angle_increment", 0),
+            dot_width_correction_mm=dot_width_correction_mm,
         )
 
         final_ops = result.ops

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -394,9 +394,8 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         self.dot_width_correction_row = Adw.SpinRow(
             title=_("Dot Width Correction"),
             subtitle=_(
-                "Shortens each engraved run by this distance at both "
-                "ends to compensate for the physical width of the "
-                "laser spot. Does not affect toolpath movement."
+                "Reduces engrave length at both ends to compensate "
+                "for physical dot width"
             ),
             adjustment=dot_width_correction_adj,
             digits=3,

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/widgets/raster_widget.py
@@ -378,6 +378,37 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         )
         group.add(self.sample_interval_row)
 
+        default_dot_width_correction_mm = (
+            laser.spot_size_mm[0] / 2.0 if laser else 0.05
+        )
+        dot_width_correction_adj = Gtk.Adjustment(
+            lower=0.0,
+            upper=5.0,
+            step_increment=0.01,
+            value=(
+                self.step.dot_width_correction_mm
+                if self.step.dot_width_correction_mm is not None
+                else default_dot_width_correction_mm
+            ),
+        )
+        self.dot_width_correction_row = Adw.SpinRow(
+            title=_("Dot Width Correction"),
+            subtitle=_(
+                "Shortens each engraved run by this distance at both "
+                "ends to compensate for the physical width of the "
+                "laser spot. Does not affect toolpath movement."
+            ),
+            adjustment=dot_width_correction_adj,
+            digits=3,
+        )
+        self.dot_width_correction_row.connect(
+            "changed",
+            lambda r: self._debounce(
+                self._on_dot_width_correction_changed, get_spinrow_float(r)
+            ),
+        )
+        group.add(self.dot_width_correction_row)
+
         bidir_x_offset_adj = Gtk.Adjustment(
             lower=-5.0,
             upper=5.0,
@@ -616,6 +647,11 @@ class RasterSettingsWidget(DebounceMixin, StepComponentSettingsWidget):
         if value is not None and value <= 0:
             value = None
         self._on_param_changed("sample_interval_mm", value)
+
+    def _on_dot_width_correction_changed(self, value: Optional[float]):
+        # Unlike line/sample interval, 0.0 is a meaningful explicit value
+        # here (no correction), not a sentinel for "reset to auto".
+        self._on_param_changed("dot_width_correction_mm", value or 0.0)
 
     def _on_bidir_x_offset_changed(self, value: Optional[float]):
         self._on_param_changed("bidir_x_offset_mm", value or 0.0)

--- a/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_raster_step.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 from laser_essentials.steps import EngraveStep
 
@@ -75,6 +76,7 @@ class TestEngraveStep:
             "mode",
             "line_interval_mm",
             "sample_interval_mm",
+            "dot_width_correction_mm",
             "min_power",
             "max_power",
             "step_power",
@@ -95,6 +97,70 @@ class TestEngraveStep:
         step.scan_angle = 45.0
         step.depth_mode = "MULTI_PASS"
         step.line_interval_mm = 0.2  # type: ignore[assignment]
+        step.dot_width_correction_mm = 0.05  # type: ignore[assignment]
         data = step.to_dict()
         restored = EngraveStep.from_dict(data)
         assert data == restored.to_dict()
+        assert restored.dot_width_correction_mm == 0.05
+
+
+class TestAssembleOnSurfaceAutoDefaults:
+    """
+    assemble_on_surface must resolve dot_width_correction_mm the same
+    way line_interval_mm/sample_interval_mm already do: None falls back
+    to a laser-spot-size-derived value actually used at generation
+    time, an explicit override is passed through unchanged.
+    """
+
+    def _run(self, step, machine_defaults, laser_spot_size_mm):
+        laser = MagicMock()
+        laser.uid = "laser-1"
+        laser.spot_size_mm = laser_spot_size_mm
+
+        surface = MagicMock()
+        surface.get_width.return_value = 10
+        surface.get_height.return_value = 10
+
+        workpiece = MagicMock()
+        workpiece.size = (10.0, 10.0)
+        workpiece.bbox = (0.0, 0.0, 10.0, 10.0)
+        workpiece.uid = "wp-1"
+
+        fake_image = np.zeros((10, 10), dtype=np.uint8)
+        fake_alpha = np.ones((10, 10), dtype=np.float32)
+
+        with (
+            patch(
+                "laser_essentials.steps.raster_step.preprocess_raster_image",
+                return_value=(fake_image, fake_alpha),
+            ),
+            patch("laser_essentials.steps.raster_step.make_artifact"),
+            patch(
+                "laser_essentials.steps.raster_step.assembler_registry"
+            ) as mock_registry,
+        ):
+            mock_result = MagicMock()
+            mock_result.ops = MagicMock(len=MagicMock(return_value=0))
+            mock_registry.assemble.return_value = mock_result
+
+            step.assemble_on_surface(
+                workpiece,
+                laser,
+                generation_id=1,
+                surface=surface,
+                pixels_per_mm=(1.0, 1.0),
+                machine_defaults=machine_defaults,
+            )
+
+        return mock_registry.assemble.call_args.kwargs
+
+    def test_auto_default_uses_half_spot_size(self, machine_defaults):
+        step = EngraveStep(name="Test")
+        kwargs = self._run(step, machine_defaults, (0.2, 0.15))
+        assert kwargs["dot_width_correction_mm"] == pytest.approx(0.1)
+
+    def test_explicit_override_is_respected(self, machine_defaults):
+        step = EngraveStep(name="Test")
+        step.dot_width_correction_mm = 0.5  # type: ignore[assignment]
+        kwargs = self._run(step, machine_defaults, (0.2, 0.15))
+        assert kwargs["dot_width_correction_mm"] == pytest.approx(0.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-raygeo==1.23.0
+raygeo==1.24.0
 aiohttp==3.14.1
 asyncudp==0.11.0
 blinker==1.9.0


### PR DESCRIPTION
### Summary

Adds LightBurn-style "Dot Correction" support to raster engraving: shortens the marked area of every continuous engraved run by compensating for the physical width of the laser spot, so engraved images come out at their intended size instead of slightly larger/darker along the scan-line direction. This especially matters for fine detail — thin dark features and the gaps between them are closest in size to the spot diameter, so without correction they're the first to over-thicken and wash out.

Depends on the raygeo change in branch `feature/dot-width-correction` (https://github.com/vyvcodd/raygeo/tree/feature/dot-width-correction), which does the actual work: it delays laser-on and advances laser-off by half the spot diameter at each end of every engraved run, without changing any toolpath geometry. See that branch's PR description for the full rationale — in short, this is a firing-timing correction, not a geometric one, so it's implemented separately from (and cannot reuse) the existing kerf/tool-radius offset machinery. It also documents a known, deliberate limitation: engraved detail smaller than roughly the spot diameter is dropped entirely rather than shrunk to a point, since this feature is inherently a lossy scale-down of the burn and a hard threshold is the easiest version of that tradeoff to reason about.

### Changes

- `EngraveStep.dot_width_correction_mm` (`raster_step.py`): `Optional[float]`, defaulting to `None` (auto = half the selected laser's `spot_size_mm[0]`), same convention as the existing `line_interval_mm`/`sample_interval_mm` — auto value shown as the default, explicit override once the user edits it, no separate toggle. Wired through `get_assembler_kwargs`/`assemble_on_surface` into the new `dot_width_correction_mm` kwarg on the raygeo `raster()` assembler.
- `raster_widget.py`: new "Dot Width Correction" `Adw.SpinRow` in `RasterSettingsWidget`, next to Line Spacing / Sample Interval.
- `test_raster_step.py`: updated `test_get_assembler_kwargs`'s expected key set, added a roundtrip-serialization assertion for the new field, and a mocked `assemble_on_surface` test (`TestAssembleOnSurfaceAutoDefaults`) asserting the auto-default actually resolves to half the laser's spot size at generation time, and that an explicit override is respected — this exact "resolves to the right value when generating, not just a hardcoded placeholder" class of bug is what the settings-widget-auto-value-bugs PR fixed for the other raster fields, so it's worth locking down here too.

### Checks

- `rayforge/builtin_addons/rayforge-addon-laser/tests/steps/test_raster_step.py`: 8 passed.
- Full suite (`tests/` + `rayforge/builtin_addons/`), rebased onto current `main`: 5277 passed, 300 deselected.
- Not yet manually verified in a running app — the automated screenshot check (`scripts/screenshot/cli.py step-settings:engrave:general:variable`) hung in this environment and was killed rather than left running; worth a quick manual look at the new spin row before merging.

### Sequencing note — do not merge before the raygeo pin bump

This is not a dormant feature waiting on a later release — it's a breaking change against the currently-pinned raygeo. `dot_width_correction_mm` is passed unconditionally on every raster generation, and the pinned release (1.23.0) doesn't accept that kwarg at all:

```
raster() got an unexpected keyword argument 'dot_width_correction_mm'
```

Verified directly against the actual cached 1.23.0 wheel. Every Engrave step would fail to generate. This must land in the same PR (or immediately after, with no gap) as the `raygeo` pin bump to the release that includes `feature/dot-width-correction`, matching the existing "bump pin + migrate code" convention already used for every other raygeo version bump in this repo's history. Until then, test locally with `scripts/run_with_local_raygeo.sh ../raygeo` pointed at that branch.
