### PR TITLE
fix(mac): restore Monterey-compatible bundles

### DIFF
--- a/Rayforge.spec
+++ b/Rayforge.spec
@@ -76,5 +76,8 @@ app = BUNDLE(
     name='Rayforge.app',
     icon=_icon,
     bundle_identifier='org.rayforge.rayforge',
-    info_plist={'CFBundleIconName': 'rayforge'} if _use_car else {},
+    info_plist={
+        **({'CFBundleIconName': 'rayforge'} if _use_car else {}),
+        'LSMinimumSystemVersion': '12.0',
+    },
 )

--- a/rayforge/app.py
+++ b/rayforge/app.py
@@ -28,6 +28,7 @@ from rayforge.logging_setup import setup_logging
 # ===================================================================
 
 logger = logging.getLogger(__name__)
+_unhandled_exception = False
 
 
 # Suppress NumPy longdouble UserWarning when run under mingw on Windows
@@ -148,9 +149,13 @@ def handle_exception(exc_type, exc_value, exc_traceback):
     Catches unhandled exceptions, logs them, and shows a user-friendly dialog.
     This is crucial for --noconsole builds.
     """
+    global _unhandled_exception
+
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
         return
+
+    _unhandled_exception = True
 
     # Print full traceback to stderr (console or log)
     traceback.print_exception(exc_type, exc_value, exc_traceback)
@@ -167,6 +172,10 @@ def main():
     # This function contains all logic that should ONLY run in the
     # main process.
     # ===================================================================
+
+    global _unhandled_exception
+
+    _unhandled_exception = False
 
     # Set the global exception handler.
     sys.excepthook = handle_exception
@@ -563,6 +572,11 @@ def main():
     exit_code = app.run(None)
     logger.info("app.run() returned with exit_code=%s", exit_code)
     if app.win is None:
+        if _unhandled_exception:
+            logger.error(
+                "Application startup failed before creating a window."
+            )
+            return exit_code or 1
         logger.info(
             "No window created (another instance is likely running). Exiting."
         )

--- a/scripts/mac/mac_build.sh
+++ b/scripts/mac/mac_build.sh
@@ -6,8 +6,13 @@ DO_BUNDLE=0
 DO_DMG=0
 DO_RUN_APP=0
 VERSION_OVERRIDE=""
+MACOS_MIN_VERSION="12.0"
+MACOS_NUMPY_VERSION="1.26.4"
+MACOS_SCIPY_VERSION="1.11.4"
 GREEN="\033[0;32m"
 NC="\033[0m"
+
+export MACOSX_DEPLOYMENT_TARGET="$MACOS_MIN_VERSION"
 
 print_info() {
     local title=$1
@@ -110,29 +115,32 @@ VENV_PY="$VENV_PATH/bin/python"
 "$VENV_PY" -m pip install --upgrade pip
 "$VENV_PY" -m pip install --upgrade build pyinstaller
 TMP_REQUIREMENTS=$(mktemp)
+trap 'rm -f "$TMP_REQUIREMENTS" "$TMP_REQUIREMENTS.patched"' EXIT
 grep -Evi '^(PyOpenGL_accelerate|opencv[_-]python)' \
     requirements.txt > "$TMP_REQUIREMENTS"
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    awk '
+    awk \
+        -v numpy_version="$MACOS_NUMPY_VERSION" \
+        -v scipy_version="$MACOS_SCIPY_VERSION" '
         BEGIN { done_numpy = 0; done_scipy = 0 }
         /^numpy[=~><!]/ {
-            print "numpy==1.26.4"
+            print "numpy==" numpy_version
             done_numpy = 1
             next
         }
         /^scipy[=~><!]/ {
-            print "scipy==1.17.1"
+            print "scipy==" scipy_version
             done_scipy = 1
             next
         }
         { print }
         END {
             if (done_numpy == 0) {
-                print "numpy==1.26.4"
+                print "numpy==" numpy_version
             }
             if (done_scipy == 0) {
-                    print "scipy==1.17.1"
+                print "scipy==" scipy_version
             }
         }
     ' "$TMP_REQUIREMENTS" > "$TMP_REQUIREMENTS.patched"
@@ -148,11 +156,32 @@ fi
 "$VENV_PY" -m pip install -r "$TMP_REQUIREMENTS"
 if [ "$(uname -s)" = "Darwin" ]; then
     "$VENV_PY" -m pip install --upgrade --force-reinstall \
-        "numpy==1.26.4" "scipy==1.17.1"
+        --only-binary=:all: \
+        "numpy==$MACOS_NUMPY_VERSION" "scipy==$MACOS_SCIPY_VERSION"
 fi
 rm -f "$TMP_REQUIREMENTS"
+trap - EXIT
 "$VENV_PY" -m pip install PyOpenGL_accelerate==3.1.10 || \
     echo "PyOpenGL_accelerate install failed; continuing."
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    "$VENV_PY" - "$MACOS_NUMPY_VERSION" \
+        "$MACOS_SCIPY_VERSION" <<'PY'
+import sys
+
+import numpy
+import scipy
+from scipy.linalg import null_space
+from scipy.ndimage import binary_dilation
+from scipy.optimize import least_squares
+from scipy.signal import fftconvolve
+
+assert numpy.__version__ == sys.argv[1]
+assert scipy.__version__ == sys.argv[2]
+assert all((null_space, binary_dilation, least_squares, fftconvolve))
+print("Verified SciPy modules used by Rayforge.")
+PY
+fi
 
 bash scripts/update_translations.sh --compile-only
 
@@ -177,7 +206,7 @@ if (( DO_BUNDLE == 1 )); then
     print_info "  .app Bundle"
     print_info "--------------------------------------"
     echo ""
-    python - <<'PY'
+    "$VENV_PY" - <<'PY'
 import os
 import shutil
 import stat
@@ -201,13 +230,15 @@ PY
     ICON_SOURCE=""
     if [ -d "rayforge/resources/icons/rayforge.icon" ]; then
         echo "Compiling rayforge.icon → Assets.car..."
+        rm -f "Assets.car"
         if ! xcrun actool rayforge/resources/icons/rayforge.icon \
                 --compile "$(pwd)" \
                --app-icon rayforge \
                 --platform macosx \
                 --target-device mac \
-                --minimum-deployment-target 10.14 \
-            --output-partial-info-plist /dev/null; then
+                --minimum-deployment-target "$MACOS_MIN_VERSION" \
+            --output-partial-info-plist /dev/null || \
+            [ ! -f "Assets.car" ]; then
             echo "actool failed; falling back to .icns if available." >&2
             ICON_SOURCE="icns"
         else
@@ -440,12 +471,16 @@ SH
                     "$FW_DIR/$libname"
                 changed=1
             fi
-        done < <(otool -L "$BIN_DIR/Rayforge" "$FW_DIR"/*.dylib 2>/dev/null | \
+        done < <(otool -L "$BIN_DIR/Rayforge.bin" \
+            "$FW_DIR"/*.dylib 2>/dev/null | \
             awk '{print $1}' | \
             grep -E '^/usr/local/|^/opt/homebrew/|^@rpath/' | \
             sort -u || true)
 
-        return $changed
+        if (( changed == 1 )); then
+            return 0
+        fi
+        return 1
     }
 
     # Iteratively pull in any Homebrew deps referenced by bundled binaries.
@@ -524,7 +559,7 @@ SH
         for lib in libpng16.16.dylib libfontconfig.1.dylib \
             libfreetype.6.dylib libintl.8.dylib
         do
-            ln -sf ../"$lib" "$lib"
+            ln -sf ../../"$lib" "$lib"
         done
         popd >/dev/null
     fi


### PR DESCRIPTION
This PR restores macOS Monterey compatibility for Rayforge bundles and hardens the macOS packaging process.

## Root cause

SciPy was upgraded from 1.11.4 to 1.17.1 in the macOS bundle. Recent SciPy wheels use Apple's newer Accelerate LAPACK interface, which requires macOS 13.3 or later.

On macOS Monterey, Rayforge failed during startup with:

```text
Symbol not found: (_dstevr$NEWLAPACK)
Expected in: Accelerate.framework
```

The startup exception was swallowed by the GTK application loop, causing Rayforge to exit with code `0` and incorrectly report that another instance was probably running.

## Changes

- Restore the macOS bundle pins:
  - NumPy 1.26.4
  - SciPy 1.11.4
- Require binary NumPy and SciPy wheels during macOS builds.
- Verify the installed versions and import the SciPy modules used by Rayforge before packaging.
- Set `MACOSX_DEPLOYMENT_TARGET` and `LSMinimumSystemVersion` to macOS 12.0.
- Return a non-zero exit code when startup fails before creating a window.
- Avoid reporting startup failures as an already-running instance.
- Fix the iterative Homebrew dependency-copying loop.
- Inspect the actual Mach-O launcher instead of the shell wrapper.
- Fix incorrect relative symlinks for bundled OpenCV libraries.
- Detect when `actool` succeeds without producing `Assets.car`, as observed on Monterey, and fall back to the legacy `.icns` icon.
- Use the virtual environment's Python consistently during packaging.
- Clean temporary requirement files when the build fails.

## Validation

Tested locally with:

- macOS Monterey 12.7.6
- Intel `x86_64`
- Python 3.11.14
- Rayforge 1.9.0-beta1

## Apple Silicon

The packaging changes are shared by the Intel and Apple Silicon builds.

Local validation was performed on Intel Monterey. The ARM and universal bundles should also be verified by CI.