### PR TITLE
Add CNC Essentials addon with milling steps

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/__init__.py
@@ -1,0 +1,5 @@
+"""
+CNC Essentials addon.
+
+Provides step classes and UI for CNC machining operations.
+"""

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/commands/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/commands/__init__.py
@@ -1,0 +1,3 @@
+"""
+CNC Commands (planned for Phase 5).
+"""

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/commands/generate_plan_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/commands/generate_plan_cmd.py
@@ -1,0 +1,3 @@
+"""
+Auto-plan command (planned for Phase 5).
+"""

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/frontend.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/frontend.py
@@ -1,0 +1,20 @@
+"""
+Frontend entry point for cnc-essentials addon.
+
+Registers UI widgets with the main application.
+"""
+
+from rayforge.core.hooks import hookimpl
+
+from .widgets import ASSEMBLER_WIDGETS
+
+ADDON_NAME = "cnc_essentials"
+
+
+@hookimpl
+def register_step_settings_pages(step_settings_page_registry):
+    """Register step settings page classes based on assembler name."""
+    for assembler_name, page_cls in ASSEMBLER_WIDGETS.items():
+        step_settings_page_registry.register(
+            assembler_name, page_cls, ADDON_NAME
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/__init__.py
@@ -1,0 +1,27 @@
+"""
+CNC steps.
+
+Provides step implementations for CNC milling operations.
+"""
+
+from .adaptive_clearing_step import AdaptiveClearStep
+from .cnc_assembler_step import CncAssemblerStep
+from .flat_spiral_step import FlatSpiralStep
+from .helix_plunge_step import HelixPlungeStep
+from .profile_inner_step import ProfileInnerStep
+from .profile_outer_step import ProfileOuterStep
+from .ramp_entry_step import RampEntryStep
+from .slot_step import SlotStep
+from .toroidal_clear_step import ToroidalClearStep
+
+__all__ = [
+    "AdaptiveClearStep",
+    "CncAssemblerStep",
+    "FlatSpiralStep",
+    "HelixPlungeStep",
+    "ProfileInnerStep",
+    "ProfileOuterStep",
+    "RampEntryStep",
+    "SlotStep",
+    "ToroidalClearStep",
+]

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/adaptive_clearing_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/adaptive_clearing_step.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any, cast
+
+from raygeo.cnc.execution.specs import ComputePayload
+from raygeo.ops.assembly.adaptive import AdaptiveClearingSpec
+from raygeo.ops.part import Part
+
+from rayforge.core.varset import FloatVar, LengthVar, VarSet
+
+from .cnc_assembler_step import CncAssemblerStep
+
+if TYPE_CHECKING:
+    from rayforge.core.workpiece import WorkPiece
+    from rayforge.machine.models.machine import Machine
+
+
+class AdaptiveClearStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "adaptive_clearing"  # matches PlanStep.kind
+    TYPELABEL = _("Adaptive Clear")
+    uses_global_state = True  # consumes predecessor cleared-area
+
+    @classmethod
+    def recipe_varset(cls) -> VarSet:
+        return VarSet(
+            vars=[
+                *CncAssemblerStep.recipe_varset().vars,
+                LengthVar(
+                    key="step_over",
+                    label=_("Step Over"),
+                    default=2.0,
+                    min_val=0.1,
+                ),
+                LengthVar(
+                    key="step_length",
+                    label=_("Step Length"),
+                    default=0.6,
+                    min_val=0.1,
+                ),
+                FloatVar(
+                    key="max_deflection_deg",
+                    label=_("Max Deflection"),
+                    default=30.0,
+                    min_val=0.0,
+                    max_val=90.0,
+                ),
+                LengthVar(
+                    key="wall_margin",
+                    label=_("Wall Margin"),
+                    default=0.0,
+                    min_val=0.0,
+                ),
+                FloatVar(
+                    key="area_tolerance",
+                    label=_("Area Tolerance"),
+                    default=1.0,
+                    min_val=0.0,
+                ),
+            ]
+        )
+
+    def __init__(self, name=None, typelabel=None):
+        super().__init__(name=name, typelabel=typelabel)
+        self.step_over: float = 2.0
+        self.step_length: float = 0.6
+        self.max_deflection_deg: float = 30.0
+        self.wall_margin: float = 0.0
+        self.area_tolerance: float = 1.0
+
+    def build_spec(self, workpiece) -> AdaptiveClearingSpec:
+        return AdaptiveClearingSpec(
+            tool_radius=self.tool_diameter / 2,
+            step_over=self.step_over,
+            step_length=self.step_length,
+            target_z=self.target_depth,
+            safe_z=self.safe_z,
+            max_deflection_deg=self.max_deflection_deg,
+            wall_margin=self.wall_margin,
+            area_tolerance=self.area_tolerance,
+        )
+
+    def build_compute_payload(
+        self,
+        machine: Machine,
+        workpiece: WorkPiece,
+    ) -> tuple[Part, ComputePayload]:
+        # Multi-pocket handling is done on the Rust side:
+        # Part.from_geometry_multi_face exposes each pocket as a face,
+        # the compute stage iterates them, and AdaptiveClearingSpec
+        # splits each pocket into regions via find_regions.  No
+        # Python-side seeding needed.
+        return super().build_compute_payload(machine, workpiece)
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        params = super().assembler_token_params(machine, workpiece)
+        params.update(
+            {
+                "step_over": self.step_over,
+                "step_length": self.step_length,
+                "max_deflection_deg": self.max_deflection_deg,
+                "wall_margin": self.wall_margin,
+                "area_tolerance": self.area_tolerance,
+            }
+        )
+        return params
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result.update(
+            {
+                "step_over": self.step_over,
+                "step_length": self.step_length,
+                "max_deflection_deg": self.max_deflection_deg,
+                "wall_margin": self.wall_margin,
+                "area_tolerance": self.area_tolerance,
+            }
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, data) -> AdaptiveClearStep:
+        step = cast("AdaptiveClearStep", super().from_dict(data))
+        step.step_over = data.get("step_over", step.step_over)
+        step.step_length = data.get("step_length", step.step_length)
+        step.max_deflection_deg = data.get(
+            "max_deflection_deg", step.max_deflection_deg
+        )
+        step.wall_margin = data.get("wall_margin", step.wall_margin)
+        step.area_tolerance = data.get("area_tolerance", step.area_tolerance)
+        return step
+
+    @classmethod
+    def _serialized_keys(cls) -> frozenset[str]:
+        return super()._serialized_keys() | frozenset(
+            {
+                "step_over",
+                "step_length",
+                "max_deflection_deg",
+                "wall_margin",
+                "area_tolerance",
+            }
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/cnc_assembler_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/cnc_assembler_step.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from raygeo.cnc.execution.specs import ComputePayload
+from raygeo.ops.assembly import Assembler
+from raygeo.ops.part import Part
+
+from rayforge.core.capability import MachineCapability
+from rayforge.core.step import Step
+from rayforge.core.varset import IntVar, LengthVar, SpeedVar, VarSet
+from rayforge.machine.models.spindle import SpindleHead
+
+if TYPE_CHECKING:
+    from rayforge.context import RayforgeContext
+    from rayforge.core.workpiece import WorkPiece
+    from rayforge.machine.models.machine import Machine
+
+
+class CncAssemblerStep(Step):
+    """Base class for CNC assembler-driven steps.
+
+    Subclasses set ``ASSEMBLER_NAME`` and override
+    ``build_spec`` to construct the matching raygeo spec.
+    """
+
+    REQUIRED_MACHINE_CAPS = frozenset({MachineCapability.MILL})
+    TYPELABEL = "CNC Step"
+
+    @property
+    def show_general_settings(self) -> bool:
+        return False
+
+    # Phase 3 turns this on for steps that consume predecessor state.
+    uses_global_state: ClassVar[bool] = False
+
+    def __init__(self, name=None, typelabel=None):
+        self.tool_diameter: float = 6.0
+        self.spindle_rpm: int = 12000
+        self.plunge_speed: int = 200
+        self.target_depth: float = -5.0
+        self.depth_per_pass: float = 1.0
+        self.safe_z: float = 2.0
+        super().__init__(typelabel=typelabel or self.TYPELABEL, name=name)
+
+    @classmethod
+    def create(
+        cls,
+        context: RayforgeContext,
+        name=None,
+        **kwargs,
+    ) -> CncAssemblerStep:
+        machine = context.machine
+        step = cls(name=name)
+        step.per_workpiece_transformers_dicts = []
+        step.per_step_transformers_dicts = []
+        if machine is not None:
+            default_head = machine.get_default_head()
+            step.selected_head_uid = default_head.uid
+            step.max_cut_speed = machine.max_cut_speed
+            step.max_travel_speed = machine.max_travel_speed
+        else:
+            step.selected_head_uid = None
+        return step
+
+    def set_tool_diameter(self, diameter: float):
+        if self.tool_diameter != diameter:
+            self.tool_diameter = float(diameter)
+            self.updated.send(self)
+
+    def set_spindle_rpm(self, rpm: int):
+        if self.spindle_rpm != rpm:
+            self.spindle_rpm = int(rpm)
+            self.updated.send(self)
+
+    def set_plunge_speed(self, speed: int):
+        if self.plunge_speed != speed:
+            self.plunge_speed = int(speed)
+            self.updated.send(self)
+
+    def set_target_depth(self, depth: float):
+        if self.target_depth != depth:
+            self.target_depth = float(depth)
+            self.updated.send(self)
+
+    def set_depth_per_pass(self, depth: float):
+        if self.depth_per_pass != depth:
+            self.depth_per_pass = float(depth)
+            self.updated.send(self)
+
+    def set_safe_z(self, z: float):
+        if self.safe_z != z:
+            self.safe_z = float(z)
+            self.updated.send(self)
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result.update(
+            {
+                "tool_diameter": self.tool_diameter,
+                "spindle_rpm": self.spindle_rpm,
+                "plunge_speed": self.plunge_speed,
+                "target_depth": self.target_depth,
+                "depth_per_pass": self.depth_per_pass,
+                "safe_z": self.safe_z,
+            }
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CncAssemblerStep:
+        step = cast("CncAssemblerStep", super().from_dict(data))
+        step.tool_diameter = data.get("tool_diameter", step.tool_diameter)
+        step.spindle_rpm = data.get("spindle_rpm", step.spindle_rpm)
+        step.plunge_speed = data.get("plunge_speed", step.plunge_speed)
+        step.target_depth = data.get("target_depth", step.target_depth)
+        step.depth_per_pass = data.get("depth_per_pass", step.depth_per_pass)
+        step.safe_z = data.get("safe_z", step.safe_z)
+        return step
+
+    @classmethod
+    def _serialized_keys(cls) -> frozenset[str]:
+        return super()._serialized_keys() | frozenset(
+            {
+                "tool_diameter",
+                "spindle_rpm",
+                "plunge_speed",
+                "target_depth",
+                "depth_per_pass",
+                "safe_z",
+            }
+        )
+
+    @classmethod
+    def recipe_varset(cls) -> VarSet:
+        return VarSet(
+            vars=[
+                LengthVar(
+                    key="tool_diameter",
+                    label=_("Tool Diameter"),
+                    default=6.0,
+                    min_val=0.1,
+                    max_val=50.0,
+                ),
+                IntVar(
+                    key="spindle_rpm",
+                    label=_("Spindle RPM"),
+                    default=12000,
+                    min_val=100,
+                    max_val=60000,
+                ),
+                *Step.recipe_varset().vars,
+                SpeedVar(
+                    key="plunge_speed",
+                    label=_("Plunge Rate"),
+                    default=200,
+                    min_val=1,
+                    role="cut",
+                ),
+                LengthVar(
+                    key="target_depth",
+                    label=_("Target Depth"),
+                    default=-5.0,
+                    min_val=-50.0,
+                    max_val=0.0,
+                ),
+                LengthVar(
+                    key="depth_per_pass",
+                    label=_("Depth per Pass"),
+                    default=1.0,
+                    min_val=0.1,
+                    max_val=10.0,
+                ),
+                LengthVar(
+                    key="safe_z",
+                    label=_("Safe Z Height"),
+                    default=2.0,
+                    min_val=0.0,
+                    max_val=50.0,
+                ),
+            ]
+        )
+
+    @classmethod
+    def recipe_varset_groups(cls) -> list[tuple[str, VarSet]]:
+        full = cls.recipe_varset()
+        base_keys = {v.key for v in CncAssemblerStep.recipe_varset()}
+        cnc_vars = [v for v in full if v.key in base_keys]
+        step_vars = [v for v in full if v.key not in base_keys]
+        groups: list[tuple[str, VarSet]] = []
+        if cnc_vars:
+            groups.append((_("CNC"), VarSet(vars=cnc_vars)))
+        if step_vars:
+            groups.append((_("Step Settings"), VarSet(vars=step_vars)))
+        return groups or [(_("CNC"), VarSet(vars=cnc_vars))]
+
+    def build_spec(self, workpiece: WorkPiece) -> object:
+        """Return the raygeo assembler spec for this step.
+
+        Subclasses must override.
+        """
+        raise NotImplementedError
+
+    def populate_payload(self, payload, machine: Machine):
+        super().populate_payload(payload, machine)
+        # The renderer colours ops by power and treats zero as a "no cut"
+        # state. Express the spindle's power level as the fraction of its
+        # max RPM so a running spindle renders as a cut at the right intensity.
+        payload.power = self._spindle_power_fraction(machine)
+
+    def _spindle_power_fraction(self, machine: Machine) -> float:
+        """CNC power level in ``[0, 1]`` from the spindle's RPM ratio."""
+        head = self.get_selected_head(machine)
+        if isinstance(head, SpindleHead):
+            return min(1.0, self.spindle_rpm / head.max_rpm)
+        return 1.0
+
+    def build_compute_payload(
+        self,
+        machine: Machine,
+        workpiece: WorkPiece,
+    ) -> tuple[Part, ComputePayload]:
+        part = workpiece.to_part()
+        if part is None:
+            part = Part(size_mm=workpiece.size)
+        spec = self.build_spec(workpiece)
+        return part, ComputePayload(
+            assembler=Assembler(spec),
+            cut_speed=self.cut_speed,
+        )
+
+    def assembler_token_params(
+        self,
+        machine: Machine,
+        workpiece: WorkPiece,
+    ) -> dict[str, Any]:
+        """Return a JSON-serialisable view of ``build_spec``'s params.
+
+        Default implementation reflects the common CNC attributes;
+        subclasses extend it with their own.
+        """
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+            "depth_per_pass": self.depth_per_pass,
+            "safe_z": self.safe_z,
+        }

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/flat_spiral_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/flat_spiral_step.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Any
+
+from raygeo.ops.assembly.spiral import SpiralSpec
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class FlatSpiralStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "spiral"
+    TYPELABEL = _("Flat Spiral")
+
+    def build_spec(self, workpiece) -> SpiralSpec:
+        part = workpiece.to_part()
+        if part is not None:
+            sr = part.stock_region
+            cx = sum(p[0] for p in sr.boundary) / len(sr.boundary)
+            cy = sum(p[1] for p in sr.boundary) / len(sr.boundary)
+            max_r = max(
+                ((p[0] - cx) ** 2 + (p[1] - cy) ** 2) ** 0.5
+                for p in sr.boundary
+            )
+        else:
+            cx = workpiece.size[0] / 2.0
+            cy = workpiece.size[1] / 2.0
+            max_r = min(cx, cy) * 0.8
+        return SpiralSpec(
+            center=(cx, cy),
+            z=self.target_depth,
+            start_radius=self.tool_diameter / 2.0 * 1.5,
+            end_radius=max_r * 0.9,
+            revolutions=3.0,
+        )
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+        }

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/helix_plunge_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/helix_plunge_step.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Any
+
+from raygeo.ops.assembly.helix import HelixSpec
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class HelixPlungeStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "helix"
+    TYPELABEL = _("Helix Plunge")
+
+    def build_spec(self, workpiece) -> HelixSpec:
+        part = workpiece.to_part()
+        if part is not None:
+            sr = part.stock_region
+            cx = sum(p[0] for p in sr.boundary) / len(sr.boundary)
+            cy = sum(p[1] for p in sr.boundary) / len(sr.boundary)
+        else:
+            cx = workpiece.size[0] / 2.0
+            cy = workpiece.size[1] / 2.0
+        return HelixSpec(
+            center=(cx, cy),
+            start_radius=self.tool_diameter / 2.0 * 1.5,
+            z_start=0.0,
+            z_end=self.target_depth,
+            pitch=abs(self.target_depth / max(self.depth_per_pass, 0.1)),
+        )
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+            "depth_per_pass": self.depth_per_pass,
+        }

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/profile_inner_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/profile_inner_step.py
@@ -1,0 +1,86 @@
+from gettext import gettext as _
+from typing import Any, cast
+
+from raygeo.ops.assembly.profile import ProfileSpec
+
+from rayforge.core.varset import LengthVar, VarSet
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class ProfileInnerStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "profile_inner"
+    TYPELABEL = _("Profile Inner")
+    uses_global_state = True
+
+    @classmethod
+    def recipe_varset(cls) -> VarSet:
+        return VarSet(
+            vars=[
+                *CncAssemblerStep.recipe_varset().vars,
+                LengthVar(
+                    key="step_over",
+                    label=_("Step Over"),
+                    default=2.0,
+                    min_val=0.1,
+                ),
+                LengthVar(
+                    key="step_length",
+                    label=_("Step Length"),
+                    default=0.6,
+                    min_val=0.1,
+                ),
+                LengthVar(
+                    key="wall_margin",
+                    label=_("Wall Margin"),
+                    default=0.0,
+                    min_val=0.0,
+                ),
+            ]
+        )
+
+    def __init__(self, name=None, typelabel=None):
+        super().__init__(name=name, typelabel=typelabel)
+        self.step_over: float = 2.0
+        self.step_length: float = 0.6
+        self.wall_margin: float = 0.0
+
+    def build_spec(self, workpiece) -> ProfileSpec:
+        return ProfileSpec(
+            kind="inner",
+            tool_radius=self.tool_diameter / 2.0,
+            step_over=self.step_over,
+            step_length=self.step_length,
+            target_z=self.target_depth,
+            safe_z=self.safe_z,
+            wall_margin=self.wall_margin,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result.update(
+            {
+                "step_over": self.step_over,
+                "step_length": self.step_length,
+                "wall_margin": self.wall_margin,
+            }
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, data) -> "ProfileInnerStep":
+        step = cast("ProfileInnerStep", super().from_dict(data))
+        step.step_over = data.get("step_over", step.step_over)
+        step.step_length = data.get("step_length", step.step_length)
+        step.wall_margin = data.get("wall_margin", step.wall_margin)
+        return step
+
+    @classmethod
+    def _serialized_keys(cls) -> frozenset[str]:
+        return super()._serialized_keys() | frozenset(
+            {
+                "step_over",
+                "step_length",
+                "wall_margin",
+            }
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/profile_outer_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/profile_outer_step.py
@@ -1,0 +1,86 @@
+from gettext import gettext as _
+from typing import Any, cast
+
+from raygeo.ops.assembly.profile import ProfileSpec
+
+from rayforge.core.varset import LengthVar, VarSet
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class ProfileOuterStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "profile_outer"
+    TYPELABEL = _("Profile Outer")
+    uses_global_state = True
+
+    @classmethod
+    def recipe_varset(cls) -> VarSet:
+        return VarSet(
+            vars=[
+                *CncAssemblerStep.recipe_varset().vars,
+                LengthVar(
+                    key="step_over",
+                    label=_("Step Over"),
+                    default=2.0,
+                    min_val=0.1,
+                ),
+                LengthVar(
+                    key="step_length",
+                    label=_("Step Length"),
+                    default=0.6,
+                    min_val=0.1,
+                ),
+                LengthVar(
+                    key="wall_margin",
+                    label=_("Wall Margin"),
+                    default=0.0,
+                    min_val=0.0,
+                ),
+            ]
+        )
+
+    def __init__(self, name=None, typelabel=None):
+        super().__init__(name=name, typelabel=typelabel)
+        self.step_over: float = 2.0
+        self.step_length: float = 0.6
+        self.wall_margin: float = 0.0
+
+    def build_spec(self, workpiece) -> ProfileSpec:
+        return ProfileSpec(
+            kind="outer",
+            tool_radius=self.tool_diameter / 2.0,
+            step_over=self.step_over,
+            step_length=self.step_length,
+            target_z=self.target_depth,
+            safe_z=self.safe_z,
+            wall_margin=self.wall_margin,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result.update(
+            {
+                "step_over": self.step_over,
+                "step_length": self.step_length,
+                "wall_margin": self.wall_margin,
+            }
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, data) -> "ProfileOuterStep":
+        step = cast("ProfileOuterStep", super().from_dict(data))
+        step.step_over = data.get("step_over", step.step_over)
+        step.step_length = data.get("step_length", step.step_length)
+        step.wall_margin = data.get("wall_margin", step.wall_margin)
+        return step
+
+    @classmethod
+    def _serialized_keys(cls) -> frozenset[str]:
+        return super()._serialized_keys() | frozenset(
+            {
+                "step_over",
+                "step_length",
+                "wall_margin",
+            }
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/ramp_entry_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/ramp_entry_step.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Any
+
+from raygeo.ops.assembly.ramp import RampSpec
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class RampEntryStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "ramp"
+    TYPELABEL = _("Ramp Entry")
+
+    def build_spec(self, workpiece) -> RampSpec:
+        part = workpiece.to_part()
+        if part is not None:
+            sr = part.stock_region
+            cx = sum(p[0] for p in sr.boundary) / len(sr.boundary)
+            cy = sum(p[1] for p in sr.boundary) / len(sr.boundary)
+        else:
+            cx = workpiece.size[0] / 2.0
+            cy = workpiece.size[1] / 2.0
+        r = self.tool_diameter / 2.0
+        return RampSpec(
+            start=(cx - r, cy),
+            end=(cx + r, cy),
+            z_start=0.0,
+            z_end=self.target_depth,
+        )
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+        }

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/slot_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/slot_step.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Any
+
+from raygeo.ops.assembly.slot import SlotSpec
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class SlotStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "slot"
+    TYPELABEL = _("Slot")
+
+    def build_spec(self, workpiece) -> SlotSpec:
+        part = workpiece.to_part()
+        if part is not None:
+            sr = part.stock_region
+            cx = sum(p[0] for p in sr.boundary) / len(sr.boundary)
+            cy = sum(p[1] for p in sr.boundary) / len(sr.boundary)
+        else:
+            cx = workpiece.size[0] / 2.0
+            cy = workpiece.size[1] / 2.0
+        half_len = self.tool_diameter * 2
+        return SlotSpec(
+            carrier=[(cx - half_len, cy), (cx + half_len, cy)],
+            tool_radius=self.tool_diameter / 2.0,
+            target_z=self.target_depth,
+        )
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+        }

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/toroidal_clear_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/toroidal_clear_step.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Any, cast
+
+from raygeo.ops.assembly.toroid import ToroidalClearSpec
+
+from rayforge.core.varset import LengthVar, VarSet
+
+from .cnc_assembler_step import CncAssemblerStep
+
+
+class ToroidalClearStep(CncAssemblerStep):
+    ASSEMBLER_NAME = "toroidal_clear"
+    TYPELABEL = _("Toroidal Clear")
+    uses_global_state = True
+
+    @classmethod
+    def recipe_varset(cls) -> VarSet:
+        return VarSet(
+            vars=[
+                *CncAssemblerStep.recipe_varset().vars,
+                LengthVar(
+                    key="step_over",
+                    label=_("Step Over"),
+                    default=2.0,
+                    min_val=0.1,
+                ),
+            ]
+        )
+
+    def __init__(self, name=None, typelabel=None):
+        super().__init__(name=name, typelabel=typelabel)
+        self.step_over: float = 2.0
+
+    def build_spec(self, workpiece) -> ToroidalClearSpec:
+        part = workpiece.to_part()
+        if part is not None:
+            sr = part.stock_region
+            cx = sum(p[0] for p in sr.boundary) / len(sr.boundary)
+            cy = sum(p[1] for p in sr.boundary) / len(sr.boundary)
+        else:
+            cx = workpiece.size[0] / 2.0
+            cy = workpiece.size[1] / 2.0
+        r = self.tool_diameter / 2.0 * 1.5
+        carrier = [(cx, cy), (cx + self.step_over * 2, cy)]
+        return ToroidalClearSpec(
+            carrier=carrier,
+            start=(cx, cy, 0.0),
+            target_z=self.target_depth,
+            tool_radius=r,
+            step_over=self.step_over,
+        )
+
+    def assembler_token_params(self, machine, workpiece) -> dict[str, Any]:
+        return {
+            "tool_diameter": self.tool_diameter,
+            "target_depth": self.target_depth,
+            "depth_per_pass": self.depth_per_pass,
+            "step_over": self.step_over,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result["step_over"] = self.step_over
+        return result
+
+    @classmethod
+    def from_dict(cls, data) -> ToroidalClearStep:
+        step = cast("ToroidalClearStep", super().from_dict(data))
+        step.step_over = data.get("step_over", step.step_over)
+        return step
+
+    @classmethod
+    def _serialized_keys(cls) -> frozenset[str]:
+        return super()._serialized_keys() | frozenset({"step_over"})

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/__init__.py
@@ -1,0 +1,33 @@
+"""
+CNC Essentials UI Widgets.
+"""
+
+from .pages import (
+    AdaptiveClearPage,
+    HelixPlungePage,
+    ProfileInnerPage,
+    ProfileOuterPage,
+    SlotPage,
+    ToroidalClearPage,
+)
+
+ASSEMBLER_WIDGETS = {
+    "adaptive_clearing": AdaptiveClearPage,
+    "helix": HelixPlungePage,
+    "spiral": HelixPlungePage,
+    "ramp": HelixPlungePage,
+    "toroidal_clear": ToroidalClearPage,
+    "slot": SlotPage,
+    "profile_inner": ProfileInnerPage,
+    "profile_outer": ProfileOuterPage,
+}
+
+__all__ = [
+    "ASSEMBLER_WIDGETS",
+    "AdaptiveClearPage",
+    "HelixPlungePage",
+    "ProfileInnerPage",
+    "ProfileOuterPage",
+    "SlotPage",
+    "ToroidalClearPage",
+]

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/__init__.py
@@ -1,0 +1,19 @@
+"""CNC step settings pages."""
+
+from .adaptive_clear_page import AdaptiveClearPage
+from .cnc_step_page import CncStepSettingsPage
+from .helix_plunge_page import HelixPlungePage
+from .profile_inner_page import ProfileInnerPage
+from .profile_outer_page import ProfileOuterPage
+from .slot_page import SlotPage
+from .toroidal_clear_page import ToroidalClearPage
+
+__all__ = [
+    "AdaptiveClearPage",
+    "CncStepSettingsPage",
+    "HelixPlungePage",
+    "ProfileInnerPage",
+    "ProfileOuterPage",
+    "SlotPage",
+    "ToroidalClearPage",
+]

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/adaptive_clear_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/adaptive_clear_page.py
@@ -1,0 +1,34 @@
+"""Adaptive clearing step settings page."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..rows import (
+    AreaToleranceRow,
+    MaxDeflectionRow,
+    StepLengthRow,
+    StepOverRow,
+    WallMarginRow,
+)
+from .cnc_step_page import CncStepSettingsPage
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class AdaptiveClearPage(CncStepSettingsPage):
+    """Settings page for the adaptive clearing step."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(editor, step)
+        self.add_section(
+            _("Adaptive Clearing"),
+            StepOverRow,
+            StepLengthRow,
+            MaxDeflectionRow,
+            WallMarginRow,
+            AreaToleranceRow,
+            description=_("Rough out a pocket with adaptive passes."),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/cnc_step_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/cnc_step_page.py
@@ -1,0 +1,53 @@
+"""CNC step settings widget base."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.pages import StepSettingsPage
+from rayforge.ui_gtk.doceditor.step_settings.rows import (
+    CutSpeedRow,
+    TravelSpeedRow,
+)
+
+from ..rows.depth_per_pass_row import DepthPerPassRow
+from ..rows.plunge_speed_row import PlungeSpeedRow
+from ..rows.safe_z_row import SafeZRow
+from ..rows.spindle_rpm_row import SpindleRpmRow
+from ..rows.target_depth_row import TargetDepthRow
+from ..rows.tool_diameter_row import ToolDiameterRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class CncStepSettingsPage(StepSettingsPage):
+    """Base page for CNC step settings.
+
+    Adds the common CNC sections (spindle, depth, feed). Subclasses
+    add their step-specific sections.
+    """
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(editor, step)
+        self.add_section(
+            _("Spindle"),
+            SpindleRpmRow,
+            ToolDiameterRow,
+            description=_("Spindle speed and tool geometry."),
+        )
+        self.add_section(
+            _("Depth"),
+            TargetDepthRow,
+            DepthPerPassRow,
+            SafeZRow,
+            description=_("Cut depth, depth per pass, and safe height."),
+        )
+        self.add_section(
+            _("Feed"),
+            CutSpeedRow(editor, step, title=_("Feed Rate")),
+            TravelSpeedRow,
+            PlungeSpeedRow,
+            description=_("Cutting, plunging, and travel feed rates."),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/helix_plunge_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/helix_plunge_page.py
@@ -1,0 +1,10 @@
+"""Helix/ramp/spiral step settings page."""
+
+from .cnc_step_page import CncStepSettingsPage
+
+
+class HelixPlungePage(CncStepSettingsPage):
+    """Settings page for helix/ramp/spiral steps.
+
+    All parameters live on the common CNC sections; no extra rows.
+    """

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/profile_inner_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/profile_inner_page.py
@@ -1,0 +1,26 @@
+"""Inner profiling step settings page."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..rows import StepLengthRow, StepOverRow, WallMarginRow
+from .cnc_step_page import CncStepSettingsPage
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class ProfileInnerPage(CncStepSettingsPage):
+    """Settings page for the inner profiling step."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(editor, step)
+        self.add_section(
+            _("Profiling"),
+            StepOverRow,
+            StepLengthRow,
+            WallMarginRow,
+            description=_("Cut the interior profile of the workpiece."),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/profile_outer_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/profile_outer_page.py
@@ -1,0 +1,26 @@
+"""Outer profiling step settings page."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..rows import StepLengthRow, StepOverRow, WallMarginRow
+from .cnc_step_page import CncStepSettingsPage
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class ProfileOuterPage(CncStepSettingsPage):
+    """Settings page for the outer profiling step."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(editor, step)
+        self.add_section(
+            _("Profiling"),
+            StepOverRow,
+            StepLengthRow,
+            WallMarginRow,
+            description=_("Cut the exterior profile of the workpiece."),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/slot_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/slot_page.py
@@ -1,0 +1,10 @@
+"""Slot step settings page."""
+
+from .cnc_step_page import CncStepSettingsPage
+
+
+class SlotPage(CncStepSettingsPage):
+    """Settings page for the slot step.
+
+    All parameters live on the common CNC sections; no extra rows.
+    """

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/toroidal_clear_page.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/pages/toroidal_clear_page.py
@@ -1,0 +1,24 @@
+"""Toroidal clearing step settings page."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..rows import StepOverRow
+from .cnc_step_page import CncStepSettingsPage
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class ToroidalClearPage(CncStepSettingsPage):
+    """Settings page for the toroidal clearing step."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(editor, step)
+        self.add_section(
+            _("Clearing"),
+            StepOverRow,
+            description=_("Clear a pocket with concentric passes."),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/__init__.py
@@ -1,0 +1,27 @@
+"""CNC-domain row widgets."""
+
+from .area_tolerance_row import AreaToleranceRow
+from .depth_per_pass_row import DepthPerPassRow
+from .max_deflection_row import MaxDeflectionRow
+from .plunge_speed_row import PlungeSpeedRow
+from .safe_z_row import SafeZRow
+from .spindle_rpm_row import SpindleRpmRow
+from .step_length_row import StepLengthRow
+from .step_over_row import StepOverRow
+from .target_depth_row import TargetDepthRow
+from .tool_diameter_row import ToolDiameterRow
+from .wall_margin_row import WallMarginRow
+
+__all__ = [
+    "AreaToleranceRow",
+    "DepthPerPassRow",
+    "MaxDeflectionRow",
+    "PlungeSpeedRow",
+    "SafeZRow",
+    "SpindleRpmRow",
+    "StepLengthRow",
+    "StepOverRow",
+    "TargetDepthRow",
+    "ToolDiameterRow",
+    "WallMarginRow",
+]

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/area_tolerance_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/area_tolerance_row.py
@@ -1,0 +1,28 @@
+"""CNC area-tolerance row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class AreaToleranceRow(SpinRow):
+    """A spin row bound to the step's ``area_tolerance`` attribute."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "area_tolerance",
+            _("Area Tolerance"),
+            _("Stopping tolerance in mm²"),
+            0.01,
+            5.0,
+            0.01,
+            2,
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/depth_per_pass_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/depth_per_pass_row.py
@@ -1,0 +1,29 @@
+"""CNC depth-per-pass row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class DepthPerPassRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.depth_per_pass``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "depth_per_pass",
+            _("Depth per Pass"),
+            _("Depth removed by each pass"),
+            0.1,
+            10.0,
+            0.1,
+            2,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/max_deflection_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/max_deflection_row.py
@@ -1,0 +1,39 @@
+"""CNC max-deflection row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+from rayforge.ui_gtk.shared.pref_rows import AngleSpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class MaxDeflectionRow(SpinRow):
+    """A spin row bound to the step's ``max_deflection_deg``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "max_deflection_deg",
+            _("Max Deflection"),
+            _("Max steering deflection per step (degrees)"),
+            1.0,
+            60.0,
+            1.0,
+            0,
+            is_int=True,
+        )
+
+    def build_widget(self):
+        return AngleSpinRow(
+            self._title,
+            self._subtitle,
+            lower=self._lower,
+            upper=self._upper,
+            digits=self._digits,
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/plunge_speed_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/plunge_speed_row.py
@@ -1,0 +1,34 @@
+"""CNC plunge speed row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class PlungeSpeedRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.plunge_speed``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "plunge_speed",
+            _("Plunge Rate"),
+            _("Vertical feed rate"),
+            1.0,
+            float(step.max_cut_speed),
+            10.0,
+            0,
+            is_int=True,
+            quantity="speed",
+        )
+
+    def _sync_dependencies(self):
+        if self.step.max_cut_speed:
+            self.set_range(1.0, float(self.step.max_cut_speed))

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/safe_z_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/safe_z_row.py
@@ -1,0 +1,29 @@
+"""CNC safe-Z row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class SafeZRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.safe_z``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "safe_z",
+            _("Safe Z Height"),
+            _("Height to retract between moves"),
+            0.0,
+            50.0,
+            0.1,
+            2,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/spindle_rpm_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/spindle_rpm_row.py
@@ -1,0 +1,29 @@
+"""CNC spindle RPM row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class SpindleRpmRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.spindle_rpm``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "spindle_rpm",
+            _("Spindle RPM"),
+            None,
+            100,
+            60000,
+            100,
+            0,
+            is_int=True,
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/step_length_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/step_length_row.py
@@ -1,0 +1,29 @@
+"""CNC step-length row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class StepLengthRow(SpinRow):
+    """A spin row bound to the step's ``step_length`` attribute."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "step_length",
+            _("Step Length"),
+            _("Forward step length"),
+            0.1,
+            5.0,
+            0.1,
+            1,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/step_over_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/step_over_row.py
@@ -1,0 +1,29 @@
+"""CNC step-over row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class StepOverRow(SpinRow):
+    """A spin row bound to the step's ``step_over`` attribute."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "step_over",
+            _("Step Over"),
+            _("Lateral step-over between passes"),
+            0.1,
+            25.0,
+            0.1,
+            1,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/target_depth_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/target_depth_row.py
@@ -1,0 +1,29 @@
+"""CNC target depth row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class TargetDepthRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.target_depth``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "target_depth",
+            _("Target Depth"),
+            _("Final depth of the cut (negative is downward)"),
+            -50.0,
+            0.0,
+            0.1,
+            2,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/tool_diameter_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/tool_diameter_row.py
@@ -1,0 +1,29 @@
+"""CNC tool diameter row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class ToolDiameterRow(SpinRow):
+    """A spin row bound to ``CncAssemblerStep.tool_diameter``."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "tool_diameter",
+            _("Tool Diameter"),
+            _("Diameter of the cutting tool"),
+            0.1,
+            50.0,
+            0.1,
+            2,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/wall_margin_row.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/widgets/rows/wall_margin_row.py
@@ -1,0 +1,29 @@
+"""CNC wall-margin row widget."""
+
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from rayforge.ui_gtk.doceditor.step_settings.rows import SpinRow
+
+if TYPE_CHECKING:
+    from rayforge.doceditor.editor import DocEditor
+
+    from ...steps.cnc_assembler_step import CncAssemblerStep
+
+
+class WallMarginRow(SpinRow):
+    """A spin row bound to the step's ``wall_margin`` attribute."""
+
+    def __init__(self, editor: "DocEditor", step: "CncAssemblerStep"):
+        super().__init__(
+            editor,
+            step,
+            "wall_margin",
+            _("Wall Margin"),
+            _("Extra clearance from the pocket wall"),
+            0.0,
+            10.0,
+            0.1,
+            1,
+            quantity="length",
+        )

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/worker.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/worker.py
@@ -1,0 +1,33 @@
+"""
+Backend entry point for cnc-essentials addon.
+
+Registers steps with the main application.
+"""
+
+from rayforge.core.hooks import hookimpl
+
+from .steps import (
+    AdaptiveClearStep,
+    FlatSpiralStep,
+    HelixPlungeStep,
+    ProfileInnerStep,
+    ProfileOuterStep,
+    RampEntryStep,
+    SlotStep,
+    ToroidalClearStep,
+)
+
+ADDON_NAME = "cnc_essentials"
+
+
+@hookimpl
+def register_steps(step_registry):
+    """Register CNC steps with the step registry."""
+    step_registry.register(AdaptiveClearStep, addon_name=ADDON_NAME)
+    step_registry.register(HelixPlungeStep, addon_name=ADDON_NAME)
+    step_registry.register(FlatSpiralStep, addon_name=ADDON_NAME)
+    step_registry.register(RampEntryStep, addon_name=ADDON_NAME)
+    step_registry.register(ToroidalClearStep, addon_name=ADDON_NAME)
+    step_registry.register(SlotStep, addon_name=ADDON_NAME)
+    step_registry.register(ProfileInnerStep, addon_name=ADDON_NAME)
+    step_registry.register(ProfileOuterStep, addon_name=ADDON_NAME)

--- a/rayforge/builtin_addons/rayforge-addon-cnc/rayforge-addon.yaml
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/rayforge-addon.yaml
@@ -1,0 +1,15 @@
+name: cnc_essentials
+display_name: "CNC Essentials"
+description: "CNC machining operations: adaptive clearing, profiling, slotting"
+api_version: 20
+requires:
+  - post_processors
+author:
+  name: "Rayforge Team"
+  email: "noreply@rayforge.org"
+provides:
+  worker: "cnc_essentials.worker"
+  frontend: "cnc_essentials.frontend"
+license:
+  name: "MIT"
+default_state: "disabled"

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/conftest.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/conftest.py
@@ -1,0 +1,53 @@
+"""
+Pytest configuration for cnc_essentials builtin addon tests.
+
+This conftest ensures that steps are registered with the step registry
+before tests run, mirroring the laser_essentials addon conftest.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from cnc_essentials.steps import (
+    AdaptiveClearStep,
+    FlatSpiralStep,
+    HelixPlungeStep,
+    ProfileInnerStep,
+    ProfileOuterStep,
+    RampEntryStep,
+    SlotStep,
+    ToroidalClearStep,
+)
+
+from rayforge.core.step_registry import step_registry
+from rayforge.machine.models.spindle import SpindleHead
+
+
+@pytest.fixture
+def machine():
+    """A machine with a spindle head for CNC steps."""
+    m = MagicMock()
+    m.heads = [SpindleHead()]
+    return m
+
+
+def _register_steps():
+    """Register all steps from cnc_essentials addon."""
+    step_registry.register(AdaptiveClearStep, addon_name="cnc_essentials")
+    step_registry.register(HelixPlungeStep, addon_name="cnc_essentials")
+    step_registry.register(FlatSpiralStep, addon_name="cnc_essentials")
+    step_registry.register(RampEntryStep, addon_name="cnc_essentials")
+    step_registry.register(ToroidalClearStep, addon_name="cnc_essentials")
+    step_registry.register(SlotStep, addon_name="cnc_essentials")
+    step_registry.register(ProfileInnerStep, addon_name="cnc_essentials")
+    step_registry.register(ProfileOuterStep, addon_name="cnc_essentials")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def register_cnc_essentials():
+    """
+    Automatically register cnc_essentials steps for all tests in this
+    addon.
+    """
+    _register_steps()
+    yield

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_adaptive_clearing_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_adaptive_clearing_step.py
@@ -1,0 +1,97 @@
+"""Tests for the adaptive-clearing CNC step."""
+
+import pytest
+
+from rayforge.core.workpiece import WorkPiece
+
+
+@pytest.fixture
+def adaptive_clear_step():
+    from cnc_essentials.steps import AdaptiveClearStep
+
+    step = AdaptiveClearStep(name="adaptive_clear")
+    step.tool_diameter = 6.0
+    step.step_over = 2.0
+    step.step_length = 0.6
+    step.max_deflection_deg = 30.0
+    step.wall_margin = 0.0
+    step.area_tolerance = 1.0
+    step.target_depth = -5.0
+    step.safe_z = 2.0
+    return step
+
+
+class TestAdaptiveClearSpec:
+    def test_build_spec_returns_adaptive_clearing_spec(
+        self, adaptive_clear_step
+    ):
+        from raygeo.ops.assembly.adaptive import AdaptiveClearingSpec
+
+        wp = WorkPiece(name="wp")
+        wp.set_size(60.0, 60.0)
+
+        spec = adaptive_clear_step.build_spec(wp)
+
+        assert isinstance(spec, AdaptiveClearingSpec)
+        assert spec.tool_radius == 3.0
+        assert spec.step_over == 2.0
+        assert spec.step_length == 0.6
+        assert spec.max_deflection_deg == 30.0
+        assert spec.wall_margin == 0.0
+        assert spec.area_tolerance == 1.0
+        assert spec.target_z == -5.0
+        assert spec.safe_z == 2.0
+
+    def test_build_compute_payload_returns_part_and_payload(
+        self, adaptive_clear_step, machine
+    ):
+        from raygeo.cnc.execution.specs import ComputePayload
+        from raygeo.ops.assembly import Assembler
+        from raygeo.ops.assembly.adaptive import AdaptiveClearingSpec
+        from raygeo.ops.part import Part
+
+        wp = WorkPiece(name="wp")
+        wp.set_size(60.0, 60.0)
+
+        part, payload = adaptive_clear_step.build_compute_payload(machine, wp)
+
+        assert isinstance(part, Part)
+        assert isinstance(payload, ComputePayload)
+        assert isinstance(payload.assembler, Assembler)
+        spec = payload.assembler.spec
+        assert isinstance(spec, AdaptiveClearingSpec)
+        assert spec.tool_radius == 3.0
+
+    def test_populate_payload_stamps_spindle_power(
+        self, adaptive_clear_step, machine
+    ):
+        """CNC payloads express power as the spindle's RPM / max RPM
+        ratio, so a running spindle renders as a cut at the right
+        intensity rather than the zero-power (no-cut) colour."""
+        adaptive_clear_step.spindle_rpm = 15000
+        wp = WorkPiece(name="wp")
+        wp.set_size(60.0, 60.0)
+
+        _part, payload = adaptive_clear_step.build_compute_payload(machine, wp)
+        adaptive_clear_step.populate_payload(payload, machine)
+
+        assert payload.power == 0.75  # 15000 / 20000 (fixture spindle max)
+        assert payload.head_uid is not None
+
+    def test_assembler_token_params_keys_and_values(
+        self, adaptive_clear_step, machine
+    ):
+        wp = WorkPiece(name="wp")
+        wp.set_size(60.0, 60.0)
+
+        token = adaptive_clear_step.assembler_token_params(machine, wp)
+
+        assert token["step_over"] == 2.0
+        assert token["step_length"] == 0.6
+        assert token["max_deflection_deg"] == 30.0
+        assert token["wall_margin"] == 0.0
+        assert token["area_tolerance"] == 1.0
+        # Base CNC attributes are included too.
+        assert token["tool_diameter"] == 6.0
+        assert token["target_depth"] == -5.0
+        assert token["safe_z"] == 2.0

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_cnc_assembler_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_cnc_assembler_step.py
@@ -1,0 +1,195 @@
+"""Tests for the base CNC assembler step setters."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from cnc_essentials.steps import (
+    AdaptiveClearStep,
+    ProfileOuterStep,
+    ToroidalClearStep,
+)
+from cnc_essentials.steps.cnc_assembler_step import CncAssemblerStep
+
+from rayforge.core.step import Step
+
+
+@pytest.fixture
+def cnc_step():
+    return ProfileOuterStep(name="profile_outer")
+
+
+@pytest.mark.parametrize(
+    "attr, value, expected",
+    [
+        ("tool_diameter", 8.0, 8.0),
+        ("spindle_rpm", 15000, 15000),
+        ("plunge_speed", 300, 300),
+        ("target_depth", -3.5, -3.5),
+        ("depth_per_pass", 0.5, 0.5),
+        ("safe_z", 5.0, 5.0),
+    ],
+)
+def test_setters_update_attribute_and_signal(cnc_step, attr, value, expected):
+    handler = MagicMock()
+    cnc_step.updated.connect(handler)
+
+    setter = getattr(cnc_step, f"set_{attr}")
+    setter(value)
+
+    assert getattr(cnc_step, attr) == expected
+    handler.assert_called_once_with(cnc_step)
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "tool_diameter",
+        "spindle_rpm",
+        "plunge_speed",
+        "target_depth",
+        "depth_per_pass",
+        "safe_z",
+    ],
+)
+def test_setters_no_signal_on_same_value(cnc_step, attr):
+    handler = MagicMock()
+    cnc_step.updated.connect(handler)
+
+    getattr(cnc_step, f"set_{attr}")(getattr(cnc_step, attr))
+
+    handler.assert_not_called()
+
+
+def test_int_setters_coerce_values(cnc_step):
+    cnc_step.set_spindle_rpm(15000.9)
+    cnc_step.set_plunge_speed(300.9)
+    assert cnc_step.spindle_rpm == 15000
+    assert cnc_step.plunge_speed == 300
+
+
+def test_float_setters_coerce_values(cnc_step):
+    cnc_step.set_tool_diameter(8)
+    assert isinstance(cnc_step.tool_diameter, float)
+    assert cnc_step.tool_diameter == 8.0
+
+
+def test_all_recipe_keys_have_setters(cnc_step):
+    for var in CncAssemblerStep.recipe_varset():
+        assert hasattr(cnc_step, f"set_{var.key}"), var.key
+
+
+BASE_CNC_KEYS = (
+    "tool_diameter",
+    "spindle_rpm",
+    "plunge_speed",
+    "target_depth",
+    "depth_per_pass",
+    "safe_z",
+)
+
+PROFILE_KEYS = ("step_over", "step_length", "wall_margin")
+
+
+class TestCncSerialization:
+    def test_base_cnc_attrs_round_trip(self):
+        step = ProfileOuterStep(name="profile_outer")
+        step.tool_diameter = 8.0
+        step.spindle_rpm = 15000
+        step.plunge_speed = 300
+        step.target_depth = -3.5
+        step.depth_per_pass = 0.5
+        step.safe_z = 5.0
+
+        data = step.to_dict()
+        restored = ProfileOuterStep.from_dict(data)
+
+        assert restored.tool_diameter == 8.0
+        assert restored.spindle_rpm == 15000
+        assert restored.plunge_speed == 300
+        assert restored.target_depth == -3.5
+        assert restored.depth_per_pass == 0.5
+        assert restored.safe_z == 5.0
+
+    def test_step_specific_attrs_round_trip(self):
+        step = ProfileOuterStep(name="profile_outer")
+        step.step_over = 3.0
+        step.step_length = 0.8
+        step.wall_margin = 0.5
+
+        data = step.to_dict()
+        restored = ProfileOuterStep.from_dict(data)
+
+        assert restored.step_over == 3.0
+        assert restored.step_length == 0.8
+        assert restored.wall_margin == 0.5
+
+    def test_adaptive_clear_attrs_round_trip(self):
+        step = AdaptiveClearStep(name="adaptive_clear")
+        step.step_over = 2.5
+        step.step_length = 0.7
+        step.max_deflection_deg = 25.0
+        step.wall_margin = 0.2
+        step.area_tolerance = 0.5
+
+        data = step.to_dict()
+        restored = AdaptiveClearStep.from_dict(data)
+
+        assert restored.step_over == 2.5
+        assert restored.step_length == 0.7
+        assert restored.max_deflection_deg == 25.0
+        assert restored.wall_margin == 0.2
+        assert restored.area_tolerance == 0.5
+
+    def test_toroidal_clear_attrs_round_trip(self):
+        step = ToroidalClearStep(name="toroidal_clear")
+        step.step_over = 3.5
+
+        data = step.to_dict()
+        restored = ToroidalClearStep.from_dict(data)
+
+        assert restored.step_over == 3.5
+
+    def test_cnc_attrs_not_stashed_in_extra(self):
+        step = ProfileOuterStep(name="profile_outer")
+        data = step.to_dict()
+        restored = ProfileOuterStep.from_dict(data)
+
+        for key in BASE_CNC_KEYS + PROFILE_KEYS:
+            assert key not in restored.extra
+
+    def test_old_files_without_cnc_keys_load_defaults(self):
+        step = ProfileOuterStep(name="profile_outer")
+        data = step.to_dict()
+        for key in BASE_CNC_KEYS:
+            data.pop(key)
+
+        restored = ProfileOuterStep.from_dict(data)
+
+        assert restored.tool_diameter == 6.0
+        assert restored.spindle_rpm == 12000
+        assert restored.plunge_speed == 200
+        assert restored.target_depth == -5.0
+        assert restored.depth_per_pass == 1.0
+        assert restored.safe_z == 2.0
+
+    def test_unknown_keys_preserved_in_extra(self):
+        step = ProfileOuterStep(name="profile_outer")
+        data = step.to_dict()
+        data["future_field"] = "future value"
+
+        restored = ProfileOuterStep.from_dict(data)
+
+        assert restored.extra["future_field"] == "future value"
+        re_serialized = restored.to_dict()
+        assert re_serialized["future_field"] == "future value"
+
+    def test_dispatch_via_base_step_from_dict(self):
+        step = ProfileOuterStep(name="profile_outer")
+        step.step_over = 3.0
+        data = step.to_dict()
+
+        restored = Step.from_dict(data)
+
+        assert isinstance(restored, ProfileOuterStep)
+        assert restored.step_over == 3.0
+        assert restored.tool_diameter == step.tool_diameter

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_cnc_recipe_keys.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/steps/test_cnc_recipe_keys.py
@@ -1,0 +1,156 @@
+"""Tests for step-declared recipe keys and recipe varsets.
+
+Verifies that each step's recipe_keys() is composed correctly through
+the inheritance hierarchy and that recipe_varset() exposes the keys
+needed by the recipe editor.
+"""
+
+from cnc_essentials.steps import (
+    AdaptiveClearStep,
+    FlatSpiralStep,
+    HelixPlungeStep,
+    ProfileInnerStep,
+    ProfileOuterStep,
+    RampEntryStep,
+    SlotStep,
+    ToroidalClearStep,
+)
+from cnc_essentials.steps.cnc_assembler_step import CncAssemblerStep
+
+from rayforge.core.step import Step
+
+
+class TestRecipeKeys:
+    """recipe_keys() composition through the step hierarchy."""
+
+    def test_base_step_keys(self):
+        assert "cut_speed" in Step.recipe_keys()
+        assert "travel_speed" in Step.recipe_keys()
+
+    def test_cnc_step_extends_base(self):
+        assert set(Step.recipe_keys()).issubset(
+            set(CncAssemblerStep.recipe_keys())
+        )
+        for key in (
+            "tool_diameter",
+            "spindle_rpm",
+            "plunge_speed",
+            "target_depth",
+            "depth_per_pass",
+            "safe_z",
+        ):
+            assert key in CncAssemblerStep.recipe_keys()
+
+    def test_adaptive_clear_extends_cnc(self):
+        assert set(CncAssemblerStep.recipe_keys()).issubset(
+            set(AdaptiveClearStep.recipe_keys())
+        )
+        for key in (
+            "step_over",
+            "step_length",
+            "max_deflection_deg",
+            "wall_margin",
+            "area_tolerance",
+        ):
+            assert key in AdaptiveClearStep.recipe_keys()
+
+    def test_profile_inner_extends_cnc(self):
+        assert set(CncAssemblerStep.recipe_keys()).issubset(
+            set(ProfileInnerStep.recipe_keys())
+        )
+        for key in ("step_over", "step_length", "wall_margin"):
+            assert key in ProfileInnerStep.recipe_keys()
+
+    def test_profile_outer_extends_cnc(self):
+        assert set(CncAssemblerStep.recipe_keys()).issubset(
+            set(ProfileOuterStep.recipe_keys())
+        )
+        for key in ("step_over", "step_length", "wall_margin"):
+            assert key in ProfileOuterStep.recipe_keys()
+
+    def test_toroidal_clear_extends_cnc(self):
+        assert set(CncAssemblerStep.recipe_keys()).issubset(
+            set(ToroidalClearStep.recipe_keys())
+        )
+        assert "step_over" in ToroidalClearStep.recipe_keys()
+
+    def test_simple_steps_inherit_cnc_keys(self):
+        """Steps without extra attrs inherit CncAssemblerStep keys."""
+        for cls in (
+            FlatSpiralStep,
+            HelixPlungeStep,
+            RampEntryStep,
+            SlotStep,
+        ):
+            assert cls.recipe_keys() == CncAssemblerStep.recipe_keys()
+
+
+class TestRecipeVarsetKeys:
+    """recipe_varset() keys are consistent with recipe_keys().
+
+    The CNC domain varset covers all process keys but not
+    ``selected_head_uid`` (same as the base Step pattern).
+    """
+
+    def test_cnc_step_varset(self):
+        keys = [var.key for var in CncAssemblerStep.recipe_varset()]
+        for key in CncAssemblerStep.recipe_keys():
+            assert key in keys, f"Missing var for recipe key '{key}'"
+
+    def test_adaptive_clear_varset_covers_keys(self):
+        keys = [var.key for var in AdaptiveClearStep.recipe_varset()]
+        for key in AdaptiveClearStep.recipe_keys():
+            assert key in keys, f"Missing var for recipe key '{key}'"
+
+    def test_profile_inner_varset_covers_keys(self):
+        keys = [var.key for var in ProfileInnerStep.recipe_varset()]
+        for key in ProfileInnerStep.recipe_keys():
+            assert key in keys, f"Missing var for recipe key '{key}'"
+
+    def test_profile_outer_varset_covers_keys(self):
+        keys = [var.key for var in ProfileOuterStep.recipe_varset()]
+        for key in ProfileOuterStep.recipe_keys():
+            assert key in keys, f"Missing var for recipe key '{key}'"
+
+    def test_toroidal_clear_varset_covers_keys(self):
+        keys = [var.key for var in ToroidalClearStep.recipe_varset()]
+        for key in ToroidalClearStep.recipe_keys():
+            assert key in keys, f"Missing var for recipe key '{key}'"
+
+
+class TestRecipeVarsetGroups:
+    """recipe_varset_groups() splits into CNC and Step Settings."""
+
+    def test_cnc_base_single_group(self):
+        groups = CncAssemblerStep.recipe_varset_groups()
+        assert len(groups) == 1
+        assert groups[0][0] == "CNC"
+
+    def test_adaptive_clear_splits(self):
+        groups = AdaptiveClearStep.recipe_varset_groups()
+        assert len(groups) == 2
+        titles = [g[0] for g in groups]
+        assert "CNC" in titles
+        assert "Step Settings" in titles
+
+    def test_profile_inner_splits(self):
+        groups = ProfileInnerStep.recipe_varset_groups()
+        assert len(groups) == 2
+
+    def test_profile_outer_splits(self):
+        groups = ProfileOuterStep.recipe_varset_groups()
+        assert len(groups) == 2
+
+    def test_toroidal_clear_splits(self):
+        groups = ToroidalClearStep.recipe_varset_groups()
+        assert len(groups) == 2
+
+    def test_simple_steps_single_group(self):
+        for cls in (
+            FlatSpiralStep,
+            HelixPlungeStep,
+            RampEntryStep,
+            SlotStep,
+        ):
+            groups = cls.recipe_varset_groups()
+            assert len(groups) == 1

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/conftest.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/conftest.py
@@ -1,0 +1,76 @@
+"""UI fixtures for cnc_essentials page tests."""
+
+import asyncio
+import logging
+
+import pytest
+
+from rayforge import config as config_module
+from rayforge import context as context_module
+from rayforge.context import get_context
+from rayforge.doceditor.editor import DocEditor
+from rayforge.machine.models.machine import Machine
+from rayforge.machine.models.spindle import SpindleHead
+from rayforge.shared import tasker
+from rayforge.shared.tasker.manager import TaskManager
+from rayforge.shared.util.glib import idle_add
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def ui_task_mgr():
+    """A test-isolated TaskManager for sync UI tests."""
+    tm = TaskManager(main_thread_scheduler=idle_add)
+    yield tm
+    if tm.has_tasks():
+        logger.warning(
+            "Task manager still has tasks at end of test. Shutting down."
+        )
+    tm.shutdown()
+
+
+@pytest.fixture
+def ui_context(ui_task_mgr, monkeypatch, tmp_path):
+    """A UI context for CNC addon tests."""
+    temp_config_dir = tmp_path / "config"
+    temp_dialect_dir = temp_config_dir / "dialects"
+    temp_machine_dir = temp_config_dir / "machines"
+    temp_addons_dir = temp_config_dir / "addons"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", temp_config_dir)
+    monkeypatch.setattr(config_module, "DIALECT_DIR", temp_dialect_dir)
+    monkeypatch.setattr(config_module, "MACHINE_DIR", temp_machine_dir)
+    monkeypatch.setattr(config_module, "ADDONS_DIR", temp_addons_dir)
+    monkeypatch.setattr(tasker.task_mgr, "_instance", ui_task_mgr)
+
+    context = get_context()
+    yield context
+
+    asyncio.run(context.shutdown())
+    context_module._context_instance = None
+
+
+@pytest.fixture
+def editor(ui_context, ui_task_mgr):
+    editor = DocEditor(task_manager=ui_task_mgr, context=ui_context)
+    yield editor
+    editor.cleanup()
+
+
+@pytest.fixture
+def cnc_machine(ui_context):
+    """A machine with a spindle head, set as the active machine."""
+    machine = Machine(ui_context)
+    machine.set_axis_extents(200, 150)
+    machine.max_cut_speed = 5000
+    machine.max_travel_speed = 10000
+
+    spindle = SpindleHead()
+    spindle.name = "Spindle 1"
+    machine.heads.clear()
+    machine.add_head(spindle)
+
+    ui_context.machine_mgr.machines.clear()
+    ui_context.machine_mgr.add_machine(machine)
+    ui_context.config.set_machine(machine)
+    return machine

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/test_cnc_frontend_registry.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/test_cnc_frontend_registry.py
@@ -1,0 +1,22 @@
+# flake8: noqa: E402
+"""Verify the cnc_essentials frontend registers pages via the new hook."""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from cnc_essentials.frontend import register_step_settings_pages
+
+from rayforge.ui_gtk.doceditor.step_settings.page_registry import (
+    StepSettingsPageRegistry,
+)
+
+
+def test_frontend_registers_pages():
+    registry = StepSettingsPageRegistry()
+    register_step_settings_pages(registry)
+    assert registry.get("adaptive_clearing") is not None
+    assert registry.get("profile_outer") is not None
+    assert registry.get("slot") is not None
+    assert registry.get("helix") is not None

--- a/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/test_cnc_pages.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/tests/ui_gtk/test_cnc_pages.py
@@ -1,0 +1,93 @@
+# flake8: noqa: E402
+"""UI tests for the CNC step settings pages."""
+
+from typing import cast
+
+import gi
+import pytest
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from cnc_essentials.steps.cnc_assembler_step import CncAssemblerStep
+from cnc_essentials.widgets.pages import AdaptiveClearPage, ProfileOuterPage
+from cnc_essentials.widgets.rows import (
+    MaxDeflectionRow,
+    PlungeSpeedRow,
+    ToolDiameterRow,
+)
+
+from rayforge.core.step_registry import step_registry
+from rayforge.ui_gtk.doceditor.step_settings.pages import StepSettingsPage
+from rayforge.ui_gtk.doceditor.step_settings.rows import (
+    CutSpeedRow,
+    TravelSpeedRow,
+)
+from rayforge.ui_gtk.shared.pref_rows import (
+    AngleSpinRow,
+    LengthSpinRow,
+    SpeedSpinRow,
+)
+
+
+def _find(widget, cls):
+    for row in widget._rows:
+        if isinstance(row, cls):
+            return row
+    raise AssertionError(f"row {cls.__name__} not found in page")
+
+
+@pytest.mark.ui
+def test_profile_outer_page_composes_common_sections(
+    editor, cnc_machine, ui_context
+):
+    step_cls = step_registry.get("ProfileOuterStep")
+    assert step_cls is not None
+    step = cast(CncAssemblerStep, step_cls.create(ui_context))
+
+    page = ProfileOuterPage(editor, step)
+    assert isinstance(page, StepSettingsPage)
+
+    rows = list(page._rows)
+    assert any(isinstance(row, CutSpeedRow) for row in rows)
+    assert any(isinstance(row, TravelSpeedRow) for row in rows)
+
+
+@pytest.mark.ui
+def test_length_rows_use_user_units(editor, cnc_machine, ui_context):
+    ui_context.config.unit_preferences["length"] = "in"
+    step_cls = step_registry.get("ProfileOuterStep")
+    assert step_cls is not None
+    step = cast(CncAssemblerStep, step_cls.create(ui_context))
+
+    page = ProfileOuterPage(editor, step)
+    tool = _find(page, ToolDiameterRow)
+    assert isinstance(tool.widget, LengthSpinRow)
+
+    step.tool_diameter = 25.4
+    step.updated.send(step)
+
+    assert tool.widget.get_value_in_base_units() == pytest.approx(25.4)
+    assert tool.widget.get_value() == pytest.approx(1.0, abs=1e-2)
+
+
+@pytest.mark.ui
+def test_plunge_speed_row_uses_speed_units(editor, cnc_machine, ui_context):
+    step_cls = step_registry.get("ProfileOuterStep")
+    assert step_cls is not None
+    step = cast(CncAssemblerStep, step_cls.create(ui_context))
+
+    page = ProfileOuterPage(editor, step)
+    plunge = _find(page, PlungeSpeedRow)
+    assert isinstance(plunge.widget, SpeedSpinRow)
+
+
+@pytest.mark.ui
+def test_deflection_row_uses_angle_spin_row(editor, cnc_machine, ui_context):
+    step_cls = step_registry.get("AdaptiveClearStep")
+    assert step_cls is not None
+    step = cast(CncAssemblerStep, step_cls.create(ui_context))
+
+    page = AdaptiveClearPage(editor, step)
+    deflection = _find(page, MaxDeflectionRow)
+    assert isinstance(deflection.widget, AngleSpinRow)

--- a/scripts/screenshot/utils.py
+++ b/scripts/screenshot/utils.py
@@ -24,16 +24,19 @@ import numpy as np
 from gi.repository import Adw, GLib
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
+from rayforge.ui_gtk.doceditor.edit_recipe_dialog import (
+    AddEditRecipeDialog,
+)
+
+from rayforge.core.recipe import Recipe
+from rayforge.core.step_registry import step_registry
+from rayforge.ui_gtk.doceditor.step_settings.dialog import (
+    StepSettingsDialog,
+)
 
 if TYPE_CHECKING:
     from rayforge.core.step import Step
     from rayforge.ui_gtk.array_dialog import _BaseArrayDialog
-    from rayforge.ui_gtk.doceditor.edit_recipe_dialog import (
-        AddEditRecipeDialog,
-    )
-    from rayforge.ui_gtk.doceditor.step_settings.dialog import (
-        StepSettingsDialog,
-    )
     from rayforge.ui_gtk.machine.settings_dialog import MachineSettingsDialog
     from rayforge.ui_gtk.mainwindow import MainWindow
     from rayforge.ui_gtk.settings.settings_dialog import SettingsWindow
@@ -664,10 +667,6 @@ def open_recipe_editor(
         settings_page: Index into the dynamic settings pages to activate
             when ``page`` is "settings".
     """
-    from rayforge.core.recipe import Recipe
-    from rayforge.ui_gtk.doceditor.edit_recipe_dialog import (
-        AddEditRecipeDialog,
-    )
 
     settings_dialog = open_app_settings(win, "recipes")
     time.sleep(0.5)
@@ -702,10 +701,6 @@ def open_recipe_editor(
 
 def open_material_test(win: "MainWindow") -> "StepSettingsDialog":
     """Open material test grid dialog."""
-    from rayforge.core.step_registry import step_registry
-    from rayforge.ui_gtk.doceditor.step_settings.dialog import (
-        StepSettingsDialog,
-    )
 
     def _open() -> "StepSettingsDialog":
         step_cls = step_registry.get("MaterialTestStep")


### PR DESCRIPTION
## CNC Essentials addon

Adds a new built-in addon `cnc_essentials` (default disabled) providing
milling operations.

### Capability & step base
- Declares the `MILL` machine capability requirement
  (`REQUIRED_MACHINE_CAPS`).
- New `CncAssemblerStep` base that builds raygeo `Assembler` specs and
  `ComputePayload`s, models spindle power as the RPM / max-RPM ratio so a
  running spindle renders at the right cut intensity, and exposes a CNC
  recipe varset (tool diameter, spindle RPM, cut/travel/plunge speeds,
  target depth, depth-per-pass, safe Z) with grouped recipe editing and
  full serialization round-tripping.

### Operations
Steps for: adaptive clearing, flat spiral, helix plunge, ramp entry,
slot, toroidal clear, profile inner, profile outer.

### Addon integration
- Worker entry point registers all CNC steps with the step registry.
- Frontend entry point registers per-step settings **pages** via the
  `StepSettingsPageRegistry` hook, composed from reusable unit-aware
  rows (length, speed, angle).

### Tests
- `test_adaptive_clearing_step.py`: spec/payload generation, spindle
  power stamping, assembler token params.
- `test_cnc_assembler_step.py`: setter signalling & value coercion,
  serialization round-trips (incl. legacy defaults and unknown-key
  preservation), base `Step.from_dict` dispatch.
- `test_cnc_recipe_keys.py`: `recipe_keys` / `recipe_varset` /
  `recipe_varset_groups` composition across the step hierarchy.
- `test_cnc_frontend_registry.py`: frontend page registration via the
  registry hook.
- `test_cnc_pages.py` (UI): step settings page composition and
  unit-aware rows.

### Other
- `scripts/screenshot/utils.py`: hoist a few imports out of deferred
  `TYPE_CHECKING` / function-local blocks to module level.
