### PR TITLE
Fix ChArUco detection array shapes

### DIFF
--- a/rayforge/camera/calibration/charuco.py
+++ b/rayforge/camera/calibration/charuco.py
@@ -177,13 +177,24 @@ class CharucoBoard:
         if charuco_corners is None or charuco_ids is None:
             return None
 
-        if len(charuco_corners) < 4:
+        try:
+            corners_array = np.asarray(
+                charuco_corners, dtype=np.float32
+            ).reshape(-1, 2)
+            ids_array = np.asarray(charuco_ids).reshape(-1)
+        except (TypeError, ValueError) as error:
+            logger.debug("Invalid ChArUco detection result: %s", error)
             return None
 
-        corners = [
-            (float(pt[0][0]), float(pt[0][1])) for pt in charuco_corners
-        ]
-        ids = [int(i[0]) for i in charuco_ids]
+        if len(corners_array) < 4 or len(corners_array) != len(ids_array):
+            return None
+
+        try:
+            corners = [(float(x), float(y)) for x, y in corners_array]
+            ids = [int(value) for value in ids_array]
+        except (TypeError, ValueError, OverflowError) as error:
+            logger.debug("Invalid ChArUco detection result: %s", error)
+            return None
 
         return corners, ids
 

--- a/tests/camera/test_charuco.py
+++ b/tests/camera/test_charuco.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from rayforge.camera.calibration.charuco import CharucoBoard, CharucoConfig
+
+
+@pytest.fixture
+def image() -> np.ndarray:
+    return np.zeros((32, 32), dtype=np.uint8)
+
+
+def make_board(corners, ids) -> CharucoBoard:
+    board = CharucoBoard(CharucoConfig())
+    detector = Mock()
+    detector.detectBoard.return_value = (corners, ids, None, None)
+    board._detector = detector
+    return board
+
+
+@pytest.mark.parametrize("corner_shape", [(4, 1, 2), (4, 2)])
+@pytest.mark.parametrize("id_shape", [(4, 1), (4,)])
+def test_detect_accepts_common_opencv_shapes(image, corner_shape, id_shape):
+    corners = np.arange(8, dtype=np.float32).reshape(corner_shape)
+    ids = np.arange(4, dtype=np.int32).reshape(id_shape)
+
+    result = make_board(corners, ids).detect(image)
+
+    assert result == (
+        [(0.0, 1.0), (2.0, 3.0), (4.0, 5.0), (6.0, 7.0)],
+        [0, 1, 2, 3],
+    )
+
+
+@pytest.mark.parametrize(
+    ("corners", "ids"),
+    [
+        (None, None),
+        (
+            np.empty((0, 2), dtype=np.float32),
+            np.empty((0,), dtype=np.int32),
+        ),
+        (
+            np.arange(9, dtype=np.float32),
+            np.arange(4, dtype=np.int32),
+        ),
+        (
+            np.full((4, 2), "invalid"),
+            np.arange(4, dtype=np.int32),
+        ),
+        (
+            np.arange(8, dtype=np.float32).reshape(4, 2),
+            np.arange(3, dtype=np.int32),
+        ),
+    ],
+)
+def test_detect_rejects_empty_or_invalid_detections(image, corners, ids):
+    assert make_board(corners, ids).detect(image) is None
+
+
+def test_detect_requires_four_corners(image):
+    corners = np.arange(6, dtype=np.float32).reshape(3, 2)
+    ids = np.arange(3, dtype=np.int32)
+
+    assert make_board(corners, ids).detect(image) is None
+
+
+def test_detect_generated_board_with_installed_opencv():
+    board = CharucoBoard(CharucoConfig())
+    image = board.generate_image()
+
+    result = board.detect(image)
+
+    assert result is not None
+    corners, ids = result
+    assert len(corners) >= 4
+    assert len(corners) == len(ids)


### PR DESCRIPTION
## Summary

- normalize ChArUco corner arrays to `(N, 2)` and ID arrays to `(N,)`
- support both singleton-dimension and flat OpenCV return shapes
- reject malformed, mismatched, empty, or insufficient detections
- add regression tests for both shape families and installed OpenCV behavior

## Problem

OpenCV 5 can return ChArUco corners as `(N, 2)` and IDs as `(N,)`.
The previous code indexed every corner as `pt[0][0]` and every ID as
`i[0]`, which raises `IndexError: invalid index to scalar variable` for
those flat shapes. This repeatedly crashes the Lens Calibration preview
and prevents Capture Frame from working.

## Verification

- `pixi run format`
- `pixi run lint` — 0 errors, 0 warnings
- `pixi run test -- -q` — 4913 passed, 2 skipped, 148 deselected
- `pixi run wheel` — wheel and sdist built successfully

Real-camera verification used the project Pixi environment with OpenCV
5.0.0 and an OBSBOT Tiny 4K:

- live result shapes were corners `(24, 2)`, IDs `(24,)`
- calibration preview displayed 24 detected corners
- five Capture Frame activations incremented the frame count to 5
- calibration became available and completed with five frames
