### PR TITLE
fix: use persistent /dev/v4l/by-id/ paths for camera identification on Linux

### DIFF
--- a/rayforge/camera/controller.py
+++ b/rayforge/camera/controller.py
@@ -40,6 +40,20 @@ COMMON_RESOLUTIONS = [
 ]
 
 
+def _get_linux_scan_targets() -> List[str]:
+    """Get device identifiers to scan on Linux.
+
+    Prefers persistent /dev/v4l/by-id/ paths. Falls back to
+    numeric indices if by-id is not available.
+    """
+    from .v4l import get_sorted_by_id_paths
+
+    by_id_paths = get_sorted_by_id_paths()
+    if by_id_paths:
+        return by_id_paths
+    return [str(i) for i in range(10)]
+
+
 def _probe_camera_device(args):
     """Probe a single camera device. Runs in subprocess."""
     device_id, backend = args
@@ -64,8 +78,13 @@ def _scan_cameras_in_subprocess() -> List[str]:
     else:
         backends = [cv2.CAP_ANY]
 
+    if sys.platform.startswith("linux"):
+        targets = _get_linux_scan_targets()
+    else:
+        targets = [str(i) for i in range(10)]
+
     devices = []
-    work = [(i, b) for i in range(10) for b in backends]
+    work = [(t, b) for t in targets for b in backends]
 
     try:
         ctx = mp.get_context("spawn")
@@ -92,18 +111,23 @@ def _scan_cameras_fallback() -> List[str]:
     else:
         backends = [(cv2.CAP_ANY, "default")]
 
-    for i in range(10):
+    if sys.platform.startswith("linux"):
+        targets = _get_linux_scan_targets()
+    else:
+        targets = [str(i) for i in range(10)]
+
+    for target in targets:
         for backend, name in backends:
             try:
-                cap = cv2.VideoCapture(i, backend)
+                cap = cv2.VideoCapture(target, backend)
                 if cap.isOpened():
-                    devices.append(str(i))
+                    devices.append(str(target))
                     cap.release()
                     break
                 if cap:
                     cap.release()
             except Exception as e:
-                logger.debug(f"Error probing camera {i}: {e}")
+                logger.debug(f"Error probing camera {target}: {e}")
 
     return devices
 
@@ -266,24 +290,32 @@ class CameraController:
         """
         Lists available camera device IDs.
         Returns a list of strings, where each string is a device ID.
+        On Linux, prefers persistent /dev/v4l/by-id/ paths.
         """
         logger.debug("Scanning for camera devices...")
         devices = []
         backends = get_backends_for_platform()
 
-        for i in range(10):
+        if sys.platform.startswith("linux"):
+            targets = _get_linux_scan_targets()
+        else:
+            targets = [str(i) for i in range(10)]
+
+        for target in targets:
             for backend, name in backends:
                 try:
-                    cap = cv2.VideoCapture(i, backend)
+                    cap = cv2.VideoCapture(target, backend)
                     if cap.isOpened():
-                        devices.append(str(i))
+                        devices.append(str(target))
                         cap.release()
-                        logger.debug(f"Found camera {i} via {name}")
+                        logger.debug(
+                            f"Found camera {target} via {name}"
+                        )
                         break
                 except cv2.error as e:
-                    logger.debug(f"OpenCV error camera {i} {name}: {e}")
+                    logger.debug(f"OpenCV error camera {target} {name}: {e}")
                 except Exception as e:
-                    logger.debug(f"Error camera {i}: {e}")
+                    logger.debug(f"Error camera {target}: {e}")
 
         logger.info(f"Available cameras: {devices}")
         return devices

--- a/rayforge/camera/controller.py
+++ b/rayforge/camera/controller.py
@@ -308,9 +308,7 @@ class CameraController:
                     if cap.isOpened():
                         devices.append(str(target))
                         cap.release()
-                        logger.debug(
-                            f"Found camera {target} via {name}"
-                        )
+                        logger.debug(f"Found camera {target} via {name}")
                         break
                 except cv2.error as e:
                     logger.debug(f"OpenCV error camera {target} {name}: {e}")

--- a/rayforge/camera/models/camera.py
+++ b/rayforge/camera/models/camera.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 from datetime import datetime
 from typing import Any, Dict, Optional, Sequence, Tuple
 
@@ -616,13 +615,7 @@ class Camera:
         }
         extra = {k: v for k, v in data.items() if k not in known_keys}
 
-        device_id = data["device_id"]
-        if sys.platform.startswith("linux"):
-            from ..v4l import resolve_device_id
-
-            device_id = resolve_device_id(device_id)
-
-        camera = cls(data["name"], device_id)
+        camera = cls(data["name"], data["device_id"])
         camera.enabled = data.get("enabled", camera.enabled)
         camera.white_balance = data.get("white_balance", None)
         camera.contrast = data.get("contrast", camera.contrast)

--- a/rayforge/camera/models/camera.py
+++ b/rayforge/camera/models/camera.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from datetime import datetime
 from typing import Any, Dict, Optional, Sequence, Tuple
 
@@ -615,7 +616,13 @@ class Camera:
         }
         extra = {k: v for k, v in data.items() if k not in known_keys}
 
-        camera = cls(data["name"], data["device_id"])
+        device_id = data["device_id"]
+        if sys.platform.startswith("linux"):
+            from ..v4l import resolve_device_id
+
+            device_id = resolve_device_id(device_id)
+
+        camera = cls(data["name"], device_id)
         camera.enabled = data.get("enabled", camera.enabled)
         camera.white_balance = data.get("white_balance", None)
         camera.contrast = data.get("contrast", camera.contrast)

--- a/rayforge/camera/v4l.py
+++ b/rayforge/camera/v4l.py
@@ -1,0 +1,139 @@
+"""Linux V4L persistent device identification.
+
+On Linux, /dev/videoN device numbers are assigned by the kernel based on
+discovery order and can change between reboots. This module resolves
+cameras using persistent /dev/v4l/by-id/ symlinks instead.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+V4L_BY_ID_DIR = Path("/dev/v4l/by-id")
+
+
+def _is_video_capture_symlink(name: str) -> bool:
+    """Check if a by-id symlink refers to a video capture device.
+
+    Video capture symlinks end with '-video-indexN'. Other entries
+    (like '-inputN' or '-altN') refer to non-capture interfaces.
+    """
+    return "-video-index" in name
+
+
+def scan_v4l_by_id() -> Dict[str, str]:
+    """Scan /dev/v4l/by-id/ for video capture devices.
+
+    Returns:
+        Dict mapping resolved '/dev/videoN' to the persistent
+        '/dev/v4l/by-id/...' symlink path.
+    """
+    if not sys.platform.startswith("linux"):
+        return {}
+
+    if not V4L_BY_ID_DIR.is_dir():
+        logger.debug("/dev/v4l/by-id/ does not exist")
+        return {}
+
+    result: Dict[str, str] = {}
+
+    try:
+        for entry in sorted(V4L_BY_ID_DIR.iterdir()):
+            if not entry.is_symlink():
+                continue
+            if not _is_video_capture_symlink(entry.name):
+                continue
+
+            try:
+                resolved = str(entry.resolve())
+                if not resolved.startswith("/dev/video"):
+                    continue
+                if resolved not in result:
+                    result[resolved] = str(entry)
+            except OSError:
+                continue
+    except OSError as e:
+        logger.debug(f"Error scanning /dev/v4l/by-id/: {e}")
+
+    logger.debug(f"Found {len(result)} V4L by-id devices")
+    return result
+
+
+def get_sorted_by_id_paths() -> List[str]:
+    """Return by-id paths sorted by underlying /dev/videoN number."""
+    mapping = scan_v4l_by_id()
+
+    def sort_key(by_id_path: str) -> int:
+        resolved = Path(by_id_path).resolve()
+        try:
+            return int(resolved.name.replace("video", ""))
+        except ValueError:
+            return 999
+
+    return sorted(mapping.values(), key=sort_key)
+
+
+def resolve_device_id(device_id: str) -> str:
+    """Resolve a numeric device ID to a persistent by-id path.
+
+    If the device_id is already a by-id path or not a plain integer
+    string, it is returned unchanged. If it is a numeric string like
+    "0" on Linux, attempts to find the corresponding by-id path.
+
+    Returns:
+        The best available device identifier string.
+    """
+    if not sys.platform.startswith("linux"):
+        return device_id
+
+    if not device_id.isdigit():
+        return device_id
+
+    mapping = scan_v4l_by_id()
+    target = f"/dev/video{device_id}"
+
+    if target in mapping:
+        logger.info(
+            f"Migrated camera device_id from '{device_id}' "
+            f"to '{mapping[target]}'"
+        )
+        return mapping[target]
+
+    logger.debug(
+        f"No by-id path found for {target}, keeping numeric ID"
+    )
+    return device_id
+
+
+def friendly_name_from_by_id(by_id_path: str) -> str:
+    """Extract a human-readable name from a by-id path.
+
+    E.g. '/dev/v4l/by-id/usb-046d_Logitech_Webcam_C930e_1234'
+    -> 'Logitech Webcam C930e'
+    """
+    filename = Path(by_id_path).stem
+
+    for prefix in ("usb-", "pci-"):
+        if filename.startswith(prefix):
+            filename = filename[len(prefix):]
+            break
+
+    idx = filename.find("-video-index")
+    if idx >= 0:
+        filename = filename[:idx]
+
+    parts = filename.split("_")
+    if len(parts) <= 1:
+        return parts[0] if parts else ""
+
+    # First segment is the hex vendor ID (e.g. '046d'), drop it.
+    # Last segment is the serial number, drop it.
+    if len(parts) > 2:
+        parts = parts[1:-1]
+    else:
+        parts = parts[:-1]
+
+    return " ".join(parts)

--- a/rayforge/camera/v4l.py
+++ b/rayforge/camera/v4l.py
@@ -8,7 +8,7 @@ cameras using persistent /dev/v4l/by-id/ symlinks instead.
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -102,10 +102,34 @@ def resolve_device_id(device_id: str) -> str:
         )
         return mapping[target]
 
-    logger.debug(
-        f"No by-id path found for {target}, keeping numeric ID"
-    )
+    logger.debug(f"No by-id path found for {target}, keeping numeric ID")
     return device_id
+
+
+def display_name(device_id: str) -> str:
+    """Return a human-readable display name for a camera device.
+
+    For by-id paths, extracts the friendly name. For other IDs,
+    returns the device_id as-is.
+    """
+    if device_id.startswith("/dev/v4l/by-id/"):
+        return friendly_name_from_by_id(device_id)
+    return device_id
+
+
+def migrate_camera_data(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Migrate numeric device IDs to persistent by-id paths.
+
+    On Linux, numeric device IDs like "0" are replaced with
+    their corresponding /dev/v4l/by-id/ path when available.
+    Returns a copy with the migrated device_id.
+    """
+    if "device_id" not in data:
+        return data
+
+    migrated = dict(data)
+    migrated["device_id"] = resolve_device_id(data["device_id"])
+    return migrated
 
 
 def friendly_name_from_by_id(by_id_path: str) -> str:
@@ -118,7 +142,7 @@ def friendly_name_from_by_id(by_id_path: str) -> str:
 
     for prefix in ("usb-", "pci-"):
         if filename.startswith(prefix):
-            filename = filename[len(prefix):]
+            filename = filename[len(prefix) :]
             break
 
     idx = filename.find("-video-index")

--- a/rayforge/image/assembler.py
+++ b/rayforge/image/assembler.py
@@ -268,9 +268,7 @@ class ItemAssembler:
             ):
                 setattr(step, "dot_width_correction_mm", dot_width)
             line_interval = settings.get("line_interval_mm")
-            if line_interval is not None and hasattr(
-                step, "line_interval_mm"
-            ):
+            if line_interval is not None and hasattr(step, "line_interval_mm"):
                 setattr(step, "line_interval_mm", line_interval)
             scan_angle = settings.get("scan_angle")
             if scan_angle is not None and hasattr(step, "scan_angle"):

--- a/rayforge/machine/device/profile.py
+++ b/rayforge/machine/device/profile.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import yaml
 
 from ...camera.models.camera import Camera
+from ...camera.v4l import migrate_camera_data
 from ...core.model import Model
 from ...machine.driver import get_driver_cls
 from ...machine.models.dialect import GcodeDialect
@@ -449,7 +450,7 @@ class DeviceProfile:
         m.cameras = []
         if cfg.cameras is not None:
             for cam_data in cfg.cameras:
-                m.add_camera(Camera.from_dict(cam_data))
+                m.add_camera(Camera.from_dict(migrate_camera_data(cam_data)))
 
         if cfg.heads is not None:
             for head in m.heads[:]:

--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -14,6 +14,7 @@ from raygeo.ops import Ops
 from raygeo.ops.axis import Axis
 
 from ...camera.models.camera import Camera
+from ...camera.v4l import migrate_camera_data
 from ...context import RayforgeContext, get_context
 from ...core.layer import Layer
 from ...core.model import Model
@@ -1771,7 +1772,7 @@ class Machine:
             ma.add_head(Laser.from_dict(obj))
         ma.cameras = []
         for obj in ma_data.get("cameras", {}):
-            ma.add_camera(Camera.from_dict(obj))
+            ma.add_camera(Camera.from_dict(migrate_camera_data(obj)))
         for obj in ma_data.get("rotary_modules", []):
             ma.add_rotary_module(RotaryModule.from_dict(obj))
         for obj in ma_data.get("nogo_zones", []):

--- a/rayforge/ui_gtk/camera/camera_preferences_page.py
+++ b/rayforge/ui_gtk/camera/camera_preferences_page.py
@@ -6,6 +6,7 @@ from gi.repository import Adw, Gtk
 
 from ...camera.controller import CameraController
 from ...camera.models.camera import Camera
+from ...camera.v4l import display_name
 from ..icons import get_icon
 from ..shared.preferences_group import PreferencesGroupWithButton
 from ..shared.preferences_page import TrackedPreferencesPage
@@ -65,14 +66,8 @@ class CameraRow(Gtk.Box):
 
     def _get_subtitle_text(self) -> str:
         """Generates the subtitle text from camera properties."""
-        device_id = self.camera.device_id
-        if device_id.startswith("/dev/v4l/by-id/"):
-            from ...camera.v4l import friendly_name_from_by_id
-
-            return friendly_name_from_by_id(device_id)
-        return _("Device ID: {device_id}").format(
-            device_id=device_id
-        )
+        name = display_name(self.camera.device_id)
+        return _("Device ID: {device_id}").format(device_id=name)
 
     def _on_remove_clicked(self, button: Gtk.Button):
         """Emits a signal requesting the removal of this camera."""

--- a/rayforge/ui_gtk/camera/camera_preferences_page.py
+++ b/rayforge/ui_gtk/camera/camera_preferences_page.py
@@ -65,8 +65,13 @@ class CameraRow(Gtk.Box):
 
     def _get_subtitle_text(self) -> str:
         """Generates the subtitle text from camera properties."""
+        device_id = self.camera.device_id
+        if device_id.startswith("/dev/v4l/by-id/"):
+            from ...camera.v4l import friendly_name_from_by_id
+
+            return friendly_name_from_by_id(device_id)
         return _("Device ID: {device_id}").format(
-            device_id=self.camera.device_id
+            device_id=device_id
         )
 
     def _on_remove_clicked(self, button: Gtk.Button):

--- a/rayforge/ui_gtk/camera/selection_dialog.py
+++ b/rayforge/ui_gtk/camera/selection_dialog.py
@@ -6,6 +6,7 @@ from gi.repository import Adw, GdkPixbuf, Gtk
 
 from ...camera.controller import CameraController
 from ...camera.models.camera import Camera
+from ...camera.v4l import display_name
 from ...context import get_context
 from ..shared.gtk import apply_css
 
@@ -159,10 +160,9 @@ class CameraSelectionDialog(Adw.MessageDialog):
         image_widget.set_margin_bottom(5)
 
         label_text = name
-        if not device_id.startswith("/dev/"):
-            label_text = _("{name} (Device ID: {device_id})").format(
-                name=name, device_id=device_id
-            )
+        dev_name = display_name(device_id)
+        if dev_name == device_id:
+            label_text = _("Camera {device_id}").format(device_id=device_id)
 
         label = Gtk.Label(label=label_text)
         label.set_halign(Gtk.Align.CENTER)
@@ -192,11 +192,7 @@ class CameraSelectionDialog(Adw.MessageDialog):
 
     @staticmethod
     def _get_display_name(device_id: str) -> str:
-        if device_id.startswith("/dev/v4l/by-id/"):
-            from ...camera.v4l import friendly_name_from_by_id
-
-            return friendly_name_from_by_id(device_id)
-        return _("Camera {device_id}").format(device_id=device_id)
+        return display_name(device_id)
 
     def list_available_cameras(self):
         self.available_devices = CameraController.list_available_devices()
@@ -206,8 +202,9 @@ class CameraSelectionDialog(Adw.MessageDialog):
             return
 
         for device_id in self.available_devices:
+            name = display_name(device_id)
             temp_config = Camera(
-                name=_("Camera {device_id}").format(device_id=device_id),
+                name=name,
                 device_id=device_id,
             )
             temp_controller = CameraController(temp_config)

--- a/rayforge/ui_gtk/camera/selection_dialog.py
+++ b/rayforge/ui_gtk/camera/selection_dialog.py
@@ -158,11 +158,13 @@ class CameraSelectionDialog(Adw.MessageDialog):
         image_widget.set_margin_top(10)
         image_widget.set_margin_bottom(5)
 
-        label = Gtk.Label(
-            label=_("{name} (Device ID: {device_id})").format(
+        label_text = name
+        if not device_id.startswith("/dev/"):
+            label_text = _("{name} (Device ID: {device_id})").format(
                 name=name, device_id=device_id
             )
-        )
+
+        label = Gtk.Label(label=label_text)
         label.set_halign(Gtk.Align.CENTER)
         label.set_valign(Gtk.Align.CENTER)
         label.set_margin_bottom(12)
@@ -187,6 +189,14 @@ class CameraSelectionDialog(Adw.MessageDialog):
         box.add_controller(motion_controller)
 
         self.carousel.append(box)
+
+    @staticmethod
+    def _get_display_name(device_id: str) -> str:
+        if device_id.startswith("/dev/v4l/by-id/"):
+            from ...camera.v4l import friendly_name_from_by_id
+
+            return friendly_name_from_by_id(device_id)
+        return _("Camera {device_id}").format(device_id=device_id)
 
     def list_available_cameras(self):
         self.available_devices = CameraController.list_available_devices()

--- a/rayforge/ui_gtk/machine/settings_dialog.py
+++ b/rayforge/ui_gtk/machine/settings_dialog.py
@@ -8,6 +8,7 @@ from gi.repository import Adw, Gdk, GLib, Gtk
 
 from ... import const
 from ...camera.models import Camera
+from ...camera.v4l import display_name
 from ...context import get_context
 from ...machine.driver import (
     DRIVER_MATURITY_LABELS,
@@ -381,7 +382,7 @@ class MachineSettingsDialog(PatchedDialogWindow):
             return  # Safety check
 
         new_camera = Camera(
-            _("Camera {device_id}").format(device_id=device_id),
+            display_name(device_id),
             device_id,
         )
         new_camera.enabled = True

--- a/tests/camera/test_v4l.py
+++ b/tests/camera/test_v4l.py
@@ -7,7 +7,9 @@ import pytest
 
 from rayforge.camera.v4l import (
     _is_video_capture_symlink,
+    display_name,
     friendly_name_from_by_id,
+    migrate_camera_data,
     resolve_device_id,
     scan_v4l_by_id,
 )
@@ -31,9 +33,7 @@ class TestIsVideoCaptureSymlink:
         )
 
     def test_plain_name(self):
-        assert not _is_video_capture_symlink(
-            "some_random_name"
-        )
+        assert not _is_video_capture_symlink("some_random_name")
 
 
 class TestFriendlyNameFromById:
@@ -68,7 +68,9 @@ class TestFriendlyNameFromById:
 
 
 class TestScanV4lById:
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="Linux only"
+    )
     def test_nonexistent_dir(self):
         with mock.patch(
             "rayforge.camera.v4l.V4L_BY_ID_DIR",
@@ -76,7 +78,9 @@ class TestScanV4lById:
         ):
             assert scan_v4l_by_id() == {}
 
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="Linux only"
+    )
     def test_empty_dir(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
@@ -100,10 +104,51 @@ class TestResolveDeviceId:
         with mock.patch("rayforge.camera.v4l.sys.platform", "linux"):
             assert resolve_device_id("some_string") == "some_string"
 
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="Linux only"
+    )
     def test_numeric_without_by_id_keeps_numeric(self):
         with mock.patch(
             "rayforge.camera.v4l.V4L_BY_ID_DIR",
             Path("/nonexistent_dir_for_testing"),
         ):
             assert resolve_device_id("5") == "5"
+
+
+class TestDisplayName:
+    def test_by_id_path_returns_friendly_name(self):
+        path = (
+            "/dev/v4l/by-id/usb-046d_Logitech_Webcam_C930e_1234-video-index0"
+        )
+        result = display_name(path)
+        assert result == "Logitech Webcam C930e"
+
+    def test_numeric_id_returns_as_is(self):
+        assert display_name("0") == "0"
+
+    def test_string_id_returns_as_is(self):
+        assert display_name("some_device") == "some_device"
+
+
+class TestMigrateCameraData:
+    def test_no_device_id_returns_unchanged(self):
+        data = {"name": "cam"}
+        assert migrate_camera_data(data) == {"name": "cam"}
+
+    def test_non_linux_returns_unchanged(self):
+        with mock.patch("rayforge.camera.v4l.sys.platform", "win32"):
+            data = {"name": "cam", "device_id": "0"}
+            result = migrate_camera_data(data)
+            assert result["device_id"] == "0"
+
+    def test_by_id_path_returns_unchanged(self):
+        path = "/dev/v4l/by-id/usb-Vendor_Product-video-index0"
+        data = {"name": "cam", "device_id": path}
+        result = migrate_camera_data(data)
+        assert result["device_id"] == path
+
+    def test_does_not_mutate_input(self):
+        data = {"name": "cam", "device_id": "0"}
+        with mock.patch("rayforge.camera.v4l.sys.platform", "win32"):
+            migrate_camera_data(data)
+        assert data["device_id"] == "0"

--- a/tests/camera/test_v4l.py
+++ b/tests/camera/test_v4l.py
@@ -1,0 +1,109 @@
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from rayforge.camera.v4l import (
+    _is_video_capture_symlink,
+    friendly_name_from_by_id,
+    resolve_device_id,
+    scan_v4l_by_id,
+)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+class TestIsVideoCaptureSymlink:
+    def test_video_index_entry(self):
+        assert _is_video_capture_symlink(
+            "usb-046d_Logitech_C930e_1234-video-index0"
+        )
+
+    def test_non_video_entry(self):
+        assert not _is_video_capture_symlink(
+            "usb-046d_Logitech_C930e_1234-input0"
+        )
+
+    def test_alt_entry(self):
+        assert not _is_video_capture_symlink(
+            "usb-046d_Logitech_C930e_1234-alt0"
+        )
+
+    def test_plain_name(self):
+        assert not _is_video_capture_symlink(
+            "some_random_name"
+        )
+
+
+class TestFriendlyNameFromById:
+    def test_usb_webcam_with_vendor_id(self):
+        path = (
+            "/dev/v4l/by-id/"
+            "usb-046d_Logitech_Webcam_C930e_1234567890"
+            "-video-index0"
+        )
+        assert friendly_name_from_by_id(path) == "Logitech Webcam C930e"
+
+    def test_usb_webcam_with_inc(self):
+        path = (
+            "/dev/v4l/by-id/"
+            "usb-1d6b_SunplusIT_Inc_Integrated_Camera_0001"
+            "-video-index0"
+        )
+        result = friendly_name_from_by_id(path)
+        assert result == "SunplusIT Inc Integrated Camera"
+
+    def test_pci_device(self):
+        path = "/dev/v4l/by-id/pci-Vendor_Product_123-video-index0"
+        assert friendly_name_from_by_id(path) == "Product"
+
+    def test_two_parts_vendor_and_serial(self):
+        path = "/dev/v4l/by-id/usb-046d_C930e_1234-video-index0"
+        assert friendly_name_from_by_id(path) == "C930e"
+
+    def test_single_part(self):
+        path = "/dev/v4l/by-id/usb-ProductName-video-index0"
+        assert friendly_name_from_by_id(path) == "ProductName"
+
+
+class TestScanV4lById:
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    def test_nonexistent_dir(self):
+        with mock.patch(
+            "rayforge.camera.v4l.V4L_BY_ID_DIR",
+            Path("/nonexistent_dir_for_testing"),
+        ):
+            assert scan_v4l_by_id() == {}
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "rayforge.camera.v4l.V4L_BY_ID_DIR",
+                Path(tmpdir),
+            ):
+                assert scan_v4l_by_id() == {}
+
+
+class TestResolveDeviceId:
+    def test_non_linux_returns_unchanged(self):
+        with mock.patch("rayforge.camera.v4l.sys.platform", "win32"):
+            assert resolve_device_id("0") == "0"
+
+    def test_by_id_path_returns_unchanged(self):
+        path = "/dev/v4l/by-id/usb-Vendor_Product-video-index0"
+        with mock.patch("rayforge.camera.v4l.sys.platform", "linux"):
+            assert resolve_device_id(path) == path
+
+    def test_string_id_returns_unchanged(self):
+        with mock.patch("rayforge.camera.v4l.sys.platform", "linux"):
+            assert resolve_device_id("some_string") == "some_string"
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+    def test_numeric_without_by_id_keeps_numeric(self):
+        with mock.patch(
+            "rayforge.camera.v4l.V4L_BY_ID_DIR",
+            Path("/nonexistent_dir_for_testing"),
+        ):
+            assert resolve_device_id("5") == "5"

--- a/tests/image/lightburn/test_lightburn_importer.py
+++ b/tests/image/lightburn/test_lightburn_importer.py
@@ -655,12 +655,8 @@ class TestApplySettingsDispatch:
                 self.min_power = 0.0
                 self.max_power = 1.0
 
-        monkeypatch.setitem(
-            step_registry._steps, "ContourStep", ContourStep
-        )
-        monkeypatch.setitem(
-            step_registry._steps, "EngraveStep", EngraveStep
-        )
+        monkeypatch.setitem(step_registry._steps, "ContourStep", ContourStep)
+        monkeypatch.setitem(step_registry._steps, "EngraveStep", EngraveStep)
         return ContourStep, EngraveStep
 
     def test_image_layer_creates_engrave_step(self, monkeypatch):


### PR DESCRIPTION
## Summary

On Linux, camera device numbers (`/dev/videoN`) are assigned by the kernel based on discovery order and can change between reboots. This caused Rayforge to connect to the wrong camera after a full shutdown when multiple cameras were connected.

The fix uses `/dev/v4l/by-id/` symlinks, which are based on persistent hardware identifiers (vendor, product, serial number) and do not change between reboots.

### Changes
- **New `rayforge/camera/v4l.py` module**: Scans `/dev/v4l/by-id/` for video capture symlinks, resolves numeric device IDs to persistent paths, and extracts human-readable camera names from by-id paths.
- **Camera scanning**: All three scanning paths (`list_available_devices`, `_scan_cameras_in_subprocess`, `_scan_cameras_fallback`) now use by-id paths on Linux, falling back to numeric indices when by-id is not available.
- **Config migration**: `Camera.from_dict()` automatically migrates old numeric device IDs (e.g. `"0"`) to persistent by-id paths when loading saved configurations on Linux.
- **UI improvements**: Camera selection dialog shows descriptive names (e.g. "Logitech Webcam C930e") instead of raw device paths. Camera preferences page shows the friendly name as subtitle.

### Backward compatibility
- If `/dev/v4l/by-id/` does not exist or has no entries, falls back to the original numeric scanning behavior.
- If a stored numeric device ID cannot be resolved (camera temporarily disconnected), the numeric ID is kept as-is.
- Non-Linux platforms are completely unaffected.

Closes #317