### PR TITLE
feat: add rotatable workspace orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Rayforge will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Workspace orientation setting (Machine → Hardware, and the machine
+  wizard): rotate the displayed machine bed 90° left or right, similar
+  to LightBurn's "swap X/Y". The canvas, axis labels, jog buttons,
+  no-go zones, camera alignment, and 3D preview follow the rotated
+  view, while G-code output is transformed back to the machine's
+  native axes. A true 90° rotation preserves design handedness, unlike a
+  bare X/Y coordinate swap. Device profiles can preset it via
+  `workspace_orientation: native | rotated_left | rotated_right`. Rotary
+  layers use their own cylindrical workspace and require Native orientation.
+
 ## 1.9.0-beta4
 
 ### Added

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/__init__.py
@@ -79,7 +79,7 @@ def _on_config_changed(sender, **kwargs):
 
     config = get_context().config
     if config.machine:
-        width_mm, height_mm = config.machine.workspace_extents
+        width_mm, height_mm = config.machine.workspace.extents
         _sketch_studio.set_world_size(width_mm, height_mm)
 
 
@@ -105,7 +105,7 @@ def setup_sketch_page(main_window: "MainWindow") -> "SketchStudio":
 
     config = get_context().config
     if config.machine:
-        width_mm, height_mm = config.machine.workspace_extents
+        width_mm, height_mm = config.machine.workspace.extents
     else:
         width_mm, height_mm = 100.0, 100.0
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/__init__.py
@@ -79,7 +79,7 @@ def _on_config_changed(sender, **kwargs):
 
     config = get_context().config
     if config.machine:
-        width_mm, height_mm = config.machine.axis_extents
+        width_mm, height_mm = config.machine.workspace_extents
         _sketch_studio.set_world_size(width_mm, height_mm)
 
 
@@ -105,7 +105,7 @@ def setup_sketch_page(main_window: "MainWindow") -> "SketchStudio":
 
     config = get_context().config
     if config.machine:
-        width_mm, height_mm = config.machine.axis_extents
+        width_mm, height_mm = config.machine.workspace_extents
     else:
         width_mm, height_mm = 100.0, 100.0
 

--- a/rayforge/doceditor/editor.py
+++ b/rayforge/doceditor/editor.py
@@ -265,7 +265,7 @@ class DocEditor:
         """Returns the configured machine's axis extents, or None."""
         config = self.context.config
         if config and config.machine:
-            return config.machine.axis_extents
+            return config.machine.workspace_extents
         return None
 
     @property

--- a/rayforge/doceditor/editor.py
+++ b/rayforge/doceditor/editor.py
@@ -265,7 +265,7 @@ class DocEditor:
         """Returns the configured machine's axis extents, or None."""
         config = self.context.config
         if config and config.machine:
-            return config.machine.workspace_extents
+            return config.machine.workspace.extents
         return None
 
     @property

--- a/rayforge/doceditor/file_cmd.py
+++ b/rayforge/doceditor/file_cmd.py
@@ -810,7 +810,7 @@ class FileCmd:
             return 1.0
 
         bbox_x, bbox_y, bbox_w, bbox_h = bbox
-        area_x, area_y, area_w, area_h = config.machine.workspace_work_area
+        area_x, area_y, area_w, area_h = config.machine.workspace.work_area
         logger.debug(
             f"_fit_and_position_at_reference_origin: bbox=({bbox_x:.2f}, "
             f"{bbox_y:.2f}, {bbox_w:.2f}, {bbox_h:.2f}), "

--- a/rayforge/doceditor/file_cmd.py
+++ b/rayforge/doceditor/file_cmd.py
@@ -810,7 +810,7 @@ class FileCmd:
             return 1.0
 
         bbox_x, bbox_y, bbox_w, bbox_h = bbox
-        area_x, area_y, area_w, area_h = config.machine.work_area
+        area_x, area_y, area_w, area_h = config.machine.workspace_work_area
         logger.debug(
             f"_fit_and_position_at_reference_origin: bbox=({bbox_x:.2f}, "
             f"{bbox_y:.2f}, {bbox_w:.2f}, {bbox_h:.2f}), "

--- a/rayforge/doceditor/layout/auto.py
+++ b/rayforge/doceditor/layout/auto.py
@@ -169,7 +169,7 @@ class PixelPerfectLayoutStrategy(LayoutStrategy):
             wa_w, wa_h = 200.0, 200.0  # Fallback
             machine = get_context().machine
             if machine:
-                work_area = machine.work_area
+                work_area = machine.workspace_work_area
                 wa_w, wa_h = work_area[2], work_area[3]
                 ref_x, ref_y = machine.get_reference_position_world()
                 space = machine.get_coordinate_space()

--- a/rayforge/doceditor/layout/auto.py
+++ b/rayforge/doceditor/layout/auto.py
@@ -169,7 +169,7 @@ class PixelPerfectLayoutStrategy(LayoutStrategy):
             wa_w, wa_h = 200.0, 200.0  # Fallback
             machine = get_context().machine
             if machine:
-                work_area = machine.workspace_work_area
+                work_area = machine.workspace.work_area
                 wa_w, wa_h = work_area[2], work_area[3]
                 ref_x, ref_y = machine.get_reference_position_world()
                 space = machine.get_coordinate_space()

--- a/rayforge/doceditor/stock_cmd.py
+++ b/rayforge/doceditor/stock_cmd.py
@@ -132,7 +132,7 @@ class StockCmd:
         doc = self._editor.doc
         machine = self._editor.context.config.machine
         if machine:
-            __, __, wa_w, wa_h = machine.workspace_work_area
+            __, __, wa_w, wa_h = machine.workspace.work_area
             ref_x, ref_y = machine.get_reference_position_world()
             stock_x = ref_x
             stock_y = ref_y

--- a/rayforge/doceditor/stock_cmd.py
+++ b/rayforge/doceditor/stock_cmd.py
@@ -132,7 +132,7 @@ class StockCmd:
         doc = self._editor.doc
         machine = self._editor.context.config.machine
         if machine:
-            __, __, wa_w, wa_h = machine.work_area
+            __, __, wa_w, wa_h = machine.workspace_work_area
             ref_x, ref_y = machine.get_reference_position_world()
             stock_x = ref_x
             stock_y = ref_y

--- a/rayforge/machine/device/profile.py
+++ b/rayforge/machine/device/profile.py
@@ -18,6 +18,7 @@ from ...machine.models.machine import Machine, Origin
 from ...machine.models.macro import Macro, MacroTrigger
 from ...machine.models.rotary_module import RotaryModule
 from ...machine.models.zone import Zone
+from ...pipeline.coordspace import WorkspaceOrientation
 from ...shared.units.system import UnitSystem
 
 if TYPE_CHECKING:
@@ -100,6 +101,14 @@ def parse_machine_config(data: dict, manifest_path: Path) -> "MachineConfig":
                     f"Invalid unit_system '{raw['unit_system']}' in "
                     f"{manifest_path}. Must be one of: "
                     f"{sorted(u.value for u in UnitSystem)}"
+                )
+        elif key == "workspace_orientation":
+            try:
+                value = WorkspaceOrientation(value)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid workspace_orientation "
+                    f"'{raw['workspace_orientation']}' in {manifest_path}"
                 )
         elif key in _TUPLE_FIELDS:
             value = tuple(value)
@@ -217,6 +226,7 @@ class MachineConfig:
     work_margins: tuple[float, float, float, float] | None = None
     soft_limits: tuple[float, float, float, float] | None = None
     origin: Origin | None = None
+    workspace_orientation: WorkspaceOrientation | None = None
     max_travel_speed: int | None = None
     max_cut_speed: int | None = None
     home_on_start: bool | None = None
@@ -238,7 +248,7 @@ class MachineConfig:
                 continue
             if isinstance(value, tuple):
                 result[key] = list(value)
-            elif isinstance(value, (Origin, UnitSystem)):
+            elif isinstance(value, (Origin, WorkspaceOrientation, UnitSystem)):
                 result[key] = value.value
             else:
                 result[key] = value
@@ -297,6 +307,7 @@ class MachineConfig:
             work_margins=work_margins,
             soft_limits=machine.soft_limits,
             origin=machine.origin,
+            workspace_orientation=machine.workspace_orientation,
             max_travel_speed=machine.max_travel_speed,
             max_cut_speed=machine.max_cut_speed,
             home_on_start=machine.home_on_start,
@@ -444,6 +455,10 @@ class DeviceProfile:
             m.set_soft_limits(*cfg.soft_limits)
         if cfg.origin is not None:
             m.origin = cfg.origin
+        if cfg.workspace_orientation is not None:
+            # Profile cameras replace the machine's cameras below and their
+            # saved alignment already uses the profile's orientation.
+            m.workspace_orientation = cfg.workspace_orientation
         if cfg.max_travel_speed is not None:
             m.max_travel_speed = cfg.max_travel_speed
         if cfg.max_cut_speed is not None:

--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
 )
 
+import numpy as np
 from blinker import Signal
 from raygeo.geo.types import Point3D, Rect
 from raygeo.ops.axis import Axis
@@ -22,7 +23,11 @@ from ...context import RayforgeContext, get_context
 from ...core.capability import MachineCapability
 from ...core.layer import Layer
 from ...core.model import Model
-from ...pipeline.coordspace import MachineSpace
+from ...pipeline.coordspace import (
+    MachineSpace,
+    OriginCorner,
+    WorkspaceOrientation,
+)
 from ...shared.tasker import task_mgr
 from ...shared.units.system import UnitSystem
 from ..assembly import Assembly
@@ -37,7 +42,7 @@ from .laser import Laser, LaserHead
 from .machine_hours import MachineHours
 from .macro import Macro, MacroTrigger
 from .rotary_module import RotaryMode, RotaryModule
-from .zone import Zone
+from .zone import Zone, ZoneShape
 
 if TYPE_CHECKING:
     from ...core.capability import StepCapability
@@ -154,6 +159,9 @@ class Machine:
         )
         self._soft_limits: Rect | None = None
         self.origin: Origin = Origin.BOTTOM_LEFT
+        self.workspace_orientation: WorkspaceOrientation = (
+            WorkspaceOrientation.NATIVE
+        )
         self.rotary_enabled_default: bool = False
         self.default_rotary_module_uid: str | None = None
         self.soft_limits_enabled: bool = True
@@ -182,6 +190,7 @@ class Machine:
 
         self.rotary_modules: dict[str, RotaryModule] = {}
         self.nogo_zones: dict[str, Zone] = {}
+        self._workspace_nogo_zones_cache: dict[str, Zone] | None = None
 
         self._assembly: Assembly | None = None
         self._assembly_dirty: bool = True
@@ -667,6 +676,21 @@ class Machine:
         )
 
     @property
+    def workspace_extents(self) -> tuple[float, float]:
+        """Dimensions of the machine bed as presented in the editor."""
+        return self.get_coordinate_space().workspace_extents
+
+    @property
+    def workspace_margins(self) -> Rect:
+        """Native work margins rotated into workspace edge order."""
+        return self.get_coordinate_space().workspace_margins
+
+    @property
+    def workspace_work_area(self) -> Rect:
+        """Usable work area in workspace coordinates."""
+        return self.get_coordinate_space().get_workarea_world_rect()
+
+    @property
     def reverse_x_axis(self) -> bool:
         cfg = self.axes.get(Axis.X)
         return cfg.direction == AxisDirection.REVERSED if cfg else False
@@ -701,6 +725,7 @@ class Machine:
     def set_axis_extents(self, width: float, height: float):
         if self.axis_extents == (width, height):
             return
+        old_space = self.get_coordinate_space()
         x_cfg = self.axes.get(Axis.X)
         y_cfg = self.axes.get(Axis.Y)
         if x_cfg:
@@ -714,6 +739,10 @@ class Machine:
         mb = min(mb, height - mt - 1)
         self._work_margins = (ml, mt, mr, mb)
         self._clamp_soft_limits()
+        self._workspace_nogo_zones_cache = None
+        self._reproject_camera_alignments(
+            old_space, self.get_coordinate_space()
+        )
         self.changed.send(self)
 
     @property
@@ -778,6 +807,60 @@ class Machine:
             return
         self.origin = origin
         self.changed.send(self)
+
+    def set_workspace_orientation(
+        self, orientation: WorkspaceOrientation
+    ) -> None:
+        """Set how the native machine bed is presented in the workspace.
+
+        All interactive changes of the orientation MUST go through this
+        setter rather than assigning `workspace_orientation` directly.
+
+        Unlike no-go zones (which are stored in native-bed coordinates and
+        projected on read, see `workspace_nogo_zones`), camera calibration
+        (`camera.image_to_world`) is stored in workspace coordinates because
+        the camera pipeline consumes it directly in that space. Any setting
+        that changes the native-bed presentation therefore re-projects the
+        stored calibration points through the old and new spaces so an
+        existing physical alignment stays valid. This includes both this
+        setter and :meth:`set_axis_extents`, because a rotated presentation's
+        translation depends on the native bed dimensions.
+        The rotation matrices contain only 0/±1 entries and exact
+        translations, so repeated re-projection does not accumulate
+        floating-point error.
+
+        Deserialization (`from_dict`) assigns the attribute directly instead,
+        because persisted camera calibration was already saved in the
+        matching workspace orientation.
+        """
+        if self.workspace_orientation == orientation:
+            return
+        old_space = self.get_coordinate_space()
+        self.workspace_orientation = orientation
+        self._workspace_nogo_zones_cache = None
+        new_space = self.get_coordinate_space()
+        self._reproject_camera_alignments(old_space, new_space)
+        self.changed.send(self)
+
+    def _reproject_camera_alignments(
+        self, old_space: MachineSpace, new_space: MachineSpace
+    ) -> None:
+        """Preserve physical camera calibration across presentation changes."""
+        for camera in self.cameras:
+            if camera.image_to_world is None:
+                continue
+            image_points, world_points = camera.image_to_world
+            projected_points = []
+            for world_x, world_y in world_points:
+                native_point = old_space.workspace_point_to_native_bed(
+                    world_x, world_y
+                )
+                projected_points.append(
+                    new_space.native_bed_point_to_workspace(*native_point)
+                )
+            alignment_date = camera.alignment_date
+            camera.image_to_world = (image_points, projected_points)
+            camera.alignment_date = alignment_date
 
     def set_reverse_x_axis(self, is_reversed: bool):
         """Sets if the X-axis coordinate display is inverted."""
@@ -887,6 +970,29 @@ class Machine:
         if direction == JogDirection.DOWN:
             return distance if self.reverse_z_axis else -distance
         return 0.0
+
+    def calculate_visual_jog(
+        self, direction: JogDirection, distance: float
+    ) -> dict[Axis, float]:
+        """Map a visual jog direction to native controller axis deltas."""
+        if direction in (JogDirection.UP, JogDirection.DOWN):
+            return {Axis.Z: self.calculate_jog(direction, distance)}
+
+        world_deltas = {
+            JogDirection.EAST: (distance, 0.0),
+            JogDirection.WEST: (-distance, 0.0),
+            JogDirection.NORTH: (0.0, distance),
+            JogDirection.SOUTH: (0.0, -distance),
+        }
+        dx, dy = world_deltas.get(direction, (0.0, 0.0))
+        matrix = self.get_coordinate_space().get_world_to_machine_matrix()
+        machine_delta = matrix @ np.array([dx, dy, 0.0, 0.0])
+        result = {}
+        if abs(machine_delta[0]) > 1e-9:
+            result[Axis.X] = float(machine_delta[0])
+        if abs(machine_delta[1]) > 1e-9:
+            result[Axis.Y] = float(machine_delta[1])
+        return result
 
     def set_soft_limits_enabled(self, enabled: bool):
         """Enable or disable soft limits for jog operations."""
@@ -1171,18 +1277,61 @@ class Machine:
 
     def add_nogo_zone(self, zone: Zone):
         self.nogo_zones[zone.uid] = zone
+        self._workspace_nogo_zones_cache = None
         zone.changed.connect(self._on_nogo_zone_changed)
         self.changed.send(self)
 
     def get_nogo_zone_by_uid(self, uid: str) -> Zone | None:
         return self.nogo_zones.get(uid)
 
+    @property
+    def workspace_nogo_zones(self) -> dict[str, Zone]:
+        """Return physical no-go zones projected into workspace space.
+
+        Profiles retain native-bed coordinates so changing the presentation
+        orientation never rewrites machine configuration.
+
+        When rotated, the returned zones are cached, READ-ONLY projections
+        for display and sanity checks. Mutating them does not affect the
+        stored zones, and their `changed` signals are not connected. Edit
+        zones via `nogo_zones` in native-bed coordinates only. Canvas zone
+        elements are neither selectable nor draggable.
+        """
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return self.nogo_zones
+        if self._workspace_nogo_zones_cache is not None:
+            return self._workspace_nogo_zones_cache
+
+        space = self.get_coordinate_space()
+        projected: dict[str, Zone] = {}
+        for uid, zone in self.nogo_zones.items():
+            workspace_zone = Zone.from_dict(zone.to_dict())
+            params = workspace_zone.params
+            x = params.get("x", 0.0)
+            y = params.get("y", 0.0)
+            if workspace_zone.shape == ZoneShape.CYLINDER:
+                params["x"], params["y"] = space.native_bed_point_to_workspace(
+                    x, y
+                )
+            else:
+                pos, size = space.native_bed_item_to_workspace(
+                    (x, y),
+                    (params.get("w", 10.0), params.get("h", 10.0)),
+                )
+                params["x"], params["y"] = pos
+                params["w"], params["h"] = size
+            projected[uid] = workspace_zone
+        self._workspace_nogo_zones_cache = projected
+        return self._workspace_nogo_zones_cache
+
     def remove_nogo_zone(self, zone: Zone):
         zone.changed.disconnect(self._on_nogo_zone_changed)
         del self.nogo_zones[zone.uid]
+        self._workspace_nogo_zones_cache = None
         self.changed.send(self)
 
     def _on_nogo_zone_changed(self, zone, *args):
+        self._workspace_nogo_zones_cache = None
         self.changed.send(self)
 
     def _on_machine_hours_changed(self, machine_hours, *args):
@@ -1289,14 +1438,16 @@ class Machine:
         Returns:
             Tuple of (x, y) in WORLD space.
         """
-        ml, mt, mr, mb = self._work_margins
-        width, height = self.axis_extents
+        space = self.get_coordinate_space()
+        ml, mt, mr, mb = space.workspace_margins
+        width, height = space.workspace_extents
+        origin = space.workspace_origin
 
-        if self.origin == Origin.BOTTOM_LEFT:
+        if origin == OriginCorner.BOTTOM_LEFT:
             return (ml, mb)
-        elif self.origin == Origin.TOP_LEFT:
+        elif origin == OriginCorner.TOP_LEFT:
             return (ml, height - mt)
-        elif self.origin == Origin.BOTTOM_RIGHT:
+        elif origin == OriginCorner.BOTTOM_RIGHT:
             return (width - mr, mb)
         else:  # TOP_RIGHT
             return (width - mr, height - mt)
@@ -1329,6 +1480,8 @@ class Machine:
             Tuple of (x, y) in WORLD space.
         """
         offset_x, offset_y, _ = self.get_reference_offset()
+        if self.wcs_origin_is_workarea_origin:
+            return offset_x, offset_y
         machine_space = MachineSpace.from_machine(self)
         return machine_space.machine_point_to_world(offset_x, offset_y)
 
@@ -1364,8 +1517,8 @@ class Machine:
             Tuple of (x, y, width, height) where x,y is the frame position
             relative to the work area origin (0,0).
         """
-        ml, mb = self._work_margins[0], self._work_margins[3]
-        extent_w, extent_h = self.axis_extents
+        ml, mb = self.workspace_margins[0], self.workspace_margins[3]
+        extent_w, extent_h = self.workspace_extents
         return (float(-ml), float(-mb), float(extent_w), float(extent_h))
 
     def has_custom_work_area(self) -> bool:
@@ -1483,6 +1636,7 @@ class Machine:
                 if self._soft_limits
                 else None,
                 "origin": self.origin.value,
+                "workspace_orientation": self.workspace_orientation.value,
                 "reverse_x_axis": self.reverse_x_axis,
                 "reverse_y_axis": self.reverse_y_axis,
                 "reverse_z_axis": self.reverse_z_axis,
@@ -1718,6 +1872,21 @@ class Machine:
                 if ma_data.get("y_axis_down", False) is False
                 else Origin.TOP_LEFT
             )
+
+        orientation_value = ma_data.get(
+            "workspace_orientation", WorkspaceOrientation.NATIVE.value
+        )
+        try:
+            # Direct assignment (not set_workspace_orientation): persisted
+            # camera calibration was saved in this orientation already, so
+            # it must not be re-projected here.
+            ma.workspace_orientation = WorkspaceOrientation(orientation_value)
+        except ValueError:
+            logger.warning(
+                "Unknown workspace orientation '%s'; using native",
+                orientation_value,
+            )
+            ma.workspace_orientation = WorkspaceOrientation.NATIVE
 
         ma.rotary_enabled_default = ma_data.get(
             "rotary_enabled_default", False

--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -12,7 +12,6 @@ from typing import (
     Optional,
 )
 
-import numpy as np
 from blinker import Signal
 from raygeo.geo.types import Point3D, Rect
 from raygeo.ops.axis import Axis
@@ -25,7 +24,6 @@ from ...core.layer import Layer
 from ...core.model import Model
 from ...pipeline.coordspace import (
     MachineSpace,
-    OriginCorner,
     WorkspaceOrientation,
 )
 from ...shared.tasker import task_mgr
@@ -40,9 +38,10 @@ from .dialect import GcodeDialect
 from .head import Head, head_from_dict
 from .laser import Laser, LaserHead
 from .machine_hours import MachineHours
+from .machine_view import JogDirection, MachineView
 from .macro import Macro, MacroTrigger
 from .rotary_module import RotaryMode, RotaryModule
-from .zone import Zone, ZoneShape
+from .zone import Zone
 
 if TYPE_CHECKING:
     from ...core.capability import StepCapability
@@ -57,17 +56,6 @@ class Origin(Enum):
     BOTTOM_LEFT = "bottom_left"
     TOP_RIGHT = "top_right"
     BOTTOM_RIGHT = "bottom_right"
-
-
-class JogDirection(Enum):
-    """Visual direction for jog operations."""
-
-    EAST = "east"
-    WEST = "west"
-    NORTH = "north"
-    SOUTH = "south"
-    UP = "up"
-    DOWN = "down"
 
 
 logger = logging.getLogger(__name__)
@@ -162,6 +150,7 @@ class Machine:
         self.workspace_orientation: WorkspaceOrientation = (
             WorkspaceOrientation.NATIVE
         )
+        self.workspace = MachineView(self)
         self.rotary_enabled_default: bool = False
         self.default_rotary_module_uid: str | None = None
         self.soft_limits_enabled: bool = True
@@ -190,7 +179,6 @@ class Machine:
 
         self.rotary_modules: dict[str, RotaryModule] = {}
         self.nogo_zones: dict[str, Zone] = {}
-        self._workspace_nogo_zones_cache: dict[str, Zone] | None = None
 
         self._assembly: Assembly | None = None
         self._assembly_dirty: bool = True
@@ -676,21 +664,6 @@ class Machine:
         )
 
     @property
-    def workspace_extents(self) -> tuple[float, float]:
-        """Dimensions of the machine bed as presented in the editor."""
-        return self.get_coordinate_space().workspace_extents
-
-    @property
-    def workspace_margins(self) -> Rect:
-        """Native work margins rotated into workspace edge order."""
-        return self.get_coordinate_space().workspace_margins
-
-    @property
-    def workspace_work_area(self) -> Rect:
-        """Usable work area in workspace coordinates."""
-        return self.get_coordinate_space().get_workarea_world_rect()
-
-    @property
     def reverse_x_axis(self) -> bool:
         cfg = self.axes.get(Axis.X)
         return cfg.direction == AxisDirection.REVERSED if cfg else False
@@ -739,7 +712,6 @@ class Machine:
         mb = min(mb, height - mt - 1)
         self._work_margins = (ml, mt, mr, mb)
         self._clamp_soft_limits()
-        self._workspace_nogo_zones_cache = None
         self._reproject_camera_alignments(
             old_space, self.get_coordinate_space()
         )
@@ -817,7 +789,7 @@ class Machine:
         setter rather than assigning `workspace_orientation` directly.
 
         Unlike no-go zones (which are stored in native-bed coordinates and
-        projected on read, see `workspace_nogo_zones`), camera calibration
+        projected by :class:`MachineView`), camera calibration
         (`camera.image_to_world`) is stored in workspace coordinates because
         the camera pipeline consumes it directly in that space. Any setting
         that changes the native-bed presentation therefore re-projects the
@@ -837,10 +809,13 @@ class Machine:
             return
         old_space = self.get_coordinate_space()
         self.workspace_orientation = orientation
-        self._workspace_nogo_zones_cache = None
         new_space = self.get_coordinate_space()
         self._reproject_camera_alignments(old_space, new_space)
         self.changed.send(self)
+
+    def supports_rotary_workspace(self) -> bool:
+        """Whether rotary mapping can compose with this workspace setup."""
+        return self.workspace_orientation is WorkspaceOrientation.NATIVE
 
     def _reproject_camera_alignments(
         self, old_space: MachineSpace, new_space: MachineSpace
@@ -970,29 +945,6 @@ class Machine:
         if direction == JogDirection.DOWN:
             return distance if self.reverse_z_axis else -distance
         return 0.0
-
-    def calculate_visual_jog(
-        self, direction: JogDirection, distance: float
-    ) -> dict[Axis, float]:
-        """Map a visual jog direction to native controller axis deltas."""
-        if direction in (JogDirection.UP, JogDirection.DOWN):
-            return {Axis.Z: self.calculate_jog(direction, distance)}
-
-        world_deltas = {
-            JogDirection.EAST: (distance, 0.0),
-            JogDirection.WEST: (-distance, 0.0),
-            JogDirection.NORTH: (0.0, distance),
-            JogDirection.SOUTH: (0.0, -distance),
-        }
-        dx, dy = world_deltas.get(direction, (0.0, 0.0))
-        matrix = self.get_coordinate_space().get_world_to_machine_matrix()
-        machine_delta = matrix @ np.array([dx, dy, 0.0, 0.0])
-        result = {}
-        if abs(machine_delta[0]) > 1e-9:
-            result[Axis.X] = float(machine_delta[0])
-        if abs(machine_delta[1]) > 1e-9:
-            result[Axis.Y] = float(machine_delta[1])
-        return result
 
     def set_soft_limits_enabled(self, enabled: bool):
         """Enable or disable soft limits for jog operations."""
@@ -1277,61 +1229,18 @@ class Machine:
 
     def add_nogo_zone(self, zone: Zone):
         self.nogo_zones[zone.uid] = zone
-        self._workspace_nogo_zones_cache = None
         zone.changed.connect(self._on_nogo_zone_changed)
         self.changed.send(self)
 
     def get_nogo_zone_by_uid(self, uid: str) -> Zone | None:
         return self.nogo_zones.get(uid)
 
-    @property
-    def workspace_nogo_zones(self) -> dict[str, Zone]:
-        """Return physical no-go zones projected into workspace space.
-
-        Profiles retain native-bed coordinates so changing the presentation
-        orientation never rewrites machine configuration.
-
-        When rotated, the returned zones are cached, READ-ONLY projections
-        for display and sanity checks. Mutating them does not affect the
-        stored zones, and their `changed` signals are not connected. Edit
-        zones via `nogo_zones` in native-bed coordinates only. Canvas zone
-        elements are neither selectable nor draggable.
-        """
-        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
-            return self.nogo_zones
-        if self._workspace_nogo_zones_cache is not None:
-            return self._workspace_nogo_zones_cache
-
-        space = self.get_coordinate_space()
-        projected: dict[str, Zone] = {}
-        for uid, zone in self.nogo_zones.items():
-            workspace_zone = Zone.from_dict(zone.to_dict())
-            params = workspace_zone.params
-            x = params.get("x", 0.0)
-            y = params.get("y", 0.0)
-            if workspace_zone.shape == ZoneShape.CYLINDER:
-                params["x"], params["y"] = space.native_bed_point_to_workspace(
-                    x, y
-                )
-            else:
-                pos, size = space.native_bed_item_to_workspace(
-                    (x, y),
-                    (params.get("w", 10.0), params.get("h", 10.0)),
-                )
-                params["x"], params["y"] = pos
-                params["w"], params["h"] = size
-            projected[uid] = workspace_zone
-        self._workspace_nogo_zones_cache = projected
-        return self._workspace_nogo_zones_cache
-
     def remove_nogo_zone(self, zone: Zone):
         zone.changed.disconnect(self._on_nogo_zone_changed)
         del self.nogo_zones[zone.uid]
-        self._workspace_nogo_zones_cache = None
         self.changed.send(self)
 
     def _on_nogo_zone_changed(self, zone, *args):
-        self._workspace_nogo_zones_cache = None
         self.changed.send(self)
 
     def _on_machine_hours_changed(self, machine_hours, *args):
@@ -1438,16 +1347,14 @@ class Machine:
         Returns:
             Tuple of (x, y) in WORLD space.
         """
-        space = self.get_coordinate_space()
-        ml, mt, mr, mb = space.workspace_margins
-        width, height = space.workspace_extents
-        origin = space.workspace_origin
+        ml, mt, mr, mb = self._work_margins
+        width, height = self.axis_extents
 
-        if origin == OriginCorner.BOTTOM_LEFT:
+        if self.origin == Origin.BOTTOM_LEFT:
             return (ml, mb)
-        elif origin == OriginCorner.TOP_LEFT:
+        elif self.origin == Origin.TOP_LEFT:
             return (ml, height - mt)
-        elif origin == OriginCorner.BOTTOM_RIGHT:
+        elif self.origin == Origin.BOTTOM_RIGHT:
             return (width - mr, mb)
         else:  # TOP_RIGHT
             return (width - mr, height - mt)
@@ -1480,8 +1387,6 @@ class Machine:
             Tuple of (x, y) in WORLD space.
         """
         offset_x, offset_y, _ = self.get_reference_offset()
-        if self.wcs_origin_is_workarea_origin:
-            return offset_x, offset_y
         machine_space = MachineSpace.from_machine(self)
         return machine_space.machine_point_to_world(offset_x, offset_y)
 
@@ -1517,8 +1422,8 @@ class Machine:
             Tuple of (x, y, width, height) where x,y is the frame position
             relative to the work area origin (0,0).
         """
-        ml, mb = self.workspace_margins[0], self.workspace_margins[3]
-        extent_w, extent_h = self.workspace_extents
+        ml, mb = self._work_margins[0], self._work_margins[3]
+        extent_w, extent_h = self.axis_extents
         return (float(-ml), float(-mb), float(extent_w), float(extent_h))
 
     def has_custom_work_area(self) -> bool:

--- a/rayforge/machine/models/machine_view.py
+++ b/rayforge/machine/models/machine_view.py
@@ -1,0 +1,119 @@
+"""Workspace-facing projection of a machine configuration."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import numpy as np
+from raygeo.geo.types import Rect
+from raygeo.ops.axis import Axis
+
+from ...pipeline.coordspace import MachineSpace
+from .zone import Zone, ZoneShape
+
+if TYPE_CHECKING:
+    from .machine import Machine
+
+
+class JogDirection(Enum):
+    """Visual direction for jog operations."""
+
+    EAST = "east"
+    WEST = "west"
+    NORTH = "north"
+    SOUTH = "south"
+    UP = "up"
+    DOWN = "down"
+
+
+@dataclass(frozen=True)
+class MachineView:
+    """Read-only workspace presentation of a native machine model.
+
+    The machine remains the source of truth in native bed coordinates. This
+    facade projects that state for display and interaction, keeping view-only
+    rotation logic out of :class:`Machine` and avoiding mutable projection
+    caches that need manual invalidation.
+    """
+
+    machine: "Machine"
+
+    @property
+    def space(self) -> MachineSpace:
+        """Current coordinate-space projection for the machine."""
+        return self.machine.get_coordinate_space()
+
+    @property
+    def extents(self) -> tuple[float, float]:
+        """Dimensions of the machine bed as presented in the editor."""
+        return self.space.workspace_extents
+
+    @property
+    def margins(self) -> Rect:
+        """Native work margins rotated into workspace edge order."""
+        return self.space.workspace_margins
+
+    @property
+    def work_area(self) -> Rect:
+        """Usable work area in workspace coordinates."""
+        return self.space.get_workarea_world_rect()
+
+    @property
+    def extent_frame(self) -> Rect:
+        """Full bed frame relative to the workspace work-area origin."""
+        ml, _, _, mb = self.margins
+        extent_w, extent_h = self.extents
+        return (float(-ml), float(-mb), float(extent_w), float(extent_h))
+
+    @property
+    def nogo_zones(self) -> dict[str, Zone]:
+        """Return read-only no-go-zone projections in workspace space.
+
+        A detached copy is returned for every orientation, including Native,
+        so callers never receive an API whose mutation behavior changes when
+        the workspace rotates. Edits must go through ``machine.nogo_zones``
+        in native bed coordinates.
+        """
+        space = self.space
+        projected: dict[str, Zone] = {}
+        for uid, zone in self.machine.nogo_zones.items():
+            workspace_zone = Zone.from_dict(zone.to_dict())
+            params = workspace_zone.params
+            x = params.get("x", 0.0)
+            y = params.get("y", 0.0)
+            if workspace_zone.shape == ZoneShape.CYLINDER:
+                params["x"], params["y"] = space.native_bed_point_to_workspace(
+                    x, y
+                )
+            else:
+                pos, size = space.native_bed_item_to_workspace(
+                    (x, y),
+                    (params.get("w", 10.0), params.get("h", 10.0)),
+                )
+                params["x"], params["y"] = pos
+                params["w"], params["h"] = size
+            projected[uid] = workspace_zone
+        return projected
+
+    def calculate_jog(
+        self, direction: JogDirection, distance: float
+    ) -> dict[Axis, float]:
+        """Map a visual jog direction to native controller axis deltas."""
+        if direction in (JogDirection.UP, JogDirection.DOWN):
+            return {Axis.Z: self.machine.calculate_jog(direction, distance)}
+
+        workspace_deltas = {
+            JogDirection.EAST: (distance, 0.0),
+            JogDirection.WEST: (-distance, 0.0),
+            JogDirection.NORTH: (0.0, distance),
+            JogDirection.SOUTH: (0.0, -distance),
+        }
+        dx, dy = workspace_deltas.get(direction, (0.0, 0.0))
+        matrix = self.space.get_world_to_machine_matrix()
+        machine_delta = matrix @ np.array([dx, dy, 0.0, 0.0])
+        result = {}
+        if abs(machine_delta[0]) > 1e-9:
+            result[Axis.X] = float(machine_delta[0])
+        if abs(machine_delta[1]) > 1e-9:
+            result[Axis.Y] = float(machine_delta[1])
+        return result

--- a/rayforge/machine/sanity/checker.py
+++ b/rayforge/machine/sanity/checker.py
@@ -59,11 +59,11 @@ class SanityChecker:
         return SanityContext(
             ops=ops,
             machine=self._machine,
-            work_area=self._machine.workspace_work_area,
-            axis_extents=self._machine.workspace_extents,
+            work_area=self._machine.workspace.work_area,
+            axis_extents=self._machine.workspace.extents,
             enabled_zones={
                 k: v
-                for k, v in self._machine.workspace_nogo_zones.items()
+                for k, v in self._machine.workspace.nogo_zones.items()
                 if v.enabled
             },
         )

--- a/rayforge/machine/sanity/checker.py
+++ b/rayforge/machine/sanity/checker.py
@@ -59,9 +59,11 @@ class SanityChecker:
         return SanityContext(
             ops=ops,
             machine=self._machine,
-            work_area=self._machine.work_area,
-            axis_extents=self._machine.axis_extents,
+            work_area=self._machine.workspace_work_area,
+            axis_extents=self._machine.workspace_extents,
             enabled_zones={
-                k: v for k, v in self._machine.nogo_zones.items() if v.enabled
+                k: v
+                for k, v in self._machine.workspace_nogo_zones.items()
+                if v.enabled
             },
         )

--- a/rayforge/pipeline/coordspace.py
+++ b/rayforge/pipeline/coordspace.py
@@ -87,6 +87,22 @@ class CoordinateSpace(ABC):
         return self.origin
 
     @property
+    def workspace_x_right(self) -> bool:
+        """Whether the displayed coordinate origin is on the right edge."""
+        return self.workspace_origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
+        )
+
+    @property
+    def workspace_y_down(self) -> bool:
+        """Whether displayed positive Y points down from a top origin."""
+        return self.workspace_origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+
+    @property
     def workspace_x_negative(self) -> bool:
         """Whether displayed workspace X maps to a reversed axis."""
         return self.reverse_x
@@ -370,26 +386,51 @@ class MachineSpace(CoordinateSpace):
         min_x, min_y = min(xs), min(ys)
         return (min_x, min_y), (max(xs) - min_x, max(ys) - min_y)
 
+    def workspace_item_to_native_bed(
+        self,
+        pos: Point,
+        size: tuple[float, float],
+    ) -> tuple[Point, tuple[float, float]]:
+        """Project an axis-aligned workspace rectangle into native bed
+        space."""
+        x, y = pos
+        width, height = size
+        corners = (
+            self.workspace_point_to_native_bed(x, y),
+            self.workspace_point_to_native_bed(x + width, y),
+            self.workspace_point_to_native_bed(x, y + height),
+            self.workspace_point_to_native_bed(x + width, y + height),
+        )
+        xs = [point[0] for point in corners]
+        ys = [point[1] for point in corners]
+        min_x, min_y = min(xs), min(ys)
+        return (min_x, min_y), (max(xs) - min_x, max(ys) - min_y)
+
     def get_transform_from_world(self) -> np.ndarray:
         """
-        Returns the inverse origin transformation matrix (world → machine).
+        Returns the inverse transformation matrix (world → machine).
 
-        Full machine output conversion, including workspace orientation and
-        controller axis reversals, is provided by
-        :meth:`get_world_to_machine_matrix`.
+        This is the inverse of get_transform_to_world(), used to convert
+        coordinates from native world space to machine space.
+
+        Note: This matrix handles origin corner transformation only.
+        Workspace orientation and reverse_x/reverse_y are applied separately.
 
         Returns:
             A 4x4 numpy array representing the inverse transformation matrix.
         """
-        return np.linalg.inv(super().get_transform_to_world(self.extents))
+        return np.linalg.inv(self.get_transform_to_world(self.extents))
 
-    @cached_property
-    def _world_to_machine_matrix(self) -> np.ndarray:
-        """Cached full world-to-machine transform. Do not mutate."""
-        native_world_to_machine = np.linalg.inv(
-            super().get_transform_to_world(self.extents)
+    def get_world_to_machine_matrix(self) -> np.ndarray:
+        """Return the full workspace-to-machine encoding transform.
+
+        The established native origin transform remains unchanged; the new
+        presentation rotation is composed immediately before it.
+        """
+        matrix = (
+            self.get_transform_to_world(self.extents)
+            @ self._workspace_to_native_matrix
         )
-        matrix = native_world_to_machine @ self._workspace_to_native_matrix
 
         if self.reverse_x or self.reverse_y:
             sign_flip = np.identity(4, dtype=np.float64)
@@ -400,25 +441,6 @@ class MachineSpace(CoordinateSpace):
             matrix = sign_flip @ matrix
 
         return matrix
-
-    @cached_property
-    def _machine_to_world_matrix(self) -> np.ndarray:
-        """Cached inverse of the world-to-machine transform."""
-        return np.linalg.inv(self._world_to_machine_matrix)
-
-    def get_world_to_machine_matrix(self) -> np.ndarray:
-        """
-        Returns the full 4x4 transformation matrix to convert from world space
-        to machine space for the encoding pipeline.
-
-        This combines workspace rotation, the origin corner transformation,
-        and the axis reversal sign flips.
-        """
-        return self._world_to_machine_matrix.copy()
-
-    def get_machine_to_world_matrix(self) -> np.ndarray:
-        """Return the full inverse native-machine to workspace transform."""
-        return self._machine_to_world_matrix.copy()
 
     def get_command_offset(
         self,
@@ -460,10 +482,10 @@ class MachineSpace(CoordinateSpace):
         """Returns the workspace (width, height) of the workarea in mm.
 
         Each side is clamped to a minimum of 1mm, mirroring
-        `Machine.work_area`. This property backs `workspace_work_area`,
-        which replaced `Machine.work_area` at its call sites, so the two
-        must agree: margins can reach or exceed the extents (device
-        profiles pass YAML margins through unvalidated), and downstream
+        `Machine.work_area`. This property backs `MachineView.work_area`,
+        which replaces `Machine.work_area` at workspace-facing call sites, so
+        both must agree. Margins can reach or exceed the extents because
+        device profiles pass YAML margins through unvalidated, and downstream
         layout and 3D viewport code assumes a positive work area.
         """
         ml, mt, mr, mb = self.workspace_margins
@@ -565,28 +587,36 @@ class MachineSpace(CoordinateSpace):
             Tuple of (x, y, z) origin offset for axis labels.
         """
         if wcs_is_workarea_origin:
-            machine_x, machine_y = self.get_workarea_origin_in_machine()
-        else:
-            machine_x, machine_y = wcs_offset[0], wcs_offset[1]
+            ml, mt, mr, mb = self.margins
+            origin_is_right = self.origin in (
+                OriginCorner.TOP_RIGHT,
+                OriginCorner.BOTTOM_RIGHT,
+            )
+            origin_is_top = self.origin in (
+                OriginCorner.TOP_LEFT,
+                OriginCorner.TOP_RIGHT,
+            )
+            if origin_is_right:
+                origin_x = mr
+            else:
+                origin_x = ml
 
-        world_x, world_y = self.machine_point_to_world(machine_x, machine_y)
-        width, height = self.workspace_extents
-        origin = self.workspace_origin
-        origin_is_right = origin in (
-            OriginCorner.TOP_RIGHT,
-            OriginCorner.BOTTOM_RIGHT,
-        )
-        origin_is_top = origin in (
-            OriginCorner.TOP_LEFT,
-            OriginCorner.TOP_RIGHT,
-        )
-        offset_x = width - world_x if origin_is_right else world_x
-        offset_y = height - world_y if origin_is_top else world_y
-        if self.workspace_x_negative:
-            offset_x = -offset_x
-        if self.workspace_y_negative:
-            offset_y = -offset_y
-        return float(offset_x), float(offset_y), 0.0
+            if origin_is_top:
+                origin_y = mt
+            else:
+                origin_y = mb
+
+            if self.reverse_x:
+                origin_x = -origin_x
+            if self.reverse_y:
+                origin_y = -origin_y
+            native_offset = (origin_x, origin_y, 0.0)
+        else:
+            native_offset = wcs_offset
+
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return native_offset
+        return (native_offset[1], native_offset[0], native_offset[2])
 
     def world_point_to_machine(self, x: float, y: float) -> Point:
         """
@@ -607,9 +637,34 @@ class MachineSpace(CoordinateSpace):
         Returns:
             Tuple of (x, y) in machine space.
         """
-        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
-        result = self._world_to_machine_matrix @ point
-        return float(result[0]), float(result[1])
+        x, y = self.workspace_point_to_native_bed(x, y)
+        width, height = self.extents
+
+        origin_is_right = self.origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
+        )
+        origin_is_top = self.origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+
+        if origin_is_right:
+            mx = width - x
+        else:
+            mx = x
+
+        if origin_is_top:
+            my = height - y
+        else:
+            my = y
+
+        if self.reverse_x:
+            mx = -mx
+        if self.reverse_y:
+            my = -my
+
+        return mx, my
 
     def machine_point_to_world(self, x: float, y: float) -> Point:
         """
@@ -627,9 +682,35 @@ class MachineSpace(CoordinateSpace):
         Returns:
             Tuple of (x, y) in world space.
         """
-        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
-        result = self._machine_to_world_matrix @ point
-        return float(result[0]), float(result[1])
+        mx, my = x, y
+
+        if self.reverse_x:
+            mx = -mx
+        if self.reverse_y:
+            my = -my
+
+        width, height = self.extents
+
+        origin_is_right = self.origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
+        )
+        origin_is_top = self.origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+
+        if origin_is_right:
+            wx = width - mx
+        else:
+            wx = mx
+
+        if origin_is_top:
+            wy = height - my
+        else:
+            wy = my
+
+        return self.native_bed_point_to_workspace(wx, wy)
 
     def world_item_to_machine(
         self,
@@ -649,18 +730,35 @@ class MachineSpace(CoordinateSpace):
         Returns:
             (x, y) position in machine coordinates.
         """
+        pos, size = self.workspace_item_to_native_bed(pos, size)
         wx, wy = pos
         w, h = size
-        corners = (
-            self.world_point_to_machine(wx, wy),
-            self.world_point_to_machine(wx + w, wy),
-            self.world_point_to_machine(wx, wy + h),
-            self.world_point_to_machine(wx + w, wy + h),
+        width, height = self.extents
+
+        origin_is_right = self.origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
         )
-        xs = [point[0] for point in corners]
-        ys = [point[1] for point in corners]
-        mx = max(xs) if self.reverse_x else min(xs)
-        my = max(ys) if self.reverse_y else min(ys)
+        origin_is_top = self.origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+
+        if origin_is_right:
+            mx = width - wx - w
+        else:
+            mx = wx
+
+        if origin_is_top:
+            my = height - wy - h
+        else:
+            my = wy
+
+        if self.reverse_x:
+            mx = -mx
+        if self.reverse_y:
+            my = -my
+
         return mx, my
 
     def machine_item_to_world(
@@ -687,25 +785,39 @@ class MachineSpace(CoordinateSpace):
             (x, y) position in world coordinates.
         """
         mx, my = pos
-        w, h = size
-        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
-            machine_w, machine_h = w, h
-        else:
-            machine_w, machine_h = h, w
+        native_size = (
+            size
+            if self.workspace_orientation == WorkspaceOrientation.NATIVE
+            else (size[1], size[0])
+        )
+        w, h = native_size
+        width, height = self.extents
 
         if self.reverse_x:
-            x_min, x_max = mx - machine_w, mx
-        else:
-            x_min, x_max = mx, mx + machine_w
+            mx = -mx
         if self.reverse_y:
-            y_min, y_max = my - machine_h, my
-        else:
-            y_min, y_max = my, my + machine_h
+            my = -my
 
-        corners = (
-            self.machine_point_to_world(x_min, y_min),
-            self.machine_point_to_world(x_max, y_min),
-            self.machine_point_to_world(x_min, y_max),
-            self.machine_point_to_world(x_max, y_max),
+        origin_is_right = self.origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
         )
-        return min(p[0] for p in corners), min(p[1] for p in corners)
+        origin_is_top = self.origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+
+        if origin_is_right:
+            wx = width - mx - w
+        else:
+            wx = mx
+
+        if origin_is_top:
+            wy = height - my - h
+        else:
+            wy = my
+
+        workspace_pos, _ = self.native_bed_item_to_workspace(
+            (wx, wy), native_size
+        )
+        return workspace_pos

--- a/rayforge/pipeline/coordspace.py
+++ b/rayforge/pipeline/coordspace.py
@@ -15,6 +15,7 @@ Coordinate Spaces:
 from abc import ABC
 from dataclasses import dataclass
 from enum import Enum, auto
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -42,6 +43,14 @@ class AxisDirection(Enum):
     POSITIVE_DOWN = auto()
 
 
+class WorkspaceOrientation(Enum):
+    """How the native machine bed is presented in the workspace."""
+
+    NATIVE = "native"
+    ROTATED_LEFT = "rotated_left"
+    ROTATED_RIGHT = "rotated_right"
+
+
 @dataclass(frozen=True)
 class CoordinateSpace(ABC):
     """
@@ -66,6 +75,26 @@ class CoordinateSpace(ABC):
     def y_reversed(self) -> bool:
         """True if Y axis positive direction is down."""
         return self.y_positive_direction == AxisDirection.POSITIVE_DOWN
+
+    @property
+    def workspace_origin(self) -> OriginCorner:
+        """The origin corner as presented in the workspace.
+
+        The base implementation is the identity: spaces without a
+        presentation rotation show their native origin. MachineSpace
+        overrides this to account for workspace_orientation.
+        """
+        return self.origin
+
+    @property
+    def workspace_x_negative(self) -> bool:
+        """Whether displayed workspace X maps to a reversed axis."""
+        return self.reverse_x
+
+    @property
+    def workspace_y_negative(self) -> bool:
+        """Whether displayed workspace Y maps to a reversed axis."""
+        return self.reverse_y
 
     def get_transform_to_world(
         self, extents: tuple[float, float]
@@ -157,10 +186,12 @@ class MachineSpace(CoordinateSpace):
     Attributes:
         extents: The (width, height) of the machine bed in mm.
         margins: The (left, top, right, bottom) margins in mm.
+        workspace_orientation: How the native bed is rotated in the editor.
     """
 
     extents: tuple[float, float] = (200.0, 200.0)
     margins: Rect = (0.0, 0.0, 0.0, 0.0)
+    workspace_orientation: WorkspaceOrientation = WorkspaceOrientation.NATIVE
 
     @classmethod
     def from_machine(cls, machine: "Machine") -> "MachineSpace":
@@ -190,8 +221,8 @@ class MachineSpace(CoordinateSpace):
         x_right = machine.origin in (Origin.TOP_RIGHT, Origin.BOTTOM_RIGHT)
 
         # Axis direction is based on origin position only.
-        # reverse_x/reverse_y are stored separately for controller
-        # sign flip handling in _machine_coords_to_canvas() and encoder.
+        # reverse_x/reverse_y are stored separately for controller coordinate
+        # conversion and encoding.
         x_dir = (
             AxisDirection.POSITIVE_LEFT
             if x_right
@@ -212,35 +243,153 @@ class MachineSpace(CoordinateSpace):
             margins=machine.work_margins,
             reverse_x=machine.reverse_x_axis,
             reverse_y=machine.reverse_y_axis,
+            workspace_orientation=machine.workspace_orientation,
         )
+
+    @property
+    def workspace_extents(self) -> tuple[float, float]:
+        """Returns the dimensions presented in world/workspace space."""
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return self.extents
+        return self.extents[1], self.extents[0]
+
+    @property
+    def workspace_margins(self) -> Rect:
+        """Returns native edge margins rotated into workspace order."""
+        left, top, right, bottom = self.margins
+        if self.workspace_orientation == WorkspaceOrientation.ROTATED_LEFT:
+            return top, right, bottom, left
+        if self.workspace_orientation == WorkspaceOrientation.ROTATED_RIGHT:
+            return bottom, left, top, right
+        return self.margins
+
+    @property
+    def workspace_origin(self) -> OriginCorner:
+        """Returns the native machine origin's visible workspace corner."""
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return self.origin
+        if self.workspace_orientation == WorkspaceOrientation.ROTATED_LEFT:
+            return {
+                OriginCorner.BOTTOM_LEFT: OriginCorner.BOTTOM_RIGHT,
+                OriginCorner.TOP_LEFT: OriginCorner.BOTTOM_LEFT,
+                OriginCorner.TOP_RIGHT: OriginCorner.TOP_LEFT,
+                OriginCorner.BOTTOM_RIGHT: OriginCorner.TOP_RIGHT,
+            }[self.origin]
+        return {
+            OriginCorner.BOTTOM_LEFT: OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_LEFT: OriginCorner.TOP_RIGHT,
+            OriginCorner.TOP_RIGHT: OriginCorner.BOTTOM_RIGHT,
+            OriginCorner.BOTTOM_RIGHT: OriginCorner.BOTTOM_LEFT,
+        }[self.origin]
+
+    @property
+    def workspace_x_negative(self) -> bool:
+        """Whether displayed workspace X maps to a reversed native axis."""
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return self.reverse_x
+        return self.reverse_y
+
+    @property
+    def workspace_y_negative(self) -> bool:
+        """Whether displayed workspace Y maps to a reversed native axis."""
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            return self.reverse_y
+        return self.reverse_x
+
+    @cached_property
+    def _workspace_to_native_matrix(self) -> np.ndarray:
+        """Cached rigid transform from workspace to native bed space.
+
+        Safe to cache because the dataclass is frozen. Do not mutate the
+        returned array; public callers get a copy via
+        :meth:`get_workspace_to_native_matrix`.
+        """
+        width, height = self.extents
+        matrix = np.identity(4, dtype=np.float64)
+        if self.workspace_orientation == WorkspaceOrientation.ROTATED_LEFT:
+            matrix[0, 0] = 0.0
+            matrix[0, 1] = 1.0
+            matrix[1, 0] = -1.0
+            matrix[1, 1] = 0.0
+            matrix[1, 3] = height
+        elif self.workspace_orientation == WorkspaceOrientation.ROTATED_RIGHT:
+            matrix[0, 0] = 0.0
+            matrix[0, 1] = -1.0
+            matrix[0, 3] = width
+            matrix[1, 0] = 1.0
+            matrix[1, 1] = 0.0
+        return matrix
+
+    @cached_property
+    def _native_to_workspace_matrix(self) -> np.ndarray:
+        """Cached inverse of the workspace-to-native transform."""
+        return np.linalg.inv(self._workspace_to_native_matrix)
+
+    def get_workspace_to_native_matrix(self) -> np.ndarray:
+        """Return the rigid transform from workspace to native bed space."""
+        return self._workspace_to_native_matrix.copy()
+
+    def get_native_to_workspace_matrix(self) -> np.ndarray:
+        """Return the rigid transform from native bed to workspace space."""
+        return self._native_to_workspace_matrix.copy()
+
+    def native_bed_point_to_workspace(self, x: float, y: float) -> Point:
+        """Project a physical native-bed point into the workspace.
+
+        Unlike :meth:`machine_point_to_world`, this applies only the
+        presentation rotation. It is intended for physical bed geometry such
+        as no-go zones, whose stored positions do not depend on the configured
+        controller origin or axis direction.
+        """
+        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
+        result = self._native_to_workspace_matrix @ point
+        return float(result[0]), float(result[1])
+
+    def workspace_point_to_native_bed(self, x: float, y: float) -> Point:
+        """Project a workspace point into canonical physical-bed space."""
+        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
+        result = self._workspace_to_native_matrix @ point
+        return float(result[0]), float(result[1])
+
+    def native_bed_item_to_workspace(
+        self,
+        pos: Point,
+        size: tuple[float, float],
+    ) -> tuple[Point, tuple[float, float]]:
+        """Project an axis-aligned native-bed rectangle into the workspace."""
+        x, y = pos
+        width, height = size
+        corners = (
+            self.native_bed_point_to_workspace(x, y),
+            self.native_bed_point_to_workspace(x + width, y),
+            self.native_bed_point_to_workspace(x, y + height),
+            self.native_bed_point_to_workspace(x + width, y + height),
+        )
+        xs = [point[0] for point in corners]
+        ys = [point[1] for point in corners]
+        min_x, min_y = min(xs), min(ys)
+        return (min_x, min_y), (max(xs) - min_x, max(ys) - min_y)
 
     def get_transform_from_world(self) -> np.ndarray:
         """
-        Returns the inverse transformation matrix (world → machine).
+        Returns the inverse origin transformation matrix (world → machine).
 
-        This is the inverse of get_transform_to_world(), used to convert
-        coordinates from world space to machine space.
-
-        Note: This matrix handles origin corner transformation only.
-        The reverse_x/reverse_y sign flips are applied separately in
-        world_point_to_machine().
+        Full machine output conversion, including workspace orientation and
+        controller axis reversals, is provided by
+        :meth:`get_world_to_machine_matrix`.
 
         Returns:
             A 4x4 numpy array representing the inverse transformation matrix.
         """
-        return np.linalg.inv(self.get_transform_to_world(self.extents))
+        return np.linalg.inv(super().get_transform_to_world(self.extents))
 
-    def get_world_to_machine_matrix(self) -> np.ndarray:
-        """
-        Returns the full 4x4 transformation matrix to convert from world space
-        to machine space for the encoding pipeline.
-
-        This combines the origin corner transformation with the axis
-        reversal sign flips.
-        """
-        # The reflection matrix to apply origin shift works identically in both
-        # directions (to_world / from_world) because it is its own inverse.
-        matrix = self.get_transform_to_world(self.extents)
+    @cached_property
+    def _world_to_machine_matrix(self) -> np.ndarray:
+        """Cached full world-to-machine transform. Do not mutate."""
+        native_world_to_machine = np.linalg.inv(
+            super().get_transform_to_world(self.extents)
+        )
+        matrix = native_world_to_machine @ self._workspace_to_native_matrix
 
         if self.reverse_x or self.reverse_y:
             sign_flip = np.identity(4, dtype=np.float64)
@@ -251,6 +400,25 @@ class MachineSpace(CoordinateSpace):
             matrix = sign_flip @ matrix
 
         return matrix
+
+    @cached_property
+    def _machine_to_world_matrix(self) -> np.ndarray:
+        """Cached inverse of the world-to-machine transform."""
+        return np.linalg.inv(self._world_to_machine_matrix)
+
+    def get_world_to_machine_matrix(self) -> np.ndarray:
+        """
+        Returns the full 4x4 transformation matrix to convert from world space
+        to machine space for the encoding pipeline.
+
+        This combines workspace rotation, the origin corner transformation,
+        and the axis reversal sign flips.
+        """
+        return self._world_to_machine_matrix.copy()
+
+    def get_machine_to_world_matrix(self) -> np.ndarray:
+        """Return the full inverse native-machine to workspace transform."""
+        return self._machine_to_world_matrix.copy()
 
     def get_command_offset(
         self,
@@ -289,19 +457,29 @@ class MachineSpace(CoordinateSpace):
 
     @property
     def workarea_size(self) -> tuple[float, float]:
-        """Returns the (width, height) of the workarea in mm."""
-        ml, mt, mr, mb = self.margins
-        width, height = self.extents
-        return width - ml - mr, height - mt - mb
+        """Returns the workspace (width, height) of the workarea in mm.
+
+        Each side is clamped to a minimum of 1mm, mirroring
+        `Machine.work_area`. This property backs `workspace_work_area`,
+        which replaced `Machine.work_area` at its call sites, so the two
+        must agree: margins can reach or exceed the extents (device
+        profiles pass YAML margins through unvalidated), and downstream
+        layout and 3D viewport code assumes a positive work area.
+        """
+        ml, mt, mr, mb = self.workspace_margins
+        width, height = self.workspace_extents
+        return (
+            max(1.0, width - ml - mr),
+            max(1.0, height - mt - mb),
+        )
 
     def get_workarea_world_rect(self) -> Rect:
         """
         Returns the work area boundary as a Rect in world space.
         """
-        pos = self.get_workarea_origin_in_machine()
+        ml, _, _, mb = self.workspace_margins
         w, h = self.workarea_size
-        wx, wy = self.machine_item_to_world(pos, (w, h))
-        return (wx, wy, w, h)
+        return float(ml), float(mb), float(w), float(h)
 
     def world_position_from_origin(
         self, ref_x: float, ref_y: float, size: tuple[float, float]
@@ -324,11 +502,12 @@ class MachineSpace(CoordinateSpace):
         """
         width, height = size
 
-        if self.origin == OriginCorner.BOTTOM_LEFT:
+        origin = self.workspace_origin
+        if origin == OriginCorner.BOTTOM_LEFT:
             return ref_x, ref_y
-        elif self.origin == OriginCorner.TOP_LEFT:
+        elif origin == OriginCorner.TOP_LEFT:
             return ref_x, ref_y - height
-        elif self.origin == OriginCorner.BOTTOM_RIGHT:
+        elif origin == OriginCorner.BOTTOM_RIGHT:
             return ref_x - width, ref_y
         else:  # TOP_RIGHT
             return ref_x - width, ref_y - height
@@ -386,36 +565,28 @@ class MachineSpace(CoordinateSpace):
             Tuple of (x, y, z) origin offset for axis labels.
         """
         if wcs_is_workarea_origin:
-            ml, mt, mr, mb = self.margins
-            _width, _height = self.extents
-
-            origin_is_right = self.origin in (
-                OriginCorner.TOP_RIGHT,
-                OriginCorner.BOTTOM_RIGHT,
-            )
-            origin_is_top = self.origin in (
-                OriginCorner.TOP_LEFT,
-                OriginCorner.TOP_RIGHT,
-            )
-
-            if origin_is_right:
-                origin_x = mr
-            else:
-                origin_x = ml
-
-            if origin_is_top:
-                origin_y = mt
-            else:
-                origin_y = mb
-
-            if self.reverse_x:
-                origin_x = -origin_x
-            if self.reverse_y:
-                origin_y = -origin_y
-
-            return (origin_x, origin_y, 0.0)
+            machine_x, machine_y = self.get_workarea_origin_in_machine()
         else:
-            return wcs_offset
+            machine_x, machine_y = wcs_offset[0], wcs_offset[1]
+
+        world_x, world_y = self.machine_point_to_world(machine_x, machine_y)
+        width, height = self.workspace_extents
+        origin = self.workspace_origin
+        origin_is_right = origin in (
+            OriginCorner.TOP_RIGHT,
+            OriginCorner.BOTTOM_RIGHT,
+        )
+        origin_is_top = origin in (
+            OriginCorner.TOP_LEFT,
+            OriginCorner.TOP_RIGHT,
+        )
+        offset_x = width - world_x if origin_is_right else world_x
+        offset_y = height - world_y if origin_is_top else world_y
+        if self.workspace_x_negative:
+            offset_x = -offset_x
+        if self.workspace_y_negative:
+            offset_y = -offset_y
+        return float(offset_x), float(offset_y), 0.0
 
     def world_point_to_machine(self, x: float, y: float) -> Point:
         """
@@ -425,8 +596,9 @@ class MachineSpace(CoordinateSpace):
         MACHINE space: Based on origin corner and axis reversal settings.
 
         This applies:
-        1. Origin corner transformation (via inverse matrix)
-        2. Axis reversal sign flip (reverse_x/reverse_y)
+        1. Workspace-to-native bed rotation
+        2. Native origin corner transformation
+        3. Axis reversal sign flip (reverse_x/reverse_y)
 
         Args:
             x: X coordinate in world space.
@@ -435,33 +607,9 @@ class MachineSpace(CoordinateSpace):
         Returns:
             Tuple of (x, y) in machine space.
         """
-        width, height = self.extents
-
-        origin_is_right = self.origin in (
-            OriginCorner.TOP_RIGHT,
-            OriginCorner.BOTTOM_RIGHT,
-        )
-        origin_is_top = self.origin in (
-            OriginCorner.TOP_LEFT,
-            OriginCorner.TOP_RIGHT,
-        )
-
-        if origin_is_right:
-            mx = width - x
-        else:
-            mx = x
-
-        if origin_is_top:
-            my = height - y
-        else:
-            my = y
-
-        if self.reverse_x:
-            mx = -mx
-        if self.reverse_y:
-            my = -my
-
-        return mx, my
+        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
+        result = self._world_to_machine_matrix @ point
+        return float(result[0]), float(result[1])
 
     def machine_point_to_world(self, x: float, y: float) -> Point:
         """
@@ -469,9 +617,8 @@ class MachineSpace(CoordinateSpace):
 
         Inverse of world_point_to_machine().
 
-        This applies:
-        1. Axis reversal sign flip (reverse_x/reverse_y)
-        2. Origin corner transformation (via matrix)
+        This reverses the axis sign, native origin, and workspace rotation
+        transformations applied by world_point_to_machine().
 
         Args:
             x: X coordinate in machine space.
@@ -480,35 +627,9 @@ class MachineSpace(CoordinateSpace):
         Returns:
             Tuple of (x, y) in world space.
         """
-        mx, my = x, y
-
-        if self.reverse_x:
-            mx = -mx
-        if self.reverse_y:
-            my = -my
-
-        width, height = self.extents
-
-        origin_is_right = self.origin in (
-            OriginCorner.TOP_RIGHT,
-            OriginCorner.BOTTOM_RIGHT,
-        )
-        origin_is_top = self.origin in (
-            OriginCorner.TOP_LEFT,
-            OriginCorner.TOP_RIGHT,
-        )
-
-        if origin_is_right:
-            wx = width - mx
-        else:
-            wx = mx
-
-        if origin_is_top:
-            wy = height - my
-        else:
-            wy = my
-
-        return wx, wy
+        point = np.array([x, y, 0.0, 1.0], dtype=np.float64)
+        result = self._machine_to_world_matrix @ point
+        return float(result[0]), float(result[1])
 
     def world_item_to_machine(
         self,
@@ -530,32 +651,16 @@ class MachineSpace(CoordinateSpace):
         """
         wx, wy = pos
         w, h = size
-        width, height = self.extents
-
-        origin_is_right = self.origin in (
-            OriginCorner.TOP_RIGHT,
-            OriginCorner.BOTTOM_RIGHT,
+        corners = (
+            self.world_point_to_machine(wx, wy),
+            self.world_point_to_machine(wx + w, wy),
+            self.world_point_to_machine(wx, wy + h),
+            self.world_point_to_machine(wx + w, wy + h),
         )
-        origin_is_top = self.origin in (
-            OriginCorner.TOP_LEFT,
-            OriginCorner.TOP_RIGHT,
-        )
-
-        if origin_is_right:
-            mx = width - wx - w
-        else:
-            mx = wx
-
-        if origin_is_top:
-            my = height - wy - h
-        else:
-            my = wy
-
-        if self.reverse_x:
-            mx = -mx
-        if self.reverse_y:
-            my = -my
-
+        xs = [point[0] for point in corners]
+        ys = [point[1] for point in corners]
+        mx = max(xs) if self.reverse_x else min(xs)
+        my = max(ys) if self.reverse_y else min(ys)
         return mx, my
 
     def machine_item_to_world(
@@ -569,39 +674,38 @@ class MachineSpace(CoordinateSpace):
         This handles the item's bounding box - for origins at right/bottom,
         the position refers to the top-left corner, which needs adjustment.
 
+        NOTE on spaces: `pos` is in MACHINE coordinates, but `size` is the
+        item's (width, height) in WORLD/workspace space. With a rotated
+        workspace orientation the two differ (width and height swap), so
+        callers must not pass a machine-space size here.
+
         Args:
             pos: (x, y) position in machine coordinates.
-            size: (width, height) of the item.
+            size: (width, height) of the item in world/workspace space.
 
         Returns:
             (x, y) position in world coordinates.
         """
         mx, my = pos
         w, h = size
-        width, height = self.extents
+        if self.workspace_orientation == WorkspaceOrientation.NATIVE:
+            machine_w, machine_h = w, h
+        else:
+            machine_w, machine_h = h, w
 
         if self.reverse_x:
-            mx = -mx
+            x_min, x_max = mx - machine_w, mx
+        else:
+            x_min, x_max = mx, mx + machine_w
         if self.reverse_y:
-            my = -my
-
-        origin_is_right = self.origin in (
-            OriginCorner.TOP_RIGHT,
-            OriginCorner.BOTTOM_RIGHT,
-        )
-        origin_is_top = self.origin in (
-            OriginCorner.TOP_LEFT,
-            OriginCorner.TOP_RIGHT,
-        )
-
-        if origin_is_right:
-            wx = width - mx - w
+            y_min, y_max = my - machine_h, my
         else:
-            wx = mx
+            y_min, y_max = my, my + machine_h
 
-        if origin_is_top:
-            wy = height - my - h
-        else:
-            wy = my
-
-        return wx, wy
+        corners = (
+            self.machine_point_to_world(x_min, y_min),
+            self.machine_point_to_world(x_max, y_min),
+            self.machine_point_to_world(x_min, y_max),
+            self.machine_point_to_world(x_max, y_max),
+        )
+        return min(p[0] for p in corners), min(p[1] for p in corners)

--- a/rayforge/pipeline/intent_builder.py
+++ b/rayforge/pipeline/intent_builder.py
@@ -74,7 +74,7 @@ from ..machine.driver.dummy import NoDeviceDriver
 from ..machine.kinematic_math import KinematicMath
 from ..machine.models.dialect import GRBL_DIALECT
 from ..machine.models.rotary_module import RotaryMode, RotaryType
-from .coordspace import MachineSpace, WorkspaceOrientation
+from .coordspace import MachineSpace
 from .encoder.base import EncodedOutput
 from .encoder.rust_helpers import build_encode_context, dialect_to_spec
 from .transformer import OpsTransformer
@@ -112,7 +112,7 @@ class UnsupportedRotaryWorkspaceOrientationError(ValueError):
 
 def validate_workspace_configuration(machine: Machine, doc: Doc) -> None:
     """Reject combinations whose coordinate semantics are ambiguous."""
-    if machine.workspace_orientation is WorkspaceOrientation.NATIVE:
+    if machine.supports_rotary_workspace():
         return
     if not any(layer.rotary_enabled for layer in doc.layers):
         return

--- a/rayforge/pipeline/intent_builder.py
+++ b/rayforge/pipeline/intent_builder.py
@@ -74,7 +74,7 @@ from ..machine.driver.dummy import NoDeviceDriver
 from ..machine.kinematic_math import KinematicMath
 from ..machine.models.dialect import GRBL_DIALECT
 from ..machine.models.rotary_module import RotaryMode, RotaryType
-from .coordspace import MachineSpace
+from .coordspace import MachineSpace, WorkspaceOrientation
 from .encoder.base import EncodedOutput
 from .encoder.rust_helpers import build_encode_context, dialect_to_spec
 from .transformer import OpsTransformer
@@ -98,6 +98,28 @@ STEP_KEY_FMT = "step:{step_uid}"
 JOB_KEY = "job"
 JOB_ENCODE_KEY = "job:encode"
 JOB_MACHINEXFORM_KEY = "job:machinexform"
+
+
+class UnsupportedRotaryWorkspaceOrientationError(ValueError):
+    """Raised when rotary output is requested from a rotated workspace.
+
+    Raygeo's rotary stage maps the unrolled cylinder's Y coordinate before
+    the workspace-to-machine transform.  A rotated flat workspace therefore
+    cannot be composed with rotary mapping without changing which coordinate
+    is treated as the circumference.
+    """
+
+
+def validate_workspace_configuration(machine: Machine, doc: Doc) -> None:
+    """Reject combinations whose coordinate semantics are ambiguous."""
+    if machine.workspace_orientation is WorkspaceOrientation.NATIVE:
+        return
+    if not any(layer.rotary_enabled for layer in doc.layers):
+        return
+    raise UnsupportedRotaryWorkspaceOrientationError(
+        "Rotary layers require the Native workspace orientation. "
+        "Set Machine → Hardware → Workspace Orientation to Native."
+    )
 
 
 def workpiece_key(wp_uid: str, step_uid: str) -> str:
@@ -164,6 +186,7 @@ class IntentBuilder:
         Walk *doc* and produce one NodeRequest per workpiece-step pair,
         one per step, and one final job aggregate.
         """
+        validate_workspace_configuration(self._machine, doc)
         self._doc = doc
         nodes: list[NodeRequest] = []
         # Map each step's key to the list of upstream workpiece compute
@@ -975,7 +998,7 @@ class IntentBuilder:
         payload = {
             "kind": "encode",
             "mxform_token": self._machine_transform_token(doc, step_tokens),
-            "machine": _machine_token_payload(self._machine),
+            "machine": _machine_token_payload(self._machine, doc),
         }
         return _hash_int(payload)
 
@@ -991,7 +1014,7 @@ class IntentBuilder:
         payload = {
             "kind": "machine_transform",
             "job_token": self._job_token(doc, step_tokens),
-            "machine": _machine_token_payload(self._machine),
+            "machine": _machine_token_payload(self._machine, doc),
         }
         if self._machine is not None:
             cfg = _machine_transform_config_payload(self._machine, doc)
@@ -1070,9 +1093,16 @@ def _is_grbl(dialect: GcodeDialect) -> bool:
     return dialect.uid == GRBL_DIALECT.uid
 
 
-def _machine_token_payload(machine: Machine | None) -> Any:
+def _machine_token_payload(machine: Machine | None, doc: Doc) -> Any:
     """Build a JSON-serialisable representation of the machine
-    identity for the encode token."""
+    identity for the encode token.
+
+    Every field below is an input to `_build_machine_transform_stage`
+    (via the world→machine matrix or the per-layer command offsets), so
+    changing any of them must invalidate cached machine-space output.
+    WCS offsets are scoped to the effective coordinate system of each layer,
+    avoiding invalidation when an unrelated coordinate system is edited.
+    """
     if machine is None:
         return None
     return {
@@ -1086,6 +1116,20 @@ def _machine_token_payload(machine: Machine | None) -> Any:
         "max_travel_speed": machine.max_travel_speed,
         "acceleration": machine.acceleration,
         "axis_extents": list(machine.axis_extents),
+        "work_margins": list(machine.work_margins),
+        "origin": machine.origin.value,
+        "workspace_orientation": machine.workspace_orientation.value,
+        "reverse_x_axis": machine.reverse_x_axis,
+        "reverse_y_axis": machine.reverse_y_axis,
+        "wcs_origin_is_workarea_origin": (
+            machine.wcs_origin_is_workarea_origin
+        ),
+        "layer_wcs_offsets": {
+            layer.uid: list(
+                machine.get_wcs_offset(layer.get_effective_wcs(machine))
+            )
+            for layer in doc.layers
+        },
     }
 
 

--- a/rayforge/pipeline/intent_controller.py
+++ b/rayforge/pipeline/intent_controller.py
@@ -44,7 +44,11 @@ from raygeo.cnc.execution.intent import (
 from raygeo.pipeline.execute import Pipeline as RaygeoPipeline
 from raygeo.pipeline.request import NodeRequest
 
-from .intent_builder import IntentBuilder, parse_workpiece_key
+from .intent_builder import (
+    IntentBuilder,
+    UnsupportedRotaryWorkspaceOrientationError,
+    parse_workpiece_key,
+)
 
 if TYPE_CHECKING:
     from ..core.doc import Doc
@@ -319,7 +323,22 @@ class IntentController:
                 generation_id=gen,
                 loop=getattr(self._task_manager, "loop", None),
             )
-            nodes = builder.build(self._doc)
+            try:
+                nodes = builder.build(self._doc)
+            except UnsupportedRotaryWorkspaceOrientationError as exc:
+                logger.warning("Unsupported workspace configuration: %s", exc)
+                self._refresh_key_to_item_map([])
+                empty_intent = create_intent_from_nodes([])
+                if self._intent is None:
+                    self._intent = empty_intent
+                else:
+                    self._intent.update(
+                        empty_intent, pipeline=self._raygeo_pipeline
+                    )
+                self._task_manager.schedule_on_main_thread(
+                    self._emit_configuration_error, str(exc)
+                )
+                return
             self._refresh_key_to_item_map(nodes)
             new_intent = create_intent_from_nodes(nodes)
             if self._intent is None:
@@ -358,6 +377,10 @@ class IntentController:
     def _emit_pipeline_error(self, error_kind: ErrorKind) -> None:
         """Emit ``pipeline_error`` on the main thread."""
         self.pipeline_error.send(self, error_kind=error_kind)
+
+    def _emit_configuration_error(self, message: str) -> None:
+        """Emit a user-actionable configuration error on the main thread."""
+        self.pipeline_error.send(self, message=message)
 
     def _emit_pipeline_warnings(self, warnings: list) -> None:
         """Emit ``pipeline_warnings`` on the main thread."""

--- a/rayforge/pipeline/pipeline.py
+++ b/rayforge/pipeline/pipeline.py
@@ -25,6 +25,10 @@ from .artifact import (
 )
 from .artifact.store import ArtifactStore
 from .encoder.base import EncodedOutput, MachineCodeOpMap
+from .intent_builder import (
+    UnsupportedRotaryWorkspaceOrientationError,
+    validate_workspace_configuration,
+)
 from .intent_controller import IntentController
 
 if TYPE_CHECKING:
@@ -284,16 +288,32 @@ class Pipeline:
     def _on_data_stale(self, sender) -> None:
         self.data_stale.send(self)
 
-    def _on_pipeline_error(self, sender, *, error_kind) -> None:
-        if error_kind == ErrorKind.CACHE_BUDGET_EXCEEDED:
+    def _on_pipeline_error(
+        self,
+        sender,
+        *,
+        error_kind: ErrorKind | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is not None:
+            self._clear_last_job_output()
+        elif error_kind == ErrorKind.CACHE_BUDGET_EXCEEDED:
             message = (
                 "Scene too complex for the current cache budget. "
                 "Reduce the number of layers or increase the cache budget."
             )
         else:
-            message = f"Pipeline error: {error_kind.value}"
+            detail = error_kind.value if error_kind is not None else "unknown"
+            message = f"Pipeline error: {detail}"
         logger.error("Pipeline execution error: %s", message)
         self.pipeline_error.send(self, message=message)
+
+    def _clear_last_job_output(self) -> None:
+        """Discard machine output that no longer matches the configuration."""
+        if self._last_job_handle is not None:
+            self._store.release(self._last_job_handle)
+            self._last_job_handle = None
+        self._last_aggregate_output = None
 
     def _on_pipeline_warnings(self, sender, *, warnings) -> None:
         """Forward assembler warnings to the UI for translation."""
@@ -460,6 +480,13 @@ class Pipeline:
     ):
         if not self._doc:
             when_done(None, RuntimeError("No document is loaded."))
+            return
+
+        try:
+            validate_workspace_configuration(self._machine, self._doc)
+        except UnsupportedRotaryWorkspaceOrientationError as exc:
+            self._clear_last_job_output()
+            when_done(None, exc)
             return
 
         if self._last_job_handle is not None:

--- a/rayforge/ui_gtk/array_dialog.py
+++ b/rayforge/ui_gtk/array_dialog.py
@@ -172,7 +172,7 @@ class _BaseArrayDialog(PatchedDialogWindow):
         machine = get_context().machine
         if not machine:
             return (0.0, 0.0)
-        wa = machine.work_area
+        wa = machine.workspace_work_area
         wa_w, wa_h = float(wa[2]), float(wa[3])
         ref_x, ref_y = machine.get_reference_position_world()
         space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/array_dialog.py
+++ b/rayforge/ui_gtk/array_dialog.py
@@ -172,7 +172,7 @@ class _BaseArrayDialog(PatchedDialogWindow):
         machine = get_context().machine
         if not machine:
             return (0.0, 0.0)
-        wa = machine.workspace_work_area
+        wa = machine.workspace.work_area
         wa_w, wa_h = float(wa[2]), float(wa[3])
         ref_x, ref_y = machine.get_reference_position_world()
         space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/camera/wizard/card_page.py
+++ b/rayforge/ui_gtk/camera/wizard/card_page.py
@@ -34,7 +34,7 @@ class CardPage(CameraWizardPage):
 
         machine = get_context().machine
         if machine:
-            _unused_x, _unused_y, wa_w, wa_h = machine.workspace_work_area
+            _unused_x, _unused_y, wa_w, wa_h = machine.workspace.work_area
             self._card_width = min(100.0, wa_w * self.DEFAULT_CARD_RATIO)
             self._card_height = min(140.0, wa_h * self.DEFAULT_CARD_RATIO)
         else:

--- a/rayforge/ui_gtk/camera/wizard/card_page.py
+++ b/rayforge/ui_gtk/camera/wizard/card_page.py
@@ -34,7 +34,7 @@ class CardPage(CameraWizardPage):
 
         machine = get_context().machine
         if machine:
-            _unused_x, _unused_y, wa_w, wa_h = machine.work_area
+            _unused_x, _unused_y, wa_w, wa_h = machine.workspace_work_area
             self._card_width = min(100.0, wa_w * self.DEFAULT_CARD_RATIO)
             self._card_height = min(140.0, wa_h * self.DEFAULT_CARD_RATIO)
         else:

--- a/rayforge/ui_gtk/canvas/axis.py
+++ b/rayforge/ui_gtk/canvas/axis.py
@@ -566,13 +566,14 @@ class AxisRenderer:
         Args:
             space: The coordinate space to use for axis orientation.
         """
-        self.y_axis_down = space.origin in (
+        origin = space.workspace_origin
+        self.y_axis_down = origin in (
             OriginCorner.TOP_LEFT,
             OriginCorner.TOP_RIGHT,
         )
-        self.x_axis_right = space.origin in (
+        self.x_axis_right = origin in (
             OriginCorner.TOP_RIGHT,
             OriginCorner.BOTTOM_RIGHT,
         )
-        self.x_axis_negative = space.reverse_x
-        self.y_axis_negative = space.reverse_y
+        self.x_axis_negative = space.workspace_x_negative
+        self.y_axis_negative = space.workspace_y_negative

--- a/rayforge/ui_gtk/canvas2d/drag_drop_cmd.py
+++ b/rayforge/ui_gtk/canvas2d/drag_drop_cmd.py
@@ -575,7 +575,7 @@ class DragDropCmd:
         try:
             machine = get_context().machine
             if machine:
-                work_area = machine.work_area
+                work_area = machine.workspace_work_area
                 wa_w, wa_h = work_area[2], work_area[3]
                 origin_x, origin_y = machine.get_reference_position_world()
                 space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/canvas2d/drag_drop_cmd.py
+++ b/rayforge/ui_gtk/canvas2d/drag_drop_cmd.py
@@ -575,7 +575,7 @@ class DragDropCmd:
         try:
             machine = get_context().machine
             if machine:
-                work_area = machine.workspace_work_area
+                work_area = machine.workspace.work_area
                 wa_w, wa_h = work_area[2], work_area[3]
                 origin_x, origin_y = machine.get_reference_position_world()
                 space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/canvas2d/elements/work_origin.py
+++ b/rayforge/ui_gtk/canvas2d/elements/work_origin.py
@@ -39,11 +39,12 @@ class WorkOriginElement(CanvasElement):
         Configures the direction of the arrows based on the coordinate space.
         """
 
-        x_axis_right = space.origin in (
+        origin = space.workspace_origin
+        x_axis_right = origin in (
             OriginCorner.TOP_RIGHT,
             OriginCorner.BOTTOM_RIGHT,
         )
-        y_axis_down = space.origin in (
+        y_axis_down = origin in (
             OriginCorner.TOP_LEFT,
             OriginCorner.TOP_RIGHT,
         )

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -20,6 +20,7 @@ from ...core.stock_asset import StockAsset
 from ...core.workpiece import WorkPiece
 from ...machine.models.machine import Machine
 from ...pipeline.artifact import RenderContext
+from ...pipeline.coordspace import WorkspaceOrientation
 from ...shared.units.formatter import get_preferred_unit_factor
 from ..canvas import Canvas, CanvasElement, WorldSurface
 from ..shared.keyboard import is_primary_modifier
@@ -69,11 +70,11 @@ class WorkSurface(WorldSurface):
         self._tracked_axis_extents: tuple[float, float] = (0.0, 0.0)
         coordinate_space = None
         if machine:
-            self._tracked_axis_extents = machine.axis_extents
+            self._tracked_axis_extents = machine.workspace_extents
             # Canvas shows full machine bed, not just workarea
             width_mm, height_mm = (
-                float(machine.axis_extents[0]),
-                float(machine.axis_extents[1]),
+                float(machine.workspace_extents[0]),
+                float(machine.workspace_extents[1]),
             )
             coordinate_space = machine.get_coordinate_space()
         else:
@@ -290,17 +291,12 @@ class WorkSurface(WorldSurface):
         """
         Convert machine-reported coordinates to canvas world coordinates.
 
-        Machine-reported coordinates come from the controller and may be
-        negated based on reverse_x/reverse_y settings. We undo this sign
-        flip before transforming to world coordinates.
+        Machine-reported coordinates come from the controller's native
+        coordinate system and are transformed into workspace coordinates.
         """
         if self.machine:
             space = self.machine.get_coordinate_space()
-            if space.reverse_x:
-                m_x = -m_x
-            if space.reverse_y:
-                m_y = -m_y
-            return space.transform_point_to_world(m_x, m_y, space.extents)
+            return space.machine_point_to_world(m_x, m_y)
         return m_x, m_y
 
     def get_global_tab_visibility(self) -> bool:
@@ -702,7 +698,10 @@ class WorkSurface(WorldSurface):
 
         space = machine.get_coordinate_space()
         if machine.wcs_origin_is_workarea_origin:
-            canvas_x, canvas_y = space.get_workarea_origin_in_machine()
+            machine_x, machine_y = space.get_workarea_origin_in_machine()
+            canvas_x, canvas_y = space.machine_point_to_world(
+                machine_x, machine_y
+            )
         else:
             wcs_x, wcs_y, _ = self._get_active_layer_wcs_offset()
             canvas_x, canvas_y = self._machine_coords_to_canvas(wcs_x, wcs_y)
@@ -1155,24 +1154,26 @@ class WorkSurface(WorldSurface):
             self._sync_camera_elements()
             return
 
-        extent_w, extent_h = machine.axis_extents
+        extent_w, extent_h = machine.workspace_extents
         extent_changed = (extent_w, extent_h) != self._tracked_axis_extents
-        y_axis_changed = machine.y_axis_down != self._axis_renderer.y_axis_down
-        x_axis_changed = (
-            machine.x_axis_right != self._axis_renderer.x_axis_right
-        )
+        space = machine.get_coordinate_space()
+        workspace_origin = space.workspace_origin
+        y_axis_down = workspace_origin.value.startswith("top")
+        x_axis_right = workspace_origin.value.endswith("right")
+        y_axis_changed = y_axis_down != self._axis_renderer.y_axis_down
+        x_axis_changed = x_axis_right != self._axis_renderer.x_axis_right
         x_reverse_changed = (
-            machine.reverse_x_axis != self._axis_renderer.x_axis_negative
+            space.workspace_x_negative != self._axis_renderer.x_axis_negative
         )
         y_reverse_changed = (
-            machine.reverse_y_axis != self._axis_renderer.y_axis_negative
+            space.workspace_y_negative != self._axis_renderer.y_axis_negative
         )
 
         logger.debug(
             f"_on_machine_changed: extent_changed={extent_changed}, "
             f"extents=({extent_w}, {extent_h}), "
             f"tracked={self._tracked_axis_extents}, "
-            f"margins={machine.work_margins}"
+            f"margins={machine.workspace_margins}"
         )
 
         if (
@@ -1210,37 +1211,45 @@ class WorkSurface(WorldSurface):
             return
 
         # Canvas shows full machine bed
-        width_mm, height_mm = self.machine.axis_extents
+        width_mm, height_mm = self.machine.workspace_extents
+        space = self.machine.get_coordinate_space()
+        workspace_origin = space.workspace_origin
+        x_axis_right = workspace_origin.value.endswith("right")
+        y_axis_down = workspace_origin.value.startswith("top")
 
         logger.debug(
             f"Resetting view for machine '{self.machine.name}' "
             f"with axis_extents=({width_mm}, {height_mm}), "
-            f"x_right={self.machine.x_axis_right}, "
-            f"y_down={self.machine.y_axis_down}, "
+            f"x_right={x_axis_right}, "
+            f"y_down={y_axis_down}, "
             f"reverse_x={self.machine.reverse_x_axis}, "
             f"reverse_y={self.machine.reverse_y_axis}"
         )
-        self._tracked_axis_extents = self.machine.axis_extents
+        self._tracked_axis_extents = self.machine.workspace_extents
         self.set_size(float(width_mm), float(height_mm))
-        ml, mt, mr, mb = self.machine.work_margins
+        ml, mt, mr, mb = self.machine.workspace_margins
         self._axis_renderer.set_width_mm(float(width_mm))
         self._axis_renderer.set_height_mm(float(height_mm))
         self._axis_renderer.set_margins_mm(
             float(ml), float(mt), float(mr), float(mb)
         )
-        self._axis_renderer.set_x_axis_right(self.machine.x_axis_right)
-        self._axis_renderer.set_y_axis_down(self.machine.y_axis_down)
-        self._axis_renderer.set_x_axis_negative(self.machine.reverse_x_axis)
-        self._axis_renderer.set_y_axis_negative(self.machine.reverse_y_axis)
+        self._axis_renderer.set_x_axis_right(x_axis_right)
+        self._axis_renderer.set_y_axis_down(y_axis_down)
+        self._axis_renderer.set_x_axis_negative(space.workspace_x_negative)
+        self._axis_renderer.set_y_axis_negative(space.workspace_y_negative)
 
-        space = self.machine.get_coordinate_space()
         self._work_origin_element.set_coordinate_space(space)
 
         self._update_extent_frame()
 
         super().reset_view()
 
-        if self.doc.active_layer.rotary_enabled and self.machine:
+        if (
+            self.doc.active_layer.rotary_enabled
+            and self.machine
+            and self.machine.workspace_orientation
+            is WorkspaceOrientation.NATIVE
+        ):
             self._center_on_rotary_axis()
 
         new_ratio = width_mm / height_mm if height_mm > 0 else 1.0
@@ -1276,8 +1285,8 @@ class WorkSurface(WorldSurface):
     def _update_extent_frame_flat(self):
         """Updates extent frame and workarea for flat (non-rotary) mode."""
         assert self.machine
-        extent_w, extent_h = self.machine.axis_extents
-        ml, mt, mr, mb = self.machine.work_margins
+        extent_w, extent_h = self.machine.workspace_extents
+        ml, mt, mr, mb = self.machine.workspace_margins
 
         logger.debug(
             f"_update_extent_frame_flat: extents=({extent_w}, "
@@ -1307,6 +1316,17 @@ class WorkSurface(WorldSurface):
     def _update_extent_frame_rotary(self):
         """Updates extent frame and workarea for rotary mode."""
         assert self.machine
+        if (
+            self.machine.workspace_orientation
+            is not WorkspaceOrientation.NATIVE
+        ):
+            self._axis_renderer.set_x_axis_y_override(None)
+            self._extent_frame_element.set_visible(False)
+            self._workarea_bg_element.set_visible(False)
+            logger.warning(
+                "Rotary canvas unavailable with a rotated workspace"
+            )
+            return
         active_layer = self.doc.active_layer
         diameter = active_layer.rotary_diameter
         circumference = math.pi * diameter
@@ -1314,7 +1334,7 @@ class WorkSurface(WorldSurface):
 
         origin_x, origin_y = self._machine_coords_to_canvas(0.0, 0.0)
 
-        bed_width = self.machine.axis_extents[0]
+        bed_width = self.machine.workspace_extents[0]
         max_length = bed_width
         default_rm = self.machine.get_default_rotary_module()
         if default_rm:
@@ -1368,15 +1388,17 @@ class WorkSurface(WorldSurface):
             self._nogo_zone_elements.clear()
             return
 
-        current_uids = set(self.machine.nogo_zones.keys())
+        workspace_zones = self.machine.workspace_nogo_zones
+        current_uids = set(workspace_zones.keys())
         existing_uids = set(self._nogo_zone_elements.keys())
 
         for uid in existing_uids - current_uids:
             self._nogo_zone_elements.pop(uid).remove()
 
-        for uid, zone in self.machine.nogo_zones.items():
+        for uid, zone in workspace_zones.items():
             if uid in self._nogo_zone_elements:
                 elem = self._nogo_zone_elements[uid]
+                elem.data = zone
                 elem._update_from_zone()
                 elem.set_visible(self._nogo_zones_visible and zone.enabled)
             else:

--- a/rayforge/ui_gtk/canvas2d/surface.py
+++ b/rayforge/ui_gtk/canvas2d/surface.py
@@ -20,7 +20,6 @@ from ...core.stock_asset import StockAsset
 from ...core.workpiece import WorkPiece
 from ...machine.models.machine import Machine
 from ...pipeline.artifact import RenderContext
-from ...pipeline.coordspace import WorkspaceOrientation
 from ...shared.units.formatter import get_preferred_unit_factor
 from ..canvas import Canvas, CanvasElement, WorldSurface
 from ..shared.keyboard import is_primary_modifier
@@ -70,11 +69,11 @@ class WorkSurface(WorldSurface):
         self._tracked_axis_extents: tuple[float, float] = (0.0, 0.0)
         coordinate_space = None
         if machine:
-            self._tracked_axis_extents = machine.workspace_extents
+            self._tracked_axis_extents = machine.workspace.extents
             # Canvas shows full machine bed, not just workarea
             width_mm, height_mm = (
-                float(machine.workspace_extents[0]),
-                float(machine.workspace_extents[1]),
+                float(machine.workspace.extents[0]),
+                float(machine.workspace.extents[1]),
             )
             coordinate_space = machine.get_coordinate_space()
         else:
@@ -1154,12 +1153,11 @@ class WorkSurface(WorldSurface):
             self._sync_camera_elements()
             return
 
-        extent_w, extent_h = machine.workspace_extents
+        extent_w, extent_h = machine.workspace.extents
         extent_changed = (extent_w, extent_h) != self._tracked_axis_extents
         space = machine.get_coordinate_space()
-        workspace_origin = space.workspace_origin
-        y_axis_down = workspace_origin.value.startswith("top")
-        x_axis_right = workspace_origin.value.endswith("right")
+        y_axis_down = space.workspace_y_down
+        x_axis_right = space.workspace_x_right
         y_axis_changed = y_axis_down != self._axis_renderer.y_axis_down
         x_axis_changed = x_axis_right != self._axis_renderer.x_axis_right
         x_reverse_changed = (
@@ -1173,7 +1171,7 @@ class WorkSurface(WorldSurface):
             f"_on_machine_changed: extent_changed={extent_changed}, "
             f"extents=({extent_w}, {extent_h}), "
             f"tracked={self._tracked_axis_extents}, "
-            f"margins={machine.workspace_margins}"
+            f"margins={machine.workspace.margins}"
         )
 
         if (
@@ -1211,11 +1209,10 @@ class WorkSurface(WorldSurface):
             return
 
         # Canvas shows full machine bed
-        width_mm, height_mm = self.machine.workspace_extents
+        width_mm, height_mm = self.machine.workspace.extents
         space = self.machine.get_coordinate_space()
-        workspace_origin = space.workspace_origin
-        x_axis_right = workspace_origin.value.endswith("right")
-        y_axis_down = workspace_origin.value.startswith("top")
+        x_axis_right = space.workspace_x_right
+        y_axis_down = space.workspace_y_down
 
         logger.debug(
             f"Resetting view for machine '{self.machine.name}' "
@@ -1225,9 +1222,9 @@ class WorkSurface(WorldSurface):
             f"reverse_x={self.machine.reverse_x_axis}, "
             f"reverse_y={self.machine.reverse_y_axis}"
         )
-        self._tracked_axis_extents = self.machine.workspace_extents
+        self._tracked_axis_extents = self.machine.workspace.extents
         self.set_size(float(width_mm), float(height_mm))
-        ml, mt, mr, mb = self.machine.workspace_margins
+        ml, mt, mr, mb = self.machine.workspace.margins
         self._axis_renderer.set_width_mm(float(width_mm))
         self._axis_renderer.set_height_mm(float(height_mm))
         self._axis_renderer.set_margins_mm(
@@ -1247,8 +1244,7 @@ class WorkSurface(WorldSurface):
         if (
             self.doc.active_layer.rotary_enabled
             and self.machine
-            and self.machine.workspace_orientation
-            is WorkspaceOrientation.NATIVE
+            and self.machine.supports_rotary_workspace()
         ):
             self._center_on_rotary_axis()
 
@@ -1285,8 +1281,8 @@ class WorkSurface(WorldSurface):
     def _update_extent_frame_flat(self):
         """Updates extent frame and workarea for flat (non-rotary) mode."""
         assert self.machine
-        extent_w, extent_h = self.machine.workspace_extents
-        ml, mt, mr, mb = self.machine.workspace_margins
+        extent_w, extent_h = self.machine.workspace.extents
+        ml, mt, mr, mb = self.machine.workspace.margins
 
         logger.debug(
             f"_update_extent_frame_flat: extents=({extent_w}, "
@@ -1316,10 +1312,7 @@ class WorkSurface(WorldSurface):
     def _update_extent_frame_rotary(self):
         """Updates extent frame and workarea for rotary mode."""
         assert self.machine
-        if (
-            self.machine.workspace_orientation
-            is not WorkspaceOrientation.NATIVE
-        ):
+        if not self.machine.supports_rotary_workspace():
             self._axis_renderer.set_x_axis_y_override(None)
             self._extent_frame_element.set_visible(False)
             self._workarea_bg_element.set_visible(False)
@@ -1334,7 +1327,7 @@ class WorkSurface(WorldSurface):
 
         origin_x, origin_y = self._machine_coords_to_canvas(0.0, 0.0)
 
-        bed_width = self.machine.workspace_extents[0]
+        bed_width = self.machine.workspace.extents[0]
         max_length = bed_width
         default_rm = self.machine.get_default_rotary_module()
         if default_rm:
@@ -1388,7 +1381,7 @@ class WorkSurface(WorldSurface):
             self._nogo_zone_elements.clear()
             return
 
-        workspace_zones = self.machine.workspace_nogo_zones
+        workspace_zones = self.machine.workspace.nogo_zones
         current_uids = set(workspace_zones.keys())
         existing_uids = set(self._nogo_zone_elements.keys())
 

--- a/rayforge/ui_gtk/doceditor/layer_column.py
+++ b/rayforge/ui_gtk/doceditor/layer_column.py
@@ -717,7 +717,7 @@ class LayerColumn(Gtk.Box):
     def _get_center_position(self) -> tuple:
         machine = get_context().machine
         if machine:
-            work_area = machine.workspace_work_area
+            work_area = machine.workspace.work_area
             wa_w, wa_h = work_area[2], work_area[3]
             origin_x, origin_y = machine.get_reference_position_world()
             space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/doceditor/layer_column.py
+++ b/rayforge/ui_gtk/doceditor/layer_column.py
@@ -717,7 +717,7 @@ class LayerColumn(Gtk.Box):
     def _get_center_position(self) -> tuple:
         machine = get_context().machine
         if machine:
-            work_area = machine.work_area
+            work_area = machine.workspace_work_area
             wa_w, wa_h = work_area[2], work_area[3]
             origin_x, origin_y = machine.get_reference_position_world()
             space = machine.get_coordinate_space()

--- a/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
+++ b/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
@@ -5,6 +5,7 @@ from gi.repository import Adw, Gdk, Gtk
 
 from ...context import get_context
 from ...core.layer import Layer
+from ...pipeline.coordspace import WorkspaceOrientation
 from ..icons import get_icon
 from ..machine.wcs_dialog import WcsDialog
 from ..shared.patched_dialog_window import PatchedDialogWindow
@@ -108,12 +109,26 @@ class LayerSettingsDialog(PatchedDialogWindow):
         )
         content.add(rotary_group)
 
+        machine = get_context().machine
+        self._rotary_orientation_supported = (
+            machine is None
+            or machine.workspace_orientation is WorkspaceOrientation.NATIVE
+        )
+
         self.rotary_enabled_row = Adw.SwitchRow()
         self.rotary_enabled_row.set_title(_("Enable Rotary Mode"))
-        self.rotary_enabled_row.set_subtitle(
-            _("Convert Y-axis to rotary axis")
-        )
+        if self._rotary_orientation_supported:
+            self.rotary_enabled_row.set_subtitle(
+                _("Convert Y-axis to rotary axis")
+            )
+        else:
+            self.rotary_enabled_row.set_subtitle(
+                _("Requires Native workspace orientation in Machine settings")
+            )
         self.rotary_enabled_row.set_active(layer.rotary_enabled)
+        self.rotary_enabled_row.set_sensitive(
+            self._rotary_orientation_supported
+        )
         self.rotary_enabled_row.connect(
             "notify::active", self._on_rotary_enabled_changed
         )
@@ -127,7 +142,9 @@ class LayerSettingsDialog(PatchedDialogWindow):
         )
         self._select_current_module()
         self.module_row.connect("notify::selected", self._on_module_changed)
-        self.module_row.set_sensitive(layer.rotary_enabled)
+        self.module_row.set_sensitive(
+            layer.rotary_enabled and self._rotary_orientation_supported
+        )
         rotary_group.add(self.module_row)
 
         self.rotary_diameter_row = LengthSpinRow(
@@ -140,7 +157,9 @@ class LayerSettingsDialog(PatchedDialogWindow):
         self.rotary_diameter_row.value_changed.connect(
             self._on_rotary_diameter_changed
         )
-        self.rotary_diameter_row.set_sensitive(layer.rotary_enabled)
+        self.rotary_diameter_row.set_sensitive(
+            layer.rotary_enabled and self._rotary_orientation_supported
+        )
         rotary_group.add(self.rotary_diameter_row)
 
         self._is_initializing = False
@@ -225,6 +244,7 @@ class LayerSettingsDialog(PatchedDialogWindow):
         if self._is_initializing:
             return
         enabled = row.get_active()
+        enabled = enabled and self._rotary_orientation_supported
         self.module_row.set_sensitive(enabled)
         self.rotary_diameter_row.set_sensitive(enabled)
         self.layer.set_rotary_enabled(enabled)

--- a/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
+++ b/rayforge/ui_gtk/doceditor/layer_settings_dialog.py
@@ -5,7 +5,6 @@ from gi.repository import Adw, Gdk, Gtk
 
 from ...context import get_context
 from ...core.layer import Layer
-from ...pipeline.coordspace import WorkspaceOrientation
 from ..icons import get_icon
 from ..machine.wcs_dialog import WcsDialog
 from ..shared.patched_dialog_window import PatchedDialogWindow
@@ -111,8 +110,7 @@ class LayerSettingsDialog(PatchedDialogWindow):
 
         machine = get_context().machine
         self._rotary_orientation_supported = (
-            machine is None
-            or machine.workspace_orientation is WorkspaceOrientation.NATIVE
+            machine is None or machine.supports_rotary_workspace()
         )
 
         self.rotary_enabled_row = Adw.SwitchRow()

--- a/rayforge/ui_gtk/doceditor/property_providers/transform.py
+++ b/rayforge/ui_gtk/doceditor/property_providers/transform.py
@@ -293,7 +293,7 @@ class TransformPropertyProvider(PropertyProvider):
             if isinstance(item, (WorkPiece, StockItem)):
                 machine = get_context().machine
                 if machine:
-                    __, __, wa_w, wa_h = machine.work_area
+                    __, __, wa_w, wa_h = machine.workspace_work_area
                     bounds = (wa_w, wa_h)
                 else:
                     bounds = default_dim

--- a/rayforge/ui_gtk/doceditor/property_providers/transform.py
+++ b/rayforge/ui_gtk/doceditor/property_providers/transform.py
@@ -293,7 +293,7 @@ class TransformPropertyProvider(PropertyProvider):
             if isinstance(item, (WorkPiece, StockItem)):
                 machine = get_context().machine
                 if machine:
-                    __, __, wa_w, wa_h = machine.workspace_work_area
+                    __, __, wa_w, wa_h = machine.workspace.work_area
                     bounds = (wa_w, wa_h)
                 else:
                     bounds = default_dim

--- a/rayforge/ui_gtk/machine/hardware_page.py
+++ b/rayforge/ui_gtk/machine/hardware_page.py
@@ -5,8 +5,11 @@ from gi.repository import Adw, Gtk
 from raygeo.ops.axis import Axis
 
 from ...machine.models.machine import Machine, Origin
+from ...pipeline.coordspace import WorkspaceOrientation
 from ..shared.pref_rows.length_spin_row import LengthSpinRow
 from ..shared.preferences_page import TrackedPreferencesPage
+
+_WORKSPACE_ORIENTATIONS = tuple(WorkspaceOrientation)
 
 
 class HardwarePage(TrackedPreferencesPage):
@@ -82,6 +85,27 @@ class HardwarePage(TrackedPreferencesPage):
         origin_combo_row.connect("notify::selected", self.on_origin_changed)
         self.origin_combo_row = origin_combo_row
         axes_group.add(origin_combo_row)
+
+        orientation_labels = [
+            _("Native"),
+            _("Rotate Left"),
+            _("Rotate Right"),
+        ]
+        self.workspace_orientation_row = Adw.ComboRow(
+            title=_("Workspace Orientation"),
+            subtitle=_(
+                "Rotate the flat workspace and remap output to the "
+                "machine; rotary layers require Native"
+            ),
+            model=Gtk.StringList.new(orientation_labels),
+        )
+        self.workspace_orientation_row.set_selected(
+            _WORKSPACE_ORIENTATIONS.index(self.machine.workspace_orientation)
+        )
+        self.workspace_orientation_row.connect(
+            "notify::selected", self.on_workspace_orientation_changed
+        )
+        axes_group.add(self.workspace_orientation_row)
 
         self.reverse_x_axis_row = Adw.SwitchRow()
         self.reverse_x_axis_row.set_title(_("Reverse X-Axis Direction"))
@@ -252,6 +276,13 @@ class HardwarePage(TrackedPreferencesPage):
         self._update_z_axis_state()
         self._update_axis_extents_ui()
         self._update_soft_limits_ui()
+        self._update_workspace_orientation_ui()
+
+    def _update_workspace_orientation_ui(self):
+        selected = _WORKSPACE_ORIENTATIONS.index(
+            self.machine.workspace_orientation
+        )
+        self.workspace_orientation_row.set_selected(selected)
 
     def _update_axis_extents_ui(self):
         self.x_extent_row.set_value_in_base_units(self.machine.axis_extents[0])
@@ -282,6 +313,13 @@ class HardwarePage(TrackedPreferencesPage):
         }
         origin = origin_map.get(selected_index, Origin.BOTTOM_LEFT)
         self.machine.set_origin(origin)
+
+    def on_workspace_orientation_changed(self, row, _):
+        selected = row.get_selected()
+        if selected >= len(_WORKSPACE_ORIENTATIONS):
+            return
+        orientation = _WORKSPACE_ORIENTATIONS[selected]
+        self.machine.set_workspace_orientation(orientation)
 
     def on_reverse_x_changed(self, row, _):
         self.machine.set_reverse_x_axis(row.get_active())

--- a/rayforge/ui_gtk/machine/jog_widget.py
+++ b/rayforge/ui_gtk/machine/jog_widget.py
@@ -253,7 +253,7 @@ class JogWidget(Gtk.Widget):
         machine: Machine = self.machine  # type: ignore
 
         def can_jog_direction(direction):
-            deltas = machine.calculate_visual_jog(direction, 1.0)
+            deltas = machine.workspace.calculate_jog(direction, 1.0)
             return bool(deltas) and all(machine.can_jog(a) for a in deltas)
 
         # Jog buttons
@@ -325,20 +325,22 @@ class JogWidget(Gtk.Widget):
 
         # Get the signed coordinate deltas for each visual direction from the
         # model
-        east = machine.calculate_visual_jog(
+        east = machine.workspace.calculate_jog(
             JogDirection.EAST, self.jog_distance
         )
-        west = machine.calculate_visual_jog(
+        west = machine.workspace.calculate_jog(
             JogDirection.WEST, self.jog_distance
         )
-        north = machine.calculate_visual_jog(
+        north = machine.workspace.calculate_jog(
             JogDirection.NORTH, self.jog_distance
         )
-        south = machine.calculate_visual_jog(
+        south = machine.workspace.calculate_jog(
             JogDirection.SOUTH, self.jog_distance
         )
-        up = machine.calculate_visual_jog(JogDirection.UP, self.jog_distance)
-        down = machine.calculate_visual_jog(
+        up = machine.workspace.calculate_jog(
+            JogDirection.UP, self.jog_distance
+        )
+        down = machine.workspace.calculate_jog(
             JogDirection.DOWN, self.jog_distance
         )
 
@@ -403,7 +405,7 @@ class JogWidget(Gtk.Widget):
             return
         deltas = {}
         for direction in directions:
-            for axis, delta in self.machine.calculate_visual_jog(
+            for axis, delta in self.machine.workspace.calculate_jog(
                 direction, self.jog_distance
             ).items():
                 deltas[axis] = deltas.get(axis, 0.0) + delta

--- a/rayforge/ui_gtk/machine/jog_widget.py
+++ b/rayforge/ui_gtk/machine/jog_widget.py
@@ -252,11 +252,15 @@ class JogWidget(Gtk.Widget):
         # Type assertion to help Pylance understand machine is not None
         machine: Machine = self.machine  # type: ignore
 
+        def can_jog_direction(direction):
+            deltas = machine.calculate_visual_jog(direction, 1.0)
+            return bool(deltas) and all(machine.can_jog(a) for a in deltas)
+
         # Jog buttons
-        self.east_btn.set_sensitive(machine.can_jog(Axis.X))
-        self.west_btn.set_sensitive(machine.can_jog(Axis.X))
-        self.north_btn.set_sensitive(machine.can_jog(Axis.Y))
-        self.south_btn.set_sensitive(machine.can_jog(Axis.Y))
+        self.east_btn.set_sensitive(can_jog_direction(JogDirection.EAST))
+        self.west_btn.set_sensitive(can_jog_direction(JogDirection.WEST))
+        self.north_btn.set_sensitive(can_jog_direction(JogDirection.NORTH))
+        self.south_btn.set_sensitive(can_jog_direction(JogDirection.SOUTH))
 
         # Diagonal buttons - need both X and Y axis support
         can_jog_xy = machine.can_jog(Axis.X) and machine.can_jog(Axis.Y)
@@ -321,20 +325,36 @@ class JogWidget(Gtk.Widget):
 
         # Get the signed coordinate deltas for each visual direction from the
         # model
-        x_east = machine.calculate_jog(JogDirection.EAST, self.jog_distance)
-        x_west = machine.calculate_jog(JogDirection.WEST, self.jog_distance)
-        y_north = machine.calculate_jog(JogDirection.NORTH, self.jog_distance)
-        y_south = machine.calculate_jog(JogDirection.SOUTH, self.jog_distance)
-        z_up = machine.calculate_jog(JogDirection.UP, self.jog_distance)
-        z_down = machine.calculate_jog(JogDirection.DOWN, self.jog_distance)
+        east = machine.calculate_visual_jog(
+            JogDirection.EAST, self.jog_distance
+        )
+        west = machine.calculate_visual_jog(
+            JogDirection.WEST, self.jog_distance
+        )
+        north = machine.calculate_visual_jog(
+            JogDirection.NORTH, self.jog_distance
+        )
+        south = machine.calculate_visual_jog(
+            JogDirection.SOUTH, self.jog_distance
+        )
+        up = machine.calculate_visual_jog(JogDirection.UP, self.jog_distance)
+        down = machine.calculate_visual_jog(
+            JogDirection.DOWN, self.jog_distance
+        )
+
+        def exceeds(deltas):
+            return any(
+                machine.would_jog_exceed_limits(axis, delta)
+                for axis, delta in deltas.items()
+            )
 
         # Check limits using the final signed delta that will be commanded
-        exceeds_east = machine.would_jog_exceed_limits(Axis.X, x_east)
-        exceeds_west = machine.would_jog_exceed_limits(Axis.X, x_west)
-        exceeds_north = machine.would_jog_exceed_limits(Axis.Y, y_north)
-        exceeds_south = machine.would_jog_exceed_limits(Axis.Y, y_south)
-        exceeds_up = machine.would_jog_exceed_limits(Axis.Z, z_up)
-        exceeds_down = machine.would_jog_exceed_limits(Axis.Z, z_down)
+        exceeds_east = exceeds(east)
+        exceeds_west = exceeds(west)
+        exceeds_north = exceeds(north)
+        exceeds_south = exceeds(south)
+        exceeds_up = exceeds(up)
+        exceeds_down = exceeds(down)
 
         if exceeds_east:
             self.east_btn.add_css_class("warning")
@@ -367,7 +387,7 @@ class JogWidget(Gtk.Widget):
         """Handle connection status changes to update button sensitivity."""
         self._update_button_sensitivity()
 
-    def _perform_jog(self, x: float = 0.0, y: float = 0.0, z: float = 0.0):
+    def _perform_jog(self, deltas: dict[Axis, float]):
         """
         Helper to jog multiple axes simultaneously by sending a single
         command dictionary.
@@ -375,108 +395,59 @@ class JogWidget(Gtk.Widget):
         if not self.machine or not self.machine_cmd:
             return
 
-        deltas = {}
-        if x != 0:
-            deltas[Axis.X] = x
-        if y != 0:
-            deltas[Axis.Y] = y
-        if z != 0:
-            deltas[Axis.Z] = z
-
         if deltas:
             self.machine_cmd.jog(self.machine, deltas, self.jog_speed)
 
+    def _perform_visual_jog(self, *directions: JogDirection):
+        if not self.machine:
+            return
+        deltas = {}
+        for direction in directions:
+            for axis, delta in self.machine.calculate_visual_jog(
+                direction, self.jog_distance
+            ).items():
+                deltas[axis] = deltas.get(axis, 0.0) + delta
+        self._perform_jog(deltas)
+
     def _on_x_plus_clicked(self, button):
         """Handle Right (East) button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.EAST, self.jog_distance
-            )
-            self._perform_jog(x=x_dist)
+        self._perform_visual_jog(JogDirection.EAST)
 
     def _on_x_minus_clicked(self, button):
         """Handle Left (West) button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.WEST, self.jog_distance
-            )
-            self._perform_jog(x=x_dist)
+        self._perform_visual_jog(JogDirection.WEST)
 
     def _on_y_plus_clicked(self, button):
         """Handle Away (North) button click."""
-        if self.machine:
-            y_dist = self.machine.calculate_jog(
-                JogDirection.NORTH, self.jog_distance
-            )
-            self._perform_jog(y=y_dist)
+        self._perform_visual_jog(JogDirection.NORTH)
 
     def _on_y_minus_clicked(self, button):
         """Handle Toward (South) button click."""
-        if self.machine:
-            y_dist = self.machine.calculate_jog(
-                JogDirection.SOUTH, self.jog_distance
-            )
-            self._perform_jog(y=y_dist)
+        self._perform_visual_jog(JogDirection.SOUTH)
 
     def _on_z_plus_clicked(self, button):
         """Handle Up button click."""
-        if self.machine:
-            z_dist = self.machine.calculate_jog(
-                JogDirection.UP, self.jog_distance
-            )
-            self._perform_jog(z=z_dist)
+        self._perform_visual_jog(JogDirection.UP)
 
     def _on_z_minus_clicked(self, button):
         """Handle Down button click."""
-        if self.machine:
-            z_dist = self.machine.calculate_jog(
-                JogDirection.DOWN, self.jog_distance
-            )
-            self._perform_jog(z=z_dist)
+        self._perform_visual_jog(JogDirection.DOWN)
 
     def _on_x_plus_y_plus_clicked(self, button):
         """Handle Right-Away diagonal button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.EAST, self.jog_distance
-            )
-            y_dist = self.machine.calculate_jog(
-                JogDirection.NORTH, self.jog_distance
-            )
-            self._perform_jog(x=x_dist, y=y_dist)
+        self._perform_visual_jog(JogDirection.EAST, JogDirection.NORTH)
 
     def _on_x_minus_y_plus_clicked(self, button):
         """Handle Left-Away diagonal button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.WEST, self.jog_distance
-            )
-            y_dist = self.machine.calculate_jog(
-                JogDirection.NORTH, self.jog_distance
-            )
-            self._perform_jog(x=x_dist, y=y_dist)
+        self._perform_visual_jog(JogDirection.WEST, JogDirection.NORTH)
 
     def _on_x_plus_y_minus_clicked(self, button):
         """Handle Right-Toward diagonal button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.EAST, self.jog_distance
-            )
-            y_dist = self.machine.calculate_jog(
-                JogDirection.SOUTH, self.jog_distance
-            )
-            self._perform_jog(x=x_dist, y=y_dist)
+        self._perform_visual_jog(JogDirection.EAST, JogDirection.SOUTH)
 
     def _on_x_minus_y_minus_clicked(self, button):
         """Handle Left-Toward diagonal button click."""
-        if self.machine:
-            x_dist = self.machine.calculate_jog(
-                JogDirection.WEST, self.jog_distance
-            )
-            y_dist = self.machine.calculate_jog(
-                JogDirection.SOUTH, self.jog_distance
-            )
-            self._perform_jog(x=x_dist, y=y_dist)
+        self._perform_visual_jog(JogDirection.WEST, JogDirection.SOUTH)
 
     def _on_home_all_clicked(self, button):
         """Handle Home All button click."""

--- a/rayforge/ui_gtk/machine/unified_wizard.py
+++ b/rayforge/ui_gtk/machine/unified_wizard.py
@@ -638,6 +638,7 @@ def _clone_machine_config(src) -> Any:
         "work_margins",
         "soft_limits",
         "origin",
+        "workspace_orientation",
         "max_travel_speed",
         "max_cut_speed",
         "home_on_start",

--- a/rayforge/ui_gtk/machine/wizard_pages/hardware_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/hardware_page.py
@@ -16,6 +16,7 @@ from gi.repository import Adw, Gtk
 
 from ....machine.device.profile import DeviceProfile
 from ....machine.models.machine import Origin
+from ....pipeline.coordspace import WorkspaceOrientation
 from ...shared.pref_rows.acceleration_spin_row import AccelerationSpinRow
 from ...shared.pref_rows.length_spin_row import LengthSpinRow
 from ...shared.pref_rows.speed_spin_row import SpeedSpinRow
@@ -28,6 +29,7 @@ _ORIGIN_INDEX_TO_ENUM = {
     3: Origin.BOTTOM_RIGHT,
 }
 _ORIGIN_ENUM_TO_INDEX = {v: k for k, v in _ORIGIN_INDEX_TO_ENUM.items()}
+_WORKSPACE_ORIENTATIONS = tuple(WorkspaceOrientation)
 
 # Sensible starting points surfaced when a profile carries no values;
 # they mirror the Machine model defaults (machine.py).
@@ -86,6 +88,18 @@ class HardwarePage(WizardPage):
             model=origin_store,
         )
         axes_group.add(self.origin_row)
+
+        self.workspace_orientation_row = Adw.ComboRow(
+            title=_("Workspace Orientation"),
+            subtitle=_(
+                "Rotate the flat workspace and remap output to the "
+                "machine; rotary layers require Native"
+            ),
+            model=Gtk.StringList.new(
+                [_("Native"), _("Rotate Left"), _("Rotate Right")]
+            ),
+        )
+        axes_group.add(self.workspace_orientation_row)
 
         # Direction reversals.
         self.reverse_x_row = Adw.SwitchRow(
@@ -285,6 +299,10 @@ class HardwarePage(WizardPage):
 
         origin = mc.origin or Origin.BOTTOM_LEFT
         self.origin_row.set_selected(_ORIGIN_ENUM_TO_INDEX.get(origin, 0))
+        orientation = mc.workspace_orientation or WorkspaceOrientation.NATIVE
+        self.workspace_orientation_row.set_selected(
+            _WORKSPACE_ORIENTATIONS.index(orientation)
+        )
 
         # directional reversal flags aren't on MachineConfig; they live
         # on Machine directly. We treat them as ephemeral session state
@@ -350,6 +368,11 @@ class HardwarePage(WizardPage):
         mc.origin = _ORIGIN_INDEX_TO_ENUM.get(
             self.origin_row.get_selected(), Origin.BOTTOM_LEFT
         )
+        orientation_index = self.workspace_orientation_row.get_selected()
+        if orientation_index < len(_WORKSPACE_ORIENTATIONS):
+            mc.workspace_orientation = _WORKSPACE_ORIENTATIONS[
+                orientation_index
+            ]
 
         # stash reversals to aux_state (defers to Machine during
         # create_machine); the orchestrator applies them post-creation.

--- a/rayforge/ui_gtk/machine/wizard_pages/review_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/review_page.py
@@ -15,6 +15,7 @@ from gi.repository import Adw
 from ....machine.device.profile import DeviceProfile
 from ....machine.driver import get_driver_cls
 from ....machine.models.machine import Origin
+from ....pipeline.coordspace import WorkspaceOrientation
 from ....shared.units.system import UnitSystem
 from . import WizardPage, _makePreferencesGroup
 
@@ -156,6 +157,12 @@ class ReviewPage(WizardPage):
 
         origin = mc.origin if mc.origin is not None else Origin.BOTTOM_LEFT
         origin_label = _ORIGIN_LABELS[origin]
+        orientation = mc.workspace_orientation or WorkspaceOrientation.NATIVE
+        orientation_label = {
+            WorkspaceOrientation.NATIVE: _("Native"),
+            WorkspaceOrientation.ROTATED_LEFT: _("Rotate Left"),
+            WorkspaceOrientation.ROTATED_RIGHT: _("Rotate Right"),
+        }[orientation]
         unit_system = mc.unit_system or UnitSystem.METRIC
         unit_system_label = _UNIT_SYSTEM_LABELS[unit_system]
         rows_data = [
@@ -163,6 +170,7 @@ class ReviewPage(WizardPage):
             (_("Connection"), _format_connection(mc)),
             (_("Work Area X×Y"), _format_tuple(mc.axis_extents)),
             (_("Origin"), origin_label),
+            (_("Workspace Orientation"), orientation_label),
             (_("Unit System"), unit_system_label),
             (_("Max Travel Speed"), _format(mc.max_travel_speed)),
             (_("Max Cut Speed"), _format(mc.max_cut_speed)),

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -617,10 +617,9 @@ class MainWindow(Adw.ApplicationWindow):
         if not machine:
             return None
 
-        space = machine.get_coordinate_space()
-        workarea_origin_machine = space.get_workarea_origin_in_machine()
-        min_x, min_y = space.machine_point_to_world(*workarea_origin_machine)
-        workarea_w, workarea_h = space.workarea_size
+        min_x, min_y, workarea_w, workarea_h = (
+            machine.get_coordinate_space().get_workarea_world_rect()
+        )
         max_x = min_x + workarea_w
         max_y = min_y + workarea_h
 

--- a/rayforge/ui_gtk/sim3d/render_context/kinematics.py
+++ b/rayforge/ui_gtk/sim3d/render_context/kinematics.py
@@ -163,7 +163,9 @@ class KinematicsContext:
         if op_player and rotary_axis is not None and has_rotary:
             cyl_angle = math.radians(state.axes.get(rotary_axis, 0.0))
 
-        margin_shift = viewport.margin_shift
+        physical_to_visual = (
+            viewport.margin_shift @ viewport.native_to_workspace
+        )
         cylinder_transform = (
             frame.cylinder_transform
             if frame.cylinder_transform is not None
@@ -171,13 +173,13 @@ class KinematicsContext:
         )
         cyl_base_mvp = (
             mvp_ui.astype(np.float64)
-            @ margin_shift.astype(np.float64)
+            @ physical_to_visual.astype(np.float64)
             @ cylinder_transform
         )
         rot_4x4 = rotation_4x4(_VIS_ROT_AXIS, cyl_angle)
         mvp_rot = (cyl_base_mvp @ rot_4x4).astype(np.float32)
         cyl_mesh_mvp = (
-            mvp_ui @ margin_shift @ cylinder_transform @ rot_4x4
+            mvp_ui @ physical_to_visual @ cylinder_transform @ rot_4x4
         ).astype(np.float32)
 
         self._mvp_ui = mvp_ui

--- a/rayforge/ui_gtk/sim3d/render_context/viewport.py
+++ b/rayforge/ui_gtk/sim3d/render_context/viewport.py
@@ -19,6 +19,7 @@ class ViewportContext:
         self,
         *,
         model_matrix: np.ndarray | None = None,
+        native_to_workspace: np.ndarray | None = None,
         margin_shift: np.ndarray | None = None,
         wcs_offset_mm: tuple[float, float, float] | None = None,
         x_right: bool = False,
@@ -27,6 +28,9 @@ class ViewportContext:
     ):
         identity = np.eye(4, dtype=np.float32)
         self.model_matrix = identity if model_matrix is None else model_matrix
+        self.native_to_workspace = (
+            identity if native_to_workspace is None else native_to_workspace
+        )
         self.margin_shift = identity if margin_shift is None else margin_shift
         self.wcs_offset_mm = (
             (0.0, 0.0, 0.0) if wcs_offset_mm is None else wcs_offset_mm
@@ -39,6 +43,7 @@ class ViewportContext:
         """Recomputes the viewport section from the current frame inputs."""
         viewport = frame.viewport
         self.model_matrix = viewport.model_matrix
+        self.native_to_workspace = viewport.native_to_workspace
         self.margin_shift = viewport.margin_shift
         self.wcs_offset_mm = viewport.wcs_offset_mm
         self.x_right = viewport.x_right

--- a/rayforge/ui_gtk/sim3d/renderer/laser_beam_renderer.py
+++ b/rayforge/ui_gtk/sim3d/renderer/laser_beam_renderer.py
@@ -94,8 +94,9 @@ class LaserBeamRenderer(BaseRenderer):
             return
 
         ra = kinematics.rotary_axis
-        margin_shift = ctx.viewport.margin_shift
-        vis_mat = margin_shift.astype(np.float32)
+        vis_mat = (
+            ctx.viewport.margin_shift @ ctx.viewport.native_to_workspace
+        ).astype(np.float32)
         for name, (hx, hy, hz) in kinematics.head_positions.items():
             head_pos = vis_mat @ np.array([hx, hy, hz, 1.0], dtype=np.float32)
             cfg = kinematics.head_configs.get(name)

--- a/rayforge/ui_gtk/sim3d/renderer/model_renderer.py
+++ b/rayforge/ui_gtk/sim3d/renderer/model_renderer.py
@@ -172,11 +172,12 @@ class ModelRenderer(BaseRenderer):
                 pos = focused[self.link_name]
                 module_transform[:3, 3] = pos.astype(np.float32)
 
-        combined = (
-            ctx.camera.mvp_ui @ ctx.viewport.margin_shift @ module_transform
+        physical_to_visual = (
+            ctx.viewport.margin_shift @ ctx.viewport.native_to_workspace
         )
+        combined = ctx.camera.mvp_ui @ physical_to_visual @ module_transform
         self._mvp_matrix = combined
-        self._model_matrix = ctx.viewport.margin_shift @ module_transform
+        self._model_matrix = physical_to_visual @ module_transform
         self._point_light_pos = kinematics.laser_light_pos
 
     def _load_mesh(self) -> bool:

--- a/rayforge/ui_gtk/sim3d/renderer/scene_renderer.py
+++ b/rayforge/ui_gtk/sim3d/renderer/scene_renderer.py
@@ -353,7 +353,7 @@ class SceneRenderer(BaseRenderer):
             return
         if not machine:
             return
-        zones = list(machine.workspace_nogo_zones.values())
+        zones = list(machine.workspace.nogo_zones.values())
         self.zone_renderer.update_zones(zones)
 
     def clear_models(self):

--- a/rayforge/ui_gtk/sim3d/renderer/scene_renderer.py
+++ b/rayforge/ui_gtk/sim3d/renderer/scene_renderer.py
@@ -314,7 +314,7 @@ class SceneRenderer(BaseRenderer):
                 if layer.rotary_enabled and layer.rotary_diameter > 0:
                     desired_diameters[layer.rotary_diameter] = True
 
-        max_length = viewport.width_mm
+        max_length = machine.axis_extents[0] if machine else viewport.width_mm
         if machine:
             default_rm = machine.get_default_rotary_module()
             if default_rm:
@@ -353,7 +353,7 @@ class SceneRenderer(BaseRenderer):
             return
         if not machine:
             return
-        zones = list(machine.nogo_zones.values())
+        zones = list(machine.workspace_nogo_zones.values())
         self.zone_renderer.update_zones(zones)
 
     def clear_models(self):

--- a/rayforge/ui_gtk/sim3d/viewport.py
+++ b/rayforge/ui_gtk/sim3d/viewport.py
@@ -13,6 +13,7 @@ class ViewportConfig:
     width_mm: float
     depth_mm: float
     model_matrix: np.ndarray
+    native_to_workspace: np.ndarray
     wcs_offset_mm: Point3D
     margin_shift: np.ndarray
     extent_frame: Rect | None
@@ -30,6 +31,7 @@ class ViewportConfig:
             width_mm=width_mm,
             depth_mm=depth_mm,
             model_matrix=identity,
+            native_to_workspace=identity,
             wcs_offset_mm=(0.0, 0.0, 0.0),
             margin_shift=identity,
             extent_frame=None,
@@ -49,16 +51,23 @@ class ViewportConfig:
     def from_machine_with_wcs(
         cls, machine: "Machine", wcs_offset: tuple
     ) -> "ViewportConfig":
-        area = machine.work_area
+        area = machine.workspace_work_area
         width_mm = float(area[2])
         depth_mm = float(area[3])
+        space = machine.get_coordinate_space()
+        native_to_workspace = space.get_native_to_workspace_matrix().astype(
+            np.float32
+        )
+        origin = space.workspace_origin
+        x_right = origin.value.endswith("right")
+        y_down = origin.value.startswith("top")
 
         translate_mat = np.identity(4, dtype=np.float32)
         scale_mat = np.identity(4, dtype=np.float32)
-        if machine.y_axis_down:
+        if y_down:
             translate_mat[1, 3] = depth_mm
             scale_mat[1, 1] = -1.0
-        if machine.x_axis_right:
+        if x_right:
             translate_mat[0, 3] = width_mm
             scale_mat[0, 0] = -1.0
         model_matrix = translate_mat @ scale_mat
@@ -67,23 +76,25 @@ class ViewportConfig:
             wcs_offset_mm: Point3D = (0.0, 0.0, 0.0)
         else:
             wcs_x, wcs_y, wcs_z = wcs_offset
-            ml, mt, mr, mb = machine.work_margins
-            machine_x = -mr if machine.x_axis_right else -ml
-            machine_y = -mt if machine.y_axis_down else -mb
+            ml, mt, mr, mb = machine.workspace_margins
+            machine_x = -mr if x_right else -ml
+            machine_y = -mt if y_down else -mb
+            workspace_wcs = space.get_axis_label_origin(wcs_offset)
+            wcs_x, wcs_y = workspace_wcs[0], workspace_wcs[1]
             local_x = (
                 machine_x - wcs_x
-                if machine.reverse_x_axis
+                if space.workspace_x_negative
                 else machine_x + wcs_x
             )
             local_y = (
                 machine_y - wcs_y
-                if machine.reverse_y_axis
+                if space.workspace_y_negative
                 else machine_y + wcs_y
             )
             wcs_offset_mm = (local_x, local_y, wcs_z)
 
         margin_shift = np.identity(4, dtype=np.float32)
-        ml, _, _, mb = machine.work_margins
+        ml, _, _, mb = machine.workspace_margins
         margin_shift[0, 3] = -ml
         margin_shift[1, 3] = -mb
 
@@ -95,11 +106,12 @@ class ViewportConfig:
             width_mm=width_mm,
             depth_mm=depth_mm,
             model_matrix=model_matrix,
+            native_to_workspace=native_to_workspace,
             wcs_offset_mm=wcs_offset_mm,
             margin_shift=margin_shift,
             extent_frame=extent_frame,
-            x_right=machine.x_axis_right,
-            y_down=machine.y_axis_down,
-            x_negative=machine.reverse_x_axis,
-            y_negative=machine.reverse_y_axis,
+            x_right=x_right,
+            y_down=y_down,
+            x_negative=space.workspace_x_negative,
+            y_negative=space.workspace_y_negative,
         )

--- a/rayforge/ui_gtk/sim3d/viewport.py
+++ b/rayforge/ui_gtk/sim3d/viewport.py
@@ -51,16 +51,15 @@ class ViewportConfig:
     def from_machine_with_wcs(
         cls, machine: "Machine", wcs_offset: tuple
     ) -> "ViewportConfig":
-        area = machine.workspace_work_area
+        area = machine.workspace.work_area
         width_mm = float(area[2])
         depth_mm = float(area[3])
         space = machine.get_coordinate_space()
         native_to_workspace = space.get_native_to_workspace_matrix().astype(
             np.float32
         )
-        origin = space.workspace_origin
-        x_right = origin.value.endswith("right")
-        y_down = origin.value.startswith("top")
+        x_right = space.workspace_x_right
+        y_down = space.workspace_y_down
 
         translate_mat = np.identity(4, dtype=np.float32)
         scale_mat = np.identity(4, dtype=np.float32)
@@ -76,7 +75,7 @@ class ViewportConfig:
             wcs_offset_mm: Point3D = (0.0, 0.0, 0.0)
         else:
             wcs_x, wcs_y, wcs_z = wcs_offset
-            ml, mt, mr, mb = machine.workspace_margins
+            ml, mt, mr, mb = machine.workspace.margins
             machine_x = -mr if x_right else -ml
             machine_y = -mt if y_down else -mb
             workspace_wcs = space.get_axis_label_origin(wcs_offset)
@@ -94,13 +93,13 @@ class ViewportConfig:
             wcs_offset_mm = (local_x, local_y, wcs_z)
 
         margin_shift = np.identity(4, dtype=np.float32)
-        ml, _, _, mb = machine.workspace_margins
+        ml, _, _, mb = machine.workspace.margins
         margin_shift[0, 3] = -ml
         margin_shift[1, 3] = -mb
 
         extent_frame: Rect | None = None
         if machine.has_custom_work_area():
-            extent_frame = machine.get_visual_extent_frame()
+            extent_frame = machine.workspace.extent_frame
 
         return cls(
             width_mm=width_mm,

--- a/tests/doceditor/test_file_cmd.py
+++ b/tests/doceditor/test_file_cmd.py
@@ -421,6 +421,7 @@ class TestFitAndPositionAtReferenceOrigin:
             mock_machine = MagicMock()
             mock_machine.axis_extents = (200, 150)
             mock_machine.work_area = (0, 0, 200, 150)
+            mock_machine.workspace_work_area = (0, 0, 200, 150)
             mock_machine.get_reference_position_world.return_value = (0, 0)
             mock_machine.get_coordinate_space.return_value = MachineSpace(
                 origin=OriginCorner.BOTTOM_LEFT,
@@ -446,6 +447,7 @@ class TestFitAndPositionAtReferenceOrigin:
             mock_machine = MagicMock()
             mock_machine.axis_extents = (200, 150)
             mock_machine.work_area = (0, 0, 200, 150)
+            mock_machine.workspace_work_area = (0, 0, 200, 150)
             mock_machine.get_reference_position_world.return_value = (10, 20)
             mock_machine.get_coordinate_space.return_value = MachineSpace(
                 origin=OriginCorner.BOTTOM_LEFT,

--- a/tests/doceditor/test_file_cmd.py
+++ b/tests/doceditor/test_file_cmd.py
@@ -421,7 +421,7 @@ class TestFitAndPositionAtReferenceOrigin:
             mock_machine = MagicMock()
             mock_machine.axis_extents = (200, 150)
             mock_machine.work_area = (0, 0, 200, 150)
-            mock_machine.workspace_work_area = (0, 0, 200, 150)
+            mock_machine.workspace.work_area = (0, 0, 200, 150)
             mock_machine.get_reference_position_world.return_value = (0, 0)
             mock_machine.get_coordinate_space.return_value = MachineSpace(
                 origin=OriginCorner.BOTTOM_LEFT,
@@ -447,7 +447,7 @@ class TestFitAndPositionAtReferenceOrigin:
             mock_machine = MagicMock()
             mock_machine.axis_extents = (200, 150)
             mock_machine.work_area = (0, 0, 200, 150)
-            mock_machine.workspace_work_area = (0, 0, 200, 150)
+            mock_machine.workspace.work_area = (0, 0, 200, 150)
             mock_machine.get_reference_position_world.return_value = (10, 20)
             mock_machine.get_coordinate_space.return_value = MachineSpace(
                 origin=OriginCorner.BOTTOM_LEFT,

--- a/tests/doceditor/test_stock_cmd.py
+++ b/tests/doceditor/test_stock_cmd.py
@@ -19,7 +19,7 @@ def stock_cmd(doc_editor, context_initializer):
     mock_machine = MagicMock()
     mock_machine.axis_extents = (200.0, 200.0)
     mock_machine.work_area = (0.0, 0.0, 200.0, 200.0)
-    mock_machine.workspace_work_area = (0.0, 0.0, 200.0, 200.0)
+    mock_machine.workspace.work_area = (0.0, 0.0, 200.0, 200.0)
     mock_machine.get_reference_position_world.return_value = (0.0, 0.0)
     mock_machine.get_coordinate_space.return_value = MachineSpace(
         origin=OriginCorner.BOTTOM_LEFT,

--- a/tests/doceditor/test_stock_cmd.py
+++ b/tests/doceditor/test_stock_cmd.py
@@ -19,6 +19,7 @@ def stock_cmd(doc_editor, context_initializer):
     mock_machine = MagicMock()
     mock_machine.axis_extents = (200.0, 200.0)
     mock_machine.work_area = (0.0, 0.0, 200.0, 200.0)
+    mock_machine.workspace_work_area = (0.0, 0.0, 200.0, 200.0)
     mock_machine.get_reference_position_world.return_value = (0.0, 0.0)
     mock_machine.get_coordinate_space.return_value = MachineSpace(
         origin=OriginCorner.BOTTOM_LEFT,

--- a/tests/machine/device/test_device_profile.py
+++ b/tests/machine/device/test_device_profile.py
@@ -15,6 +15,7 @@ from rayforge.machine.device.profile import (
 )
 from rayforge.machine.models.laser import LaserHead, LaserType
 from rayforge.machine.models.machine import Origin
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 from rayforge.shared.tasker.manager import TaskManager
 from rayforge.shared.units.system import UnitSystem
 
@@ -118,6 +119,7 @@ class TestDeviceProfileLoad:
                     "driver": "GrblSerialDriver",
                     "axis_extents": [300, 200],
                     "origin": "top_left",
+                    "workspace_orientation": "rotated_right",
                     "supports_arcs": True,
                     "supports_curves": False,
                     "max_travel_speed": 3000,
@@ -134,6 +136,10 @@ class TestDeviceProfileLoad:
         assert pkg.meta.description == "40W CO2 laser"
         assert pkg.machine_config.axis_extents == (300, 200)
         assert pkg.machine_config.origin == Origin("top_left")
+        assert (
+            pkg.machine_config.workspace_orientation
+            == WorkspaceOrientation.ROTATED_RIGHT
+        )
         assert pkg.machine_config.supports_arcs is True
 
     def test_load_with_custom_dialect(self, tmp_path):
@@ -245,6 +251,16 @@ class TestDeviceProfileLoad:
             machine_extra={"origin": "middle_center"},
         )
         with pytest.raises(ValueError, match="Invalid origin"):
+            DeviceProfile.from_path(device_dir)
+
+    def test_invalid_workspace_orientation_raises(self, tmp_path):
+        device_dir = _make_device(
+            tmp_path,
+            name="Bad Workspace Orientation",
+            subdir="bad-workspace-orientation",
+            machine_extra={"workspace_orientation": "mirrored"},
+        )
+        with pytest.raises(ValueError, match="Invalid workspace_orientation"):
             DeviceProfile.from_path(device_dir)
 
     def test_invalid_axis_extents_raises(self, tmp_path):
@@ -615,6 +631,7 @@ class TestExportMachine:
         machine.driver_config = {}
         machine.axis_extents = (300.0, 200.0)
         machine.origin = Origin.BOTTOM_LEFT
+        machine.workspace_orientation = WorkspaceOrientation.NATIVE
         machine.supports_arcs = True
         machine.supports_curves = False
         machine.max_travel_speed = 5000
@@ -644,7 +661,10 @@ class TestExportMachine:
         )
 
     def test_export_machine_basic(self, tmp_path):
-        machine = self._make_mock_machine("Test Export")
+        machine = self._make_mock_machine(
+            "Test Export",
+            workspace_orientation=WorkspaceOrientation.ROTATED_LEFT,
+        )
 
         dest = tmp_path / "output"
         mgr = DeviceProfileManager(install_dir=tmp_path / "inst")
@@ -658,6 +678,7 @@ class TestExportMachine:
                 data = yaml.safe_load(f)
             assert data["device"]["name"] == "Test Export"
             assert data["machine"]["driver"] == "GrblSerialDriver"
+            assert data["machine"]["workspace_orientation"] == "rotated_left"
 
     def test_export_machine_to_dir(self, tmp_path):
         machine = self._make_mock_machine("Dir Export")
@@ -685,13 +706,18 @@ class TestCreateMachine:
     async def test_create_machine_gcode_has_dialect(
         self, tmp_path, lite_context, task_mgr
     ):
-        device_dir = _make_device(tmp_path, name="GRBL Test")
+        device_dir = _make_device(
+            tmp_path,
+            name="GRBL Test",
+            machine_extra={"workspace_orientation": "rotated_right"},
+        )
         pkg = DeviceProfile.from_path(device_dir)
         m = pkg.create_machine(lite_context)
         await _wait_for_tasks(task_mgr)
 
         assert m.dialect_uid is not None
         assert m.dialect is not None
+        assert m.workspace_orientation == WorkspaceOrientation.ROTATED_RIGHT
 
     @pytest.mark.asyncio
     async def test_create_machine_ruida_no_dialect(

--- a/tests/machine/models/test_machine.py
+++ b/tests/machine/models/test_machine.py
@@ -3,11 +3,14 @@ from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from raygeo.geo import Geometry, Matrix
 from raygeo.ops.axis import Axis
 
 import rayforge.machine.driver as driver_module
+from rayforge.camera.controller import CameraController
+from rayforge.camera.models.camera import Camera
 from rayforge.context import get_context
 from rayforge.core.doc import Doc
 from rayforge.core.source_asset import SourceAsset
@@ -32,6 +35,7 @@ from rayforge.machine.models.laser import Laser
 from rayforge.machine.models.machine import JogDirection, Machine, Origin
 from rayforge.machine.models.macro import MacroTrigger
 from rayforge.machine.transport import TransportStatus
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 from rayforge.pipeline.encoder.base import EncodedOutput
 from rayforge.shared.tasker.manager import TaskManager
 
@@ -421,6 +425,130 @@ class TestMachine:
         assert new_machine.reverse_x_axis is True
         assert new_machine.reverse_y_axis is True
         assert new_machine.reverse_z_axis is True
+
+    @pytest.mark.asyncio
+    async def test_workspace_orientation_serialization(
+        self, machine: Machine, task_mgr: TaskManager, lite_context
+    ):
+        """Workspace rotation is persisted and defaults to native."""
+        await wait_for_tasks_to_finish(task_mgr)
+        machine.set_workspace_orientation(WorkspaceOrientation.ROTATED_RIGHT)
+
+        data = machine.to_dict()
+        assert data["machine"]["workspace_orientation"] == "rotated_right"
+
+        restored = Machine.from_dict(data, context=lite_context)
+        await wait_for_tasks_to_finish(task_mgr)
+        assert (
+            restored.workspace_orientation
+            == WorkspaceOrientation.ROTATED_RIGHT
+        )
+
+        data["machine"].pop("workspace_orientation")
+        legacy = Machine.from_dict(data, context=lite_context)
+        await wait_for_tasks_to_finish(task_mgr)
+        assert legacy.workspace_orientation == WorkspaceOrientation.NATIVE
+
+    @pytest.mark.parametrize(
+        "orientation, expected",
+        [
+            (WorkspaceOrientation.NATIVE, (10.0, 40.0)),
+            (WorkspaceOrientation.ROTATED_LEFT, (160.0, 10.0)),
+            (WorkspaceOrientation.ROTATED_RIGHT, (40.0, 90.0)),
+        ],
+    )
+    def test_workarea_reference_origin_uses_workspace_coordinates(
+        self, isolated_machine, orientation, expected
+    ):
+        """The physical workarea origin follows the displayed bed."""
+        isolated_machine.set_axis_extents(100.0, 200.0)
+        isolated_machine.set_work_margins(10.0, 20.0, 30.0, 40.0)
+        isolated_machine.set_origin(Origin.BOTTOM_LEFT)
+        isolated_machine.set_workspace_orientation(orientation)
+        isolated_machine.wcs_origin_is_workarea_origin = True
+
+        assert isolated_machine.get_reference_position_world() == expected
+
+    def test_workspace_orientation_projects_camera_alignment(
+        self, isolated_machine
+    ):
+        """Existing physical camera alignment follows the rotated bed."""
+        isolated_machine.set_axis_extents(100.0, 200.0)
+        camera = Camera(name="Test Camera", device_id="test-camera")
+        image_points = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+        world_points = [
+            (10.0, 20.0),
+            (40.0, 20.0),
+            (40.0, 60.0),
+            (10.0, 60.0),
+        ]
+        camera.image_to_world = (image_points, world_points)
+        alignment_date = camera.alignment_date
+        isolated_machine.add_camera(camera)
+
+        isolated_machine.set_workspace_orientation(
+            WorkspaceOrientation.ROTATED_RIGHT
+        )
+
+        assert camera.image_to_world is not None
+        assert camera.image_to_world[1] == pytest.approx(
+            [(20.0, 90.0), (20.0, 60.0), (60.0, 60.0), (60.0, 90.0)]
+        )
+        assert camera.alignment_date == alignment_date
+
+        isolated_machine.set_workspace_orientation(WorkspaceOrientation.NATIVE)
+        assert camera.image_to_world[1] == pytest.approx(world_points)
+
+    def test_axis_extents_reproject_rotated_camera_alignment(
+        self, isolated_machine
+    ):
+        """Changing rotated bed dimensions preserves physical alignment."""
+        isolated_machine.set_axis_extents(100.0, 200.0)
+        isolated_machine.set_workspace_orientation(
+            WorkspaceOrientation.ROTATED_RIGHT
+        )
+        camera = Camera(name="Test Camera", device_id="test-camera")
+        image_points = [(0.0, 0.0)] * 4
+        camera.image_to_world = (image_points, [(20.0, 90.0)] * 4)
+        alignment_date = camera.alignment_date
+        isolated_machine.add_camera(camera)
+
+        isolated_machine.set_axis_extents(200.0, 200.0)
+
+        assert camera.image_to_world is not None
+        assert camera.image_to_world[1] == pytest.approx([(20.0, 190.0)] * 4)
+        assert camera.alignment_date == alignment_date
+
+    def test_rotated_camera_alignment_renders_at_workspace_position(
+        self, isolated_machine
+    ):
+        isolated_machine.set_axis_extents(100.0, 200.0)
+        camera = Camera(name="Test Camera", device_id="test-camera")
+        camera.image_to_world = (
+            [(0.0, 0.0), (99.0, 0.0), (99.0, 199.0), (0.0, 199.0)],
+            [(0.0, 200.0), (100.0, 200.0), (100.0, 0.0), (0.0, 0.0)],
+        )
+        isolated_machine.add_camera(camera)
+        image = np.zeros((200, 100, 3), dtype=np.uint8)
+        image[:100, :50, 0] = 10
+        image[:100, 50:, 0] = 20
+        image[100:, :50, 0] = 30
+        image[100:, 50:, 0] = 40
+        controller = CameraController(camera)
+        controller._image_data = image
+
+        isolated_machine.set_workspace_orientation(
+            WorkspaceOrientation.ROTATED_RIGHT
+        )
+        rendered = controller.get_work_surface_image(
+            (200, 100), ((0.0, 0.0), (200.0, 100.0))
+        )
+
+        assert rendered is not None
+        assert rendered[25, 50, 0] == 10
+        assert rendered[25, 150, 0] == 30
+        assert rendered[75, 50, 0] == 20
+        assert rendered[75, 150, 0] == 40
 
     @pytest.mark.asyncio
     async def test_serialization_migration_from_negative_to_reverse(
@@ -1512,6 +1640,39 @@ class TestJogDelegation:
             MachineController(m, isolated_context, MagicMock())
         )
         yield m
+
+    @pytest.mark.parametrize(
+        "orientation, direction, expected",
+        [
+            (
+                WorkspaceOrientation.ROTATED_RIGHT,
+                JogDirection.EAST,
+                {Axis.Y: 10.0},
+            ),
+            (
+                WorkspaceOrientation.ROTATED_RIGHT,
+                JogDirection.NORTH,
+                {Axis.X: -10.0},
+            ),
+            (
+                WorkspaceOrientation.ROTATED_LEFT,
+                JogDirection.EAST,
+                {Axis.Y: -10.0},
+            ),
+            (
+                WorkspaceOrientation.ROTATED_LEFT,
+                JogDirection.NORTH,
+                {Axis.X: 10.0},
+            ),
+        ],
+    )
+    def test_visual_jog_uses_rotated_native_axis(
+        self, jog_machine, orientation, direction, expected
+    ):
+        """Workspace-relative jogging follows the rotated canvas."""
+        jog_machine.set_workspace_orientation(orientation)
+
+        assert jog_machine.calculate_visual_jog(direction, 10.0) == expected
 
     @pytest.mark.parametrize(
         "direction, origin, reverse, distance, expected_delta",

--- a/tests/machine/models/test_machine.py
+++ b/tests/machine/models/test_machine.py
@@ -449,6 +449,15 @@ class TestMachine:
         await wait_for_tasks_to_finish(task_mgr)
         assert legacy.workspace_orientation == WorkspaceOrientation.NATIVE
 
+    def test_rotary_workspace_support_is_centralized(self, isolated_machine):
+        assert isolated_machine.supports_rotary_workspace()
+
+        isolated_machine.set_workspace_orientation(
+            WorkspaceOrientation.ROTATED_LEFT
+        )
+
+        assert not isolated_machine.supports_rotary_workspace()
+
     @pytest.mark.parametrize(
         "orientation, expected",
         [
@@ -466,6 +475,71 @@ class TestMachine:
         isolated_machine.set_origin(Origin.BOTTOM_LEFT)
         isolated_machine.set_workspace_orientation(orientation)
         isolated_machine.wcs_origin_is_workarea_origin = True
+
+        assert isolated_machine.get_reference_position_world() == expected
+
+    @pytest.mark.parametrize(
+        "wcs_is_workarea_origin, origin, reverse_x, reverse_y, expected",
+        [
+            # Active WCS offset (25, 35), checked against legacy native-mode
+            # behavior for every origin and reversal combination.
+            (False, Origin.BOTTOM_LEFT, False, False, (25.0, 35.0)),
+            (False, Origin.BOTTOM_LEFT, True, False, (-25.0, 35.0)),
+            (False, Origin.BOTTOM_LEFT, False, True, (25.0, -35.0)),
+            (False, Origin.BOTTOM_LEFT, True, True, (-25.0, -35.0)),
+            (False, Origin.TOP_LEFT, False, False, (25.0, 165.0)),
+            (False, Origin.TOP_LEFT, True, False, (-25.0, 165.0)),
+            (False, Origin.TOP_LEFT, False, True, (25.0, 235.0)),
+            (False, Origin.TOP_LEFT, True, True, (-25.0, 235.0)),
+            (False, Origin.BOTTOM_RIGHT, False, False, (75.0, 35.0)),
+            (False, Origin.BOTTOM_RIGHT, True, False, (125.0, 35.0)),
+            (False, Origin.BOTTOM_RIGHT, False, True, (75.0, -35.0)),
+            (False, Origin.BOTTOM_RIGHT, True, True, (125.0, -35.0)),
+            (False, Origin.TOP_RIGHT, False, False, (75.0, 165.0)),
+            (False, Origin.TOP_RIGHT, True, False, (125.0, 165.0)),
+            (False, Origin.TOP_RIGHT, False, True, (75.0, 235.0)),
+            (False, Origin.TOP_RIGHT, True, True, (125.0, 235.0)),
+            # Work-area reference offset with margins (10, 20, 30, 40).
+            # These values intentionally preserve the pre-feature transform
+            # through machine_point_to_world for non-bottom-left origins.
+            (True, Origin.BOTTOM_LEFT, False, False, (10.0, 40.0)),
+            (True, Origin.BOTTOM_LEFT, True, False, (-10.0, 40.0)),
+            (True, Origin.BOTTOM_LEFT, False, True, (10.0, -40.0)),
+            (True, Origin.BOTTOM_LEFT, True, True, (-10.0, -40.0)),
+            (True, Origin.TOP_LEFT, False, False, (10.0, 20.0)),
+            (True, Origin.TOP_LEFT, True, False, (-10.0, 20.0)),
+            (True, Origin.TOP_LEFT, False, True, (10.0, 380.0)),
+            (True, Origin.TOP_LEFT, True, True, (-10.0, 380.0)),
+            (True, Origin.BOTTOM_RIGHT, False, False, (30.0, 40.0)),
+            (True, Origin.BOTTOM_RIGHT, True, False, (170.0, 40.0)),
+            (True, Origin.BOTTOM_RIGHT, False, True, (30.0, -40.0)),
+            (True, Origin.BOTTOM_RIGHT, True, True, (170.0, -40.0)),
+            (True, Origin.TOP_RIGHT, False, False, (30.0, 20.0)),
+            (True, Origin.TOP_RIGHT, True, False, (170.0, 20.0)),
+            (True, Origin.TOP_RIGHT, False, True, (30.0, 380.0)),
+            (True, Origin.TOP_RIGHT, True, True, (170.0, 380.0)),
+        ],
+    )
+    def test_reference_position_world_native_regression_matrix(
+        self,
+        isolated_machine,
+        wcs_is_workarea_origin,
+        origin,
+        reverse_x,
+        reverse_y,
+        expected,
+    ):
+        """Native mode preserves all pre-orientation reference transforms."""
+        isolated_machine.set_axis_extents(100.0, 200.0)
+        isolated_machine.set_work_margins(10.0, 20.0, 30.0, 40.0)
+        isolated_machine.set_origin(origin)
+        isolated_machine.set_reverse_x_axis(reverse_x)
+        isolated_machine.set_reverse_y_axis(reverse_y)
+        isolated_machine.set_active_wcs("G54")
+        isolated_machine.update_wcs_offset("G54", (25.0, 35.0, 0.0))
+        isolated_machine.set_wcs_origin_is_workarea_origin(
+            wcs_is_workarea_origin
+        )
 
         assert isolated_machine.get_reference_position_world() == expected
 
@@ -1672,7 +1746,7 @@ class TestJogDelegation:
         """Workspace-relative jogging follows the rotated canvas."""
         jog_machine.set_workspace_orientation(orientation)
 
-        assert jog_machine.calculate_visual_jog(direction, 10.0) == expected
+        assert jog_machine.workspace.calculate_jog(direction, 10.0) == expected
 
     @pytest.mark.parametrize(
         "direction, origin, reverse, distance, expected_delta",

--- a/tests/machine/sanity/test_checker.py
+++ b/tests/machine/sanity/test_checker.py
@@ -1,8 +1,11 @@
+import pytest
+
 from rayforge.machine.sanity import (
     CheckMode,
     IssueCategory,
     SanityChecker,
 )
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 
 
 def test_clean_job(isolated_machine, make_line_ops):
@@ -35,6 +38,61 @@ def test_zone_violation_reported(
         i for i in report.issues if i.category == IssueCategory.NOGO_ZONE
     ]
     assert len(zone_issues) == 1
+
+
+@pytest.mark.parametrize(
+    "orientation, points",
+    [
+        (
+            WorkspaceOrientation.ROTATED_LEFT,
+            [(130, 25, False), (190, 25, True)],
+        ),
+        (
+            WorkspaceOrientation.ROTATED_RIGHT,
+            [(10, 75, False), (70, 75, True)],
+        ),
+    ],
+)
+def test_rotated_zone_violation_reported_at_workspace_location(
+    isolated_machine, make_line_ops, make_rect_zone, orientation, points
+):
+    """Safety checks project physical no-go zones with the workspace."""
+    isolated_machine.set_axis_extents(100, 200)
+    zone = make_rect_zone(10, 20, 30, 40, "Clamp")
+    isolated_machine.add_nogo_zone(zone)
+    isolated_machine.set_workspace_orientation(orientation)
+
+    report = SanityChecker(isolated_machine).check(make_line_ops(points))
+
+    zone_issues = [
+        issue
+        for issue in report.issues
+        if issue.category == IssueCategory.NOGO_ZONE
+    ]
+    assert len(zone_issues) == 1
+    assert zone.params == {"x": 10, "y": 20, "w": 30, "h": 40}
+
+
+def test_rotated_zone_projection_is_cached_and_invalidated(
+    isolated_machine, make_rect_zone
+):
+    isolated_machine.set_axis_extents(100, 200)
+    zone = make_rect_zone(10, 20, 30, 40, "Clamp")
+    isolated_machine.add_nogo_zone(zone)
+    isolated_machine.set_workspace_orientation(
+        WorkspaceOrientation.ROTATED_RIGHT
+    )
+
+    first = isolated_machine.workspace_nogo_zones
+    assert isolated_machine.workspace_nogo_zones is first
+
+    zone.set_param("x", 20)
+    second = isolated_machine.workspace_nogo_zones
+    assert second is not first
+    assert second[zone.uid].params["y"] == pytest.approx(50)
+
+    isolated_machine.set_axis_extents(200, 200)
+    assert isolated_machine.workspace_nogo_zones is not second
 
 
 def test_workarea_violation_reported(isolated_machine, make_line_ops):

--- a/tests/machine/sanity/test_checker.py
+++ b/tests/machine/sanity/test_checker.py
@@ -73,26 +73,34 @@ def test_rotated_zone_violation_reported_at_workspace_location(
     assert zone.params == {"x": 10, "y": 20, "w": 30, "h": 40}
 
 
-def test_rotated_zone_projection_is_cached_and_invalidated(
+def test_zone_projection_is_detached_and_always_reflects_native_state(
     isolated_machine, make_rect_zone
 ):
     isolated_machine.set_axis_extents(100, 200)
     zone = make_rect_zone(10, 20, 30, 40, "Clamp")
     isolated_machine.add_nogo_zone(zone)
+
+    native = isolated_machine.workspace.nogo_zones
+    assert native[zone.uid] is not zone
+    assert native[zone.uid].params == zone.params
+
     isolated_machine.set_workspace_orientation(
         WorkspaceOrientation.ROTATED_RIGHT
     )
 
-    first = isolated_machine.workspace_nogo_zones
-    assert isolated_machine.workspace_nogo_zones is first
+    first = isolated_machine.workspace.nogo_zones
+    assert first[zone.uid] is not zone
+    assert isolated_machine.workspace.nogo_zones is not first
 
     zone.set_param("x", 20)
-    second = isolated_machine.workspace_nogo_zones
+    second = isolated_machine.workspace.nogo_zones
     assert second is not first
     assert second[zone.uid].params["y"] == pytest.approx(50)
 
     isolated_machine.set_axis_extents(200, 200)
-    assert isolated_machine.workspace_nogo_zones is not second
+    third = isolated_machine.workspace.nogo_zones
+    assert third is not second
+    assert third[zone.uid].params["y"] == pytest.approx(150)
 
 
 def test_workarea_violation_reported(isolated_machine, make_line_ops):

--- a/tests/pipeline/test_coordspace.py
+++ b/tests/pipeline/test_coordspace.py
@@ -3,11 +3,13 @@ Unit tests for coordinate space classes.
 """
 
 import numpy as np
+import pytest
 
 from rayforge.pipeline.coordspace import (
     AxisDirection,
     MachineSpace,
     OriginCorner,
+    WorkspaceOrientation,
 )
 
 
@@ -62,6 +64,56 @@ class TestMachineSpace:
 
         assert width == 160.0
         assert height == 140.0
+
+    @pytest.mark.parametrize(
+        "margins",
+        [
+            (100.0, 0.0, 100.0, 0.0),  # margins exactly consume the width
+            (150.0, 150.0, 150.0, 150.0),  # margins exceed both extents
+        ],
+    )
+    def test_workarea_size_clamps_degenerate_margins(self, margins):
+        """Regression: the workarea never collapses to <= 0.
+
+        Mirrors the clamp in `Machine.work_area`, which this property
+        replaced at its call sites. Device profiles pass YAML margins
+        through unvalidated, so margins can meet or exceed the extents;
+        downstream layout and 3D viewport code assumes a positive size.
+        """
+        space = MachineSpace(
+            origin=OriginCorner.BOTTOM_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_UP,
+            extents=(200.0, 200.0),
+            margins=margins,
+        )
+
+        width, height = space.workarea_size
+
+        assert width >= 1.0
+        assert height >= 1.0
+
+        _, _, rect_w, rect_h = space.get_workarea_world_rect()
+        assert (rect_w, rect_h) == (width, height)
+
+    def test_workarea_size_clamps_when_rotated(self):
+        """The clamp applies after margins rotate with the workspace.
+
+        The native left/right margins (150mm each) overrun the 100mm
+        native width. Rotated, they land on the workspace's vertical
+        axis, so the height clamps while the width stays valid.
+        """
+        space = MachineSpace(
+            origin=OriginCorner.BOTTOM_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_UP,
+            extents=(100.0, 200.0),
+            margins=(150.0, 60.0, 150.0, 60.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_RIGHT,
+        )
+
+        assert space.workspace_extents == (200.0, 100.0)
+        assert space.workarea_size == (80.0, 1.0)
 
     def test_get_workarea_origin_in_machine_bottom_left(self):
         """Workarea origin for BL origin machine should be at margins."""
@@ -160,6 +212,191 @@ class TestMachineSpace:
         expected = np.identity(4, dtype=np.float64)
         expected[1, 1] = -1.0
         np.testing.assert_array_almost_equal(matrix, expected)
+
+    def test_rotated_right_swaps_extents_and_axes(self):
+        """Right rotation maps workspace X/Y to machine Y/-X."""
+        space = MachineSpace(
+            origin=OriginCorner.BOTTOM_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_UP,
+            extents=(400.0, 800.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_RIGHT,
+        )
+
+        assert space.workspace_extents == (800.0, 400.0)
+        assert space.world_point_to_machine(0.0, 0.0) == (400.0, 0.0)
+        assert space.world_point_to_machine(800.0, 400.0) == (0.0, 800.0)
+        assert space.machine_point_to_world(323.0, 127.0) == (127.0, 77.0)
+
+    def test_rotated_left_swaps_extents_and_axes(self):
+        """Left rotation maps workspace X/Y to machine -Y/X."""
+        space = MachineSpace(
+            origin=OriginCorner.BOTTOM_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_UP,
+            extents=(400.0, 800.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_LEFT,
+        )
+
+        assert space.workspace_extents == (800.0, 400.0)
+        assert space.world_point_to_machine(0.0, 0.0) == (0.0, 800.0)
+        assert space.world_point_to_machine(800.0, 400.0) == (400.0, 0.0)
+        assert space.machine_point_to_world(77.0, 673.0) == (127.0, 77.0)
+
+    def test_rotated_workspace_edges_and_origin(self):
+        """Margins and origin rotate with the physical bed edges."""
+        left = MachineSpace(
+            origin=OriginCorner.TOP_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_DOWN,
+            extents=(400.0, 800.0),
+            margins=(10.0, 20.0, 30.0, 40.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_LEFT,
+        )
+        right = MachineSpace(
+            origin=OriginCorner.TOP_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_DOWN,
+            extents=(400.0, 800.0),
+            margins=(10.0, 20.0, 30.0, 40.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_RIGHT,
+        )
+
+        assert left.workspace_margins == (20.0, 30.0, 40.0, 10.0)
+        assert left.workspace_origin == OriginCorner.BOTTOM_LEFT
+        assert left.get_workarea_world_rect() == (20.0, 10.0, 740.0, 360.0)
+        assert right.workspace_margins == (40.0, 10.0, 20.0, 30.0)
+        assert right.workspace_origin == OriginCorner.TOP_RIGHT
+        assert right.get_workarea_world_rect() == (40.0, 30.0, 740.0, 360.0)
+
+    @pytest.mark.parametrize(
+        "orientation, expected_pos",
+        [
+            (WorkspaceOrientation.ROTATED_LEFT, (140.0, 10.0)),
+            (WorkspaceOrientation.ROTATED_RIGHT, (20.0, 60.0)),
+        ],
+    )
+    def test_native_bed_item_projects_into_rotated_workspace(
+        self, orientation, expected_pos
+    ):
+        """Physical bed overlays rotate without origin/reversal effects."""
+        space = MachineSpace(
+            origin=OriginCorner.TOP_RIGHT,
+            x_positive_direction=AxisDirection.POSITIVE_LEFT,
+            y_positive_direction=AxisDirection.POSITIVE_DOWN,
+            extents=(100.0, 200.0),
+            reverse_x=True,
+            reverse_y=True,
+            workspace_orientation=orientation,
+        )
+
+        pos, size = space.native_bed_item_to_workspace(
+            (10.0, 20.0), (30.0, 40.0)
+        )
+
+        assert pos == pytest.approx(expected_pos)
+        assert size == pytest.approx((40.0, 30.0))
+
+    @pytest.mark.parametrize("orientation", list(WorkspaceOrientation))
+    @pytest.mark.parametrize("origin", list(OriginCorner))
+    @pytest.mark.parametrize("reverse_x", [False, True])
+    @pytest.mark.parametrize("reverse_y", [False, True])
+    def test_workspace_transform_round_trip_all_configurations(
+        self, orientation, origin, reverse_x, reverse_y
+    ):
+        """Points and item bounds round-trip for every machine setup."""
+        x_direction = (
+            AxisDirection.POSITIVE_LEFT
+            if origin in (OriginCorner.TOP_RIGHT, OriginCorner.BOTTOM_RIGHT)
+            else AxisDirection.POSITIVE_RIGHT
+        )
+        y_direction = (
+            AxisDirection.POSITIVE_DOWN
+            if origin in (OriginCorner.TOP_LEFT, OriginCorner.TOP_RIGHT)
+            else AxisDirection.POSITIVE_UP
+        )
+        space = MachineSpace(
+            origin=origin,
+            x_positive_direction=x_direction,
+            y_positive_direction=y_direction,
+            extents=(400.0, 800.0),
+            reverse_x=reverse_x,
+            reverse_y=reverse_y,
+            workspace_orientation=orientation,
+        )
+
+        world_point = (123.25, 77.5)
+        machine_point = space.world_point_to_machine(*world_point)
+        assert space.machine_point_to_world(*machine_point) == pytest.approx(
+            world_point
+        )
+
+        world_pos = (20.0, 30.0)
+        item_size = (50.0, 70.0)
+        machine_pos = space.world_item_to_machine(world_pos, item_size)
+        assert space.machine_item_to_world(
+            machine_pos, item_size
+        ) == pytest.approx(world_pos)
+
+    @pytest.mark.parametrize("origin", list(OriginCorner))
+    @pytest.mark.parametrize("reverse_x", [False, True])
+    @pytest.mark.parametrize("reverse_y", [False, True])
+    def test_axis_label_origin_native_matches_raw_wcs_offset(
+        self, origin, reverse_x, reverse_y
+    ):
+        """Regression: in the native orientation, the WCS branch of
+        get_axis_label_origin must return the raw offset unchanged,
+        exactly as it did before workspace rotation existed."""
+        x_direction = (
+            AxisDirection.POSITIVE_LEFT
+            if origin in (OriginCorner.TOP_RIGHT, OriginCorner.BOTTOM_RIGHT)
+            else AxisDirection.POSITIVE_RIGHT
+        )
+        y_direction = (
+            AxisDirection.POSITIVE_DOWN
+            if origin in (OriginCorner.TOP_LEFT, OriginCorner.TOP_RIGHT)
+            else AxisDirection.POSITIVE_UP
+        )
+        space = MachineSpace(
+            origin=origin,
+            x_positive_direction=x_direction,
+            y_positive_direction=y_direction,
+            extents=(400.0, 800.0),
+            reverse_x=reverse_x,
+            reverse_y=reverse_y,
+        )
+
+        assert space.get_axis_label_origin(
+            wcs_offset=(50.0, 60.0, 0.0)
+        ) == pytest.approx((50.0, 60.0, 0.0))
+
+    def test_axis_label_origin_native_workarea_matches_margins(self):
+        """Regression: native workarea-origin labels come from margins."""
+        space = MachineSpace(
+            origin=OriginCorner.TOP_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_DOWN,
+            extents=(400.0, 800.0),
+            margins=(10.0, 20.0, 30.0, 40.0),
+        )
+
+        assert space.get_axis_label_origin(
+            wcs_is_workarea_origin=True
+        ) == pytest.approx((10.0, 20.0, 0.0))
+
+    def test_axis_label_origin_rotated_right_swaps_axes(self):
+        """A rotated workspace shows the WCS offset along swapped axes."""
+        space = MachineSpace(
+            origin=OriginCorner.BOTTOM_LEFT,
+            x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+            y_positive_direction=AxisDirection.POSITIVE_UP,
+            extents=(400.0, 800.0),
+            workspace_orientation=WorkspaceOrientation.ROTATED_RIGHT,
+        )
+
+        assert space.get_axis_label_origin(
+            wcs_offset=(50.0, 60.0, 0.0)
+        ) == pytest.approx((60.0, 50.0, 0.0))
 
 
 class TestCoordinateSpaceTransforms:

--- a/tests/pipeline/test_coordspace.py
+++ b/tests/pipeline/test_coordspace.py
@@ -264,9 +264,13 @@ class TestMachineSpace:
 
         assert left.workspace_margins == (20.0, 30.0, 40.0, 10.0)
         assert left.workspace_origin == OriginCorner.BOTTOM_LEFT
+        assert left.workspace_x_right is False
+        assert left.workspace_y_down is False
         assert left.get_workarea_world_rect() == (20.0, 10.0, 740.0, 360.0)
         assert right.workspace_margins == (40.0, 10.0, 20.0, 30.0)
         assert right.workspace_origin == OriginCorner.TOP_RIGHT
+        assert right.workspace_x_right is True
+        assert right.workspace_y_down is True
         assert right.get_workarea_world_rect() == (40.0, 30.0, 740.0, 360.0)
 
     @pytest.mark.parametrize(
@@ -337,6 +341,60 @@ class TestMachineSpace:
         assert space.machine_item_to_world(
             machine_pos, item_size
         ) == pytest.approx(world_pos)
+
+    @pytest.mark.parametrize("orientation", list(WorkspaceOrientation))
+    @pytest.mark.parametrize("origin", list(OriginCorner))
+    @pytest.mark.parametrize("reverse_x", [False, True])
+    @pytest.mark.parametrize("reverse_y", [False, True])
+    def test_scalar_and_matrix_paths_agree(
+        self, orientation, origin, reverse_x, reverse_y
+    ):
+        """The two world→machine implementations must not drift apart.
+
+        `world_point_to_machine` applies the origin/reversal rules as
+        scalar branches (used by the UI), while the encoding pipeline
+        consumes `get_world_to_machine_matrix`. They are separate code
+        paths describing the same transform, so a change to one that is
+        not mirrored in the other would silently desynchronise what the
+        canvas shows from what the machine is told to do.
+        """
+        x_direction = (
+            AxisDirection.POSITIVE_LEFT
+            if origin in (OriginCorner.TOP_RIGHT, OriginCorner.BOTTOM_RIGHT)
+            else AxisDirection.POSITIVE_RIGHT
+        )
+        y_direction = (
+            AxisDirection.POSITIVE_DOWN
+            if origin in (OriginCorner.TOP_LEFT, OriginCorner.TOP_RIGHT)
+            else AxisDirection.POSITIVE_UP
+        )
+        space = MachineSpace(
+            origin=origin,
+            x_positive_direction=x_direction,
+            y_positive_direction=y_direction,
+            extents=(400.0, 800.0),
+            reverse_x=reverse_x,
+            reverse_y=reverse_y,
+            workspace_orientation=orientation,
+        )
+        matrix = space.get_world_to_machine_matrix()
+        workspace_width, workspace_height = space.workspace_extents
+
+        # Includes both bed corners and asymmetric interior points, so a
+        # missing translation term cannot pass by symmetry. Deriving the
+        # probes from workspace extents keeps every point on the presented
+        # bed in both native and rotated orientations.
+        for world_x, world_y in (
+            (0.0, 0.0),
+            (workspace_width, workspace_height),
+            (workspace_width * 0.31, workspace_height * 0.17),
+            (workspace_width * 0.73, workspace_height * 0.61),
+        ):
+            scalar = space.world_point_to_machine(world_x, world_y)
+            transformed = matrix @ np.array([world_x, world_y, 0.0, 1.0])
+            assert scalar == pytest.approx((transformed[0], transformed[1])), (
+                f"paths disagree at ({world_x}, {world_y})"
+            )
 
     @pytest.mark.parametrize("origin", list(OriginCorner))
     @pytest.mark.parametrize("reverse_x", [False, True])

--- a/tests/pipeline/test_intent_builder.py
+++ b/tests/pipeline/test_intent_builder.py
@@ -41,9 +41,11 @@ from rayforge.core.workpiece import WorkPiece
 from rayforge.machine.models.dialect.grbl import GRBL_DIALECT
 from rayforge.machine.models.machine import Machine, Origin
 from rayforge.machine.models.rotary_module import RotaryMode, RotaryModule
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 from rayforge.pipeline.encoder.rust_helpers import dialect_to_spec
 from rayforge.pipeline.intent_builder import (
     IntentBuilder,
+    UnsupportedRotaryWorkspaceOrientationError,
     job_encode_key,
     job_key,
     job_machinexform_key,
@@ -110,6 +112,22 @@ def test_keys_are_stable_across_rebuilds(isolated_machine):
     n1 = IntentBuilder(machine=isolated_machine).build(doc)
     n2 = IntentBuilder(machine=isolated_machine).build(doc)
     assert [n.key for n in n1] == [n.key for n in n2]
+
+
+def test_rotary_layer_rejects_rotated_workspace(isolated_machine):
+    """Rotary uses its own cylindrical coordinate space, not the rotated
+    flat-bed presentation."""
+    doc = _make_doc(_TestStep(name="s1"), WorkPiece(name="wp"))
+    doc.active_layer.set_rotary_enabled(True)
+    isolated_machine.set_workspace_orientation(
+        WorkspaceOrientation.ROTATED_RIGHT
+    )
+
+    with pytest.raises(
+        UnsupportedRotaryWorkspaceOrientationError,
+        match="Rotary layers require the Native workspace orientation",
+    ):
+        IntentBuilder(machine=isolated_machine).build(doc)
 
 
 # ----------------------------------------------------------------------
@@ -663,6 +681,41 @@ def test_job_encode_token_changes_on_machine_swap(
     assert before_t != after_t
 
 
+def test_machine_token_ignores_unused_wcs_offset(isolated_machine):
+    step = _TestStep(name="s1")
+    doc = _make_doc(step, WorkPiece(name="wp"))
+    before = IntentBuilder(machine=isolated_machine).build(doc)
+
+    isolated_machine.update_wcs_offset("G55", (10.0, 20.0, 0.0))
+    after = IntentBuilder(machine=isolated_machine).build(doc)
+
+    before_t = next(
+        n.version_token for n in before if n.key == job_machinexform_key()
+    )
+    after_t = next(
+        n.version_token for n in after if n.key == job_machinexform_key()
+    )
+    assert after_t == before_t
+
+
+def test_machine_token_tracks_effective_layer_wcs_offset(isolated_machine):
+    step = _TestStep(name="s1")
+    doc = _make_doc(step, WorkPiece(name="wp"))
+    doc.active_layer.set_wcs("G55")
+    before = IntentBuilder(machine=isolated_machine).build(doc)
+
+    isolated_machine.update_wcs_offset("G55", (10.0, 20.0, 0.0))
+    after = IntentBuilder(machine=isolated_machine).build(doc)
+
+    before_t = next(
+        n.version_token for n in before if n.key == job_machinexform_key()
+    )
+    after_t = next(
+        n.version_token for n in after if n.key == job_machinexform_key()
+    )
+    assert after_t != before_t
+
+
 def test_contour_job_encodes_through_raygeo(
     contour_step_class, test_machine_and_config
 ):
@@ -720,6 +773,53 @@ def test_machine_transform_node_present(
     mx_idx = keys.index(job_machinexform_key())
     enc_idx = keys.index(job_encode_key())
     assert job_idx < mx_idx < enc_idx
+
+
+def test_machine_transform_uses_workspace_rotation(isolated_machine):
+    """The output stage swaps axes using the selected 90-degree rotation."""
+    isolated_machine.set_axis_extents(400.0, 800.0)
+    isolated_machine.set_workspace_orientation(
+        WorkspaceOrientation.ROTATED_RIGHT
+    )
+    doc = _make_doc(_TestStep())
+
+    spec = IntentBuilder(
+        machine=isolated_machine
+    )._build_machine_transform_stage(doc)
+
+    assert spec.world_to_machine == [
+        [0.0, -1.0, 0.0, 400.0],
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+
+def test_workspace_rotation_invalidates_machine_transform(
+    contour_step_class, test_machine_and_config
+):
+    """Changing orientation invalidates cached machine-space output."""
+    machine, context = test_machine_and_config
+    doc = _make_doc(
+        contour_step_class.create(context, name="cut"),
+        WorkPiece(name="wp"),
+    )
+    before = IntentBuilder(machine=machine).build(doc)
+
+    machine.set_workspace_orientation(WorkspaceOrientation.ROTATED_LEFT)
+    after = IntentBuilder(machine=machine).build(doc)
+
+    before_token = next(
+        node.version_token
+        for node in before
+        if node.key == job_machinexform_key()
+    )
+    after_token = next(
+        node.version_token
+        for node in after
+        if node.key == job_machinexform_key()
+    )
+    assert before_token != after_token
 
 
 def test_machine_transform_linearizes_curves(
@@ -1393,3 +1493,37 @@ def test_machine_transform_wcs_offset_in_gcode(
     # First G1 cut: world (95.5, -4.5) minus WCS (50, 30) = (45.5, -34.5).
     assert coords[1][0] == pytest.approx(45.5, abs=0.1)
     assert coords[1][1] == pytest.approx(-34.5, abs=0.1)
+
+
+@pytest.mark.parametrize(
+    "orientation,expected_start,expected_next",
+    [
+        (
+            WorkspaceOrientation.ROTATED_RIGHT,
+            (204.5, -4.5),
+            (204.5, 95.5),
+        ),
+        (
+            WorkspaceOrientation.ROTATED_LEFT,
+            (-4.5, 154.5),
+            (-4.5, 54.5),
+        ),
+    ],
+)
+def test_workspace_rotation_in_gcode(
+    contour_step_class,
+    test_machine_and_config,
+    orientation,
+    expected_start,
+    expected_next,
+):
+    """Left/right workspace rotations produce the expected native axes."""
+    machine, context = test_machine_and_config
+    machine.set_origin(Origin.BOTTOM_LEFT)
+    machine.set_workspace_orientation(orientation)
+
+    gcode = _run_full_pipeline(machine, context, contour_step_class)
+    coords = _extract_cut_coords(gcode)
+    assert len(coords) >= 4
+    assert coords[0] == pytest.approx(expected_start, abs=0.1)
+    assert coords[1] == pytest.approx(expected_next, abs=0.1)

--- a/tests/pipeline/test_intent_controller.py
+++ b/tests/pipeline/test_intent_controller.py
@@ -14,6 +14,7 @@ from rayforge.core.doc import Doc
 from rayforge.core.step import Step
 from rayforge.core.workpiece import WorkPiece
 from rayforge.machine.models.machine import Machine
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 from rayforge.pipeline.intent_builder import (
     job_encode_key,
     job_key,
@@ -122,6 +123,20 @@ class FakeTaskManager:
         call = self.delayed.pop()
         call.fire()
         self.main_thread_calls.clear()
+
+
+class ImmediateMainThreadTaskManager(FakeTaskManager):
+    """Fake scheduler that executes main-thread callbacks immediately."""
+
+    def schedule_on_main_thread(
+        self,
+        callback: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> FakeCancelHandle:
+        self.main_thread_calls.append(callback)
+        callback(*args, **kwargs)
+        return FakeCancelHandle()
 
 
 class _StubNode:
@@ -273,6 +288,31 @@ def test_run_intent_called(monkeypatch, isolated_machine):
     assert intent is ctrl.intent
     assert on_completed == ctrl._on_completed
     assert pipeline is ctrl.raygeo_pipeline
+    ctrl.shutdown()
+
+
+def test_rotary_workspace_error_is_reported(isolated_machine):
+    doc = _make_doc(_TestStep(name="s1"), WorkPiece(name="wp"))
+    doc.active_layer.set_rotary_enabled(True)
+    isolated_machine.set_workspace_orientation(
+        WorkspaceOrientation.ROTATED_LEFT
+    )
+    tm = ImmediateMainThreadTaskManager()
+    ctrl = IntentController(doc, tm, machine=isolated_machine)
+    messages: list[str] = []
+    ctrl.pipeline_error.connect(
+        lambda _sender, *, message: messages.append(message), weak=False
+    )
+
+    ctrl.force_rebuild()
+
+    assert messages == [
+        (
+            "Rotary layers require the Native workspace orientation. "
+            "Set Machine → Hardware → Workspace Orientation to Native."
+        )
+    ]
+    assert ctrl.intent is not None
     ctrl.shutdown()
 
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -13,6 +13,10 @@ from rayforge.core.vectorization_spec import PassthroughSpec
 from rayforge.core.workpiece import WorkPiece
 from rayforge.image import SVG_RENDERER
 from rayforge.pipeline.artifact import WorkPieceArtifactHandle
+from rayforge.pipeline.coordspace import WorkspaceOrientation
+from rayforge.pipeline.intent_builder import (
+    UnsupportedRotaryWorkspaceOrientationError,
+)
 from rayforge.pipeline.pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
@@ -120,6 +124,48 @@ class TestPipeline:
                 context_initializer.artifact_store,
                 None,  # type: ignore
             )
+
+    def test_configuration_error_releases_stale_job(self):
+        """An invalid machine configuration must not leave old G-code
+        available to export or send."""
+        pipeline = Pipeline.__new__(Pipeline)
+        stale_handle = MagicMock()
+        pipeline._store = MagicMock()
+        pipeline._last_job_handle = stale_handle
+        pipeline._last_aggregate_output = object()
+        pipeline.pipeline_error = MagicMock()
+
+        pipeline._on_pipeline_error(None, message="invalid configuration")
+
+        pipeline._store.release.assert_called_once_with(stale_handle)
+        assert pipeline._last_job_handle is None
+        assert pipeline._last_aggregate_output is None
+        pipeline.pipeline_error.send.assert_called_once_with(
+            pipeline, message="invalid configuration"
+        )
+
+    def test_generate_job_reports_rotary_workspace_error(
+        self, doc, mock_task_mgr, context_initializer
+    ):
+        machine = context_initializer.machine
+        machine.set_workspace_orientation(WorkspaceOrientation.ROTATED_RIGHT)
+        doc.active_layer.set_rotary_enabled(True)
+        pipeline = Pipeline(
+            doc,
+            mock_task_mgr,
+            context_initializer.artifact_store,
+            machine,
+        )
+        results = []
+
+        pipeline.generate_job_artifact(
+            when_done=lambda handle, error: results.append((handle, error))
+        )
+
+        assert len(results) == 1
+        handle, error = results[0]
+        assert handle is None
+        assert isinstance(error, UnsupportedRotaryWorkspaceOrientationError)
 
     @pytest.mark.asyncio
     async def test_generate_job_artifact_no_doc(

--- a/tests/ui_gtk/canvas2d/test_surface.py
+++ b/tests/ui_gtk/canvas2d/test_surface.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from rayforge.machine.models.machine import Machine, Origin
-from rayforge.pipeline.coordspace import MachineSpace
+from rayforge.pipeline.coordspace import MachineSpace, WorkspaceOrientation
 
 
 @pytest.fixture
@@ -123,6 +123,7 @@ def test_wcs_visual_marker_location(surface, scenario):
     machine.origin = scenario["origin"]
     machine.reverse_x_axis = scenario["reverse_x"]
     machine.reverse_y_axis = scenario["reverse_y"]
+    machine.workspace_orientation = WorkspaceOrientation.NATIVE
     machine.wcs_origin_is_workarea_origin = False
     machine.work_margins = (0.0, 0.0, 0.0, 0.0)
 

--- a/tests/ui_gtk/machine/test_jog_direction.py
+++ b/tests/ui_gtk/machine/test_jog_direction.py
@@ -6,6 +6,7 @@ from raygeo.ops.axis import Axis
 from rayforge.machine.driver.driver import DeviceState
 from rayforge.machine.models.machine import Machine, Origin
 from rayforge.machine.transport import TransportStatus
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 
 # Jog distance and speed for testing
 JOG_DISTANCE = 10.0
@@ -126,6 +127,56 @@ def test_jog_button_direction(
     # 5. Verify the jog command was called with expected distance
     mock_jog.assert_called_once_with(
         machine, {expected_axis: expectation}, JOG_SPEED
+    )
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "orientation,button_name,expected_deltas",
+    [
+        (
+            WorkspaceOrientation.ROTATED_RIGHT,
+            "east",
+            {Axis.Y: JOG_DISTANCE},
+        ),
+        (
+            WorkspaceOrientation.ROTATED_RIGHT,
+            "north",
+            {Axis.X: -JOG_DISTANCE},
+        ),
+        (
+            WorkspaceOrientation.ROTATED_LEFT,
+            "east",
+            {Axis.Y: -JOG_DISTANCE},
+        ),
+        (
+            WorkspaceOrientation.ROTATED_LEFT,
+            "north",
+            {Axis.X: JOG_DISTANCE},
+        ),
+    ],
+)
+def test_jog_button_direction_with_rotated_workspace(
+    ui_context_initializer, orientation, button_name, expected_deltas
+):
+    """Cardinal buttons follow visual directions after swapping X/Y."""
+    from rayforge.ui_gtk.machine.jog_widget import JogWidget
+
+    machine = Machine(ui_context_initializer)
+    machine.set_axis_extents(400, 800)
+    machine.set_workspace_orientation(orientation)
+    ui_context_initializer.machine_mgr.add_machine(machine)
+
+    machine_cmd = MagicMock()
+    jog_widget = JogWidget()
+    jog_widget.set_machine(machine, machine_cmd)
+    jog_widget.jog_distance = JOG_DISTANCE
+    jog_widget.jog_speed = JOG_SPEED
+
+    getattr(jog_widget, f"{button_name}_btn").emit("clicked")
+
+    machine_cmd.jog.assert_called_once_with(
+        machine, expected_deltas, JOG_SPEED
     )
 
 

--- a/tests/ui_gtk/sim3d/renderer/test_model_renderer.py
+++ b/tests/ui_gtk/sim3d/renderer/test_model_renderer.py
@@ -154,6 +154,45 @@ class TestModelRenderer:
         assert renderer._point_light_pos is not None
         np.testing.assert_allclose(renderer._point_light_pos, [1.0, 2.0, 3.0])
 
+    def test_prepare_projects_native_model_into_workspace(self, tmp_path):
+        renderer = ModelRenderer(tmp_path / "test.glb", link_name="gantry")
+        module_transform = np.eye(4, dtype=np.float32)
+        module_transform[0, 3] = 10.0
+        native_to_workspace = np.array(
+            [
+                [0.0, 1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0, 100.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        kinematics = KinematicsContext(
+            mvp_ui=np.eye(4, dtype=np.float32),
+            model_world_transforms={"gantry": module_transform},
+        )
+        ctx = RenderContext(
+            camera=CameraContext(
+                mvp_ui=np.eye(4, dtype=np.float32),
+                viewport_height=800,
+                camera_position=np.zeros(3),
+                color_set=ColorSet(),
+            ),
+            viewport=ViewportContext(
+                native_to_workspace=native_to_workspace,
+                margin_shift=np.eye(4, dtype=np.float32),
+            ),
+            kinematics=kinematics,
+        )
+
+        renderer.prepare(ctx)
+
+        expected = native_to_workspace @ module_transform
+        assert renderer._model_matrix is not None
+        assert renderer._mvp_matrix is not None
+        np.testing.assert_allclose(renderer._model_matrix, expected)
+        np.testing.assert_allclose(renderer._mvp_matrix, expected)
+
     def test_prepare_noop_without_kinematics(self, tmp_path):
         renderer = ModelRenderer(tmp_path / "test.glb", link_name="gantry")
         mvp = np.eye(4, dtype=np.float32)

--- a/tests/ui_gtk/sim3d/test_doc_signals.py
+++ b/tests/ui_gtk/sim3d/test_doc_signals.py
@@ -11,6 +11,11 @@ from unittest.mock import MagicMock
 import pytest
 from blinker import Signal
 
+from rayforge.pipeline.coordspace import (
+    AxisDirection,
+    MachineSpace,
+    OriginCorner,
+)
 from rayforge.ui_gtk.sim3d.doc_signals import DocSignalHub
 
 
@@ -38,6 +43,8 @@ def _machine():
     machine.changed = Signal()
     machine.work_area = (100.0, 100.0, 100.0, 100.0)
     machine.work_margins = (0.0, 0.0, 0.0, 0.0)
+    machine.workspace_work_area = (100.0, 100.0, 100.0, 100.0)
+    machine.workspace_margins = (0.0, 0.0, 0.0, 0.0)
     machine.y_axis_down = False
     machine.x_axis_right = False
     machine.reverse_x_axis = False
@@ -45,6 +52,11 @@ def _machine():
     machine.wcs_origin_is_workarea_origin = True
     machine.has_custom_work_area.return_value = False
     machine.get_active_wcs_offset.return_value = (0.0, 0.0, 0.0)
+    machine.get_coordinate_space.return_value = MachineSpace(
+        origin=OriginCorner.BOTTOM_LEFT,
+        x_positive_direction=AxisDirection.POSITIVE_RIGHT,
+        y_positive_direction=AxisDirection.POSITIVE_UP,
+    )
     return machine
 
 

--- a/tests/ui_gtk/sim3d/test_doc_signals.py
+++ b/tests/ui_gtk/sim3d/test_doc_signals.py
@@ -43,8 +43,8 @@ def _machine():
     machine.changed = Signal()
     machine.work_area = (100.0, 100.0, 100.0, 100.0)
     machine.work_margins = (0.0, 0.0, 0.0, 0.0)
-    machine.workspace_work_area = (100.0, 100.0, 100.0, 100.0)
-    machine.workspace_margins = (0.0, 0.0, 0.0, 0.0)
+    machine.workspace.work_area = (100.0, 100.0, 100.0, 100.0)
+    machine.workspace.margins = (0.0, 0.0, 0.0, 0.0)
     machine.y_axis_down = False
     machine.x_axis_right = False
     machine.reverse_x_axis = False

--- a/tests/ui_gtk/sim3d/test_viewport_config.py
+++ b/tests/ui_gtk/sim3d/test_viewport_config.py
@@ -3,6 +3,7 @@ import pytest
 
 from rayforge.context import RayforgeContext
 from rayforge.machine.models.machine import Machine, Origin
+from rayforge.pipeline.coordspace import WorkspaceOrientation
 from rayforge.ui_gtk.sim3d.viewport import ViewportConfig
 
 
@@ -45,6 +46,28 @@ class TestViewportConfigDefaults:
 
 
 class TestViewportConfigAxisOrientation:
+    def test_rotated_right_swaps_viewport_dimensions(self):
+        m = _make_machine()
+        m.set_axis_extents(300.0, 600.0)
+        m.set_workspace_orientation(WorkspaceOrientation.ROTATED_RIGHT)
+
+        vp = ViewportConfig.from_machine(m)
+
+        assert vp.width_mm == 600.0
+        assert vp.depth_mm == 300.0
+        assert vp.x_right is False
+        assert vp.y_down is True
+        expected = np.array(
+            [
+                [0.0, 1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0, 300.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_array_equal(vp.native_to_workspace, expected)
+
     def test_y_axis_down_flips_y(self):
         m = _make_machine()
         m.origin = Origin.TOP_LEFT
@@ -155,6 +178,24 @@ class TestViewportConfigExtentFrame:
 
 
 class TestViewportConfigWcsOffset:
+    @pytest.mark.parametrize(
+        "orientation,expected_origin",
+        [
+            (WorkspaceOrientation.ROTATED_LEFT, (20.0, 40.0, 0.0)),
+            (WorkspaceOrientation.ROTATED_RIGHT, (20.0, 40.0, 0.0)),
+        ],
+    )
+    def test_rotated_workspace_wcs_offset(self, orientation, expected_origin):
+        m = _make_machine()
+        m.set_axis_extents(300.0, 600.0)
+        m.set_work_margins(10.0, 20.0, 30.0, 40.0)
+        m.set_workspace_orientation(orientation)
+        m.update_wcs_offset("G54", (50.0, 60.0, 0.0))
+
+        vp = ViewportConfig.from_machine(m)
+
+        assert vp.wcs_offset_mm == pytest.approx(expected_origin)
+
     def test_wcs_origin_is_workarea_origin(self):
         m = _make_machine()
         m.wcs_origin_is_workarea_origin = True

--- a/website/docs/machine/hardware.md
+++ b/website/docs/machine/hardware.md
@@ -39,6 +39,26 @@ Select where your machine's coordinate origin (0,0) is located. This determines 
 The coordinate origin setting affects how G-code is generated. Make sure it matches your firmware's homing configuration.
 :::
 
+### Workspace Orientation
+
+Use **Workspace Orientation** to show a portrait machine bed in landscape
+orientation without changing the machine's physical configuration:
+
+- **Native**: Show the bed using the machine's physical X and Y axes.
+- **Rotate Left**: Rotate the workspace 90° counterclockwise.
+- **Rotate Right**: Rotate the workspace 90° clockwise.
+
+Rayforge rotates the canvas, camera alignment, no-go zones, jog controls, and
+3D preview together. Generated G-code is transformed back to the machine's
+native axes, so the physical machine configuration remains unchanged. This is
+a true 90° rotation rather than a bare X/Y coordinate swap, which would mirror
+the design and reverse its handedness.
+
+:::note
+Workspace orientation applies to the flat machine bed. Rotary layers use a
+separate cylindrical workspace and require **Native** orientation.
+:::
+
 ### Axis Direction
 
 Reverse the direction of any axis if needed:

--- a/website/docs/machine/rotary.md
+++ b/website/docs/machine/rotary.md
@@ -64,6 +64,12 @@ single project, or when you have different rotary settings for different parts o
 When rotary mode is active on a layer, a small rotary icon appears next to that layer in
 the layer list so you can tell at a glance which layers will run in rotary mode.
 
+:::note
+Rotary mode uses its own unrolled-cylinder coordinate system. If you use the
+flat-bed **Workspace Orientation** setting, change it to **Native** in
+**Machine Settings → Hardware** before enabling a rotary layer.
+:::
+
 ## 3D Preview in Rotary Mode
 
 When rotary mode is active, the [3D view](../ui/3d-preview.md) shows your toolpath wrapped


### PR DESCRIPTION
## Summary

- Add a machine-level **Workspace Orientation** setting with **Native**, **Rotate Left**, and **Rotate Right** options in Machine Settings and the machine wizard.
- Present portrait machine beds in landscape while keeping physical machine extents, margins, origins, calibration data, and device configuration in native coordinates.
- Transform generated output back into native machine coordinates. This uses a true 90° rotation instead of a bare X/Y swap, so designs keep their handedness rather than being mirrored.
- Apply the workspace projection consistently across the 2D canvas, axis labels, jogging, WCS/work-area handling, no-go zones, camera alignment, sanity checks, and 3D preview.
- Persist the setting in machine files and device profiles, with legacy files defaulting to Native, and document the behavior in the user guide and changelog.

## Rotary limitation

Rotary layers use a separate unrolled-cylinder coordinate system whose Y mapping currently happens before the workspace transform in Raygeo. To avoid silently generating incorrect output, rotary layers currently require **Native** workspace orientation.

The layer dialog prevents enabling rotary while the workspace is rotated, generation validates the combination again, stale generated output is cleared, and the resulting error explains how to correct the setting. Supporting a transparent rotary bypass can be handled separately by reordering the composed transform in the Raygeo rotary stage.

## Verification

- 457 affected tests passed after rebasing onto current `main` (86 unrelated marked tests deselected).
- Ruff formatting, import ordering, and full lint checks pass.
- Flake8 and Pyflakes pass.
- Pyright reports no errors in the changed files. A repository-wide local run retains the two pre-existing `sys._MEIPASS` diagnostics in `rayforge/app.py` and `rayforge/worker_init.py`.

## AI disclosure

This contribution was developed with assistance from OpenAI Codex and Anthropic Claude for implementation, test development, and code review. I reviewed the resulting changes, resolved the identified issues, and verified the final behavior and test results. No AI tool is included as a commit co-author.
