### PR TITLE
refactor: remove 'from __future__ import annotations' everywhere

### DIFF
--- a/.github/workflows/build-macos-universal.yml
+++ b/.github/workflows/build-macos-universal.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.11"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: requirements.txt
 
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.11"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: requirements.txt
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/adaptive_clearing_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/adaptive_clearing_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any, cast
 
@@ -82,8 +80,8 @@ class AdaptiveClearStep(CncAssemblerStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         # Multi-pocket handling is done on the Rust side:
         # Part.from_geometry_multi_face exposes each pocket as a face,
@@ -119,7 +117,7 @@ class AdaptiveClearStep(CncAssemblerStep):
         return result
 
     @classmethod
-    def from_dict(cls, data) -> AdaptiveClearStep:
+    def from_dict(cls, data) -> "AdaptiveClearStep":
         step = cast("AdaptiveClearStep", super().from_dict(data))
         step.step_over = data.get("step_over", step.step_over)
         step.step_length = data.get("step_length", step.step_length)

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/cnc_assembler_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/cnc_assembler_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -47,10 +45,10 @@ class CncAssemblerStep(Step):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name=None,
         **kwargs,
-    ) -> CncAssemblerStep:
+    ) -> "CncAssemblerStep":
         machine = context.machine
         step = cls(name=name)
         step.per_workpiece_transformers_dicts = []
@@ -109,7 +107,7 @@ class CncAssemblerStep(Step):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CncAssemblerStep:
+    def from_dict(cls, data: dict[str, Any]) -> "CncAssemblerStep":
         step = cast("CncAssemblerStep", super().from_dict(data))
         step.tool_diameter = data.get("tool_diameter", step.tool_diameter)
         step.spindle_rpm = data.get("spindle_rpm", step.spindle_rpm)
@@ -195,21 +193,21 @@ class CncAssemblerStep(Step):
             groups.append((_("Step Settings"), VarSet(vars=step_vars)))
         return groups or [(_("CNC"), VarSet(vars=cnc_vars))]
 
-    def build_spec(self, workpiece: WorkPiece) -> object:
+    def build_spec(self, workpiece: "WorkPiece") -> object:
         """Return the raygeo assembler spec for this step.
 
         Subclasses must override.
         """
         raise NotImplementedError
 
-    def populate_payload(self, payload, machine: Machine):
+    def populate_payload(self, payload, machine: "Machine"):
         super().populate_payload(payload, machine)
         # The renderer colours ops by power and treats zero as a "no cut"
         # state. Express the spindle's power level as the fraction of its
         # max RPM so a running spindle renders as a cut at the right intensity.
         payload.power = self._spindle_power_fraction(machine)
 
-    def _spindle_power_fraction(self, machine: Machine) -> float:
+    def _spindle_power_fraction(self, machine: "Machine") -> float:
         """CNC power level in ``[0, 1]`` from the spindle's RPM ratio."""
         head = self.get_selected_head(machine)
         if isinstance(head, SpindleHead):
@@ -218,8 +216,8 @@ class CncAssemblerStep(Step):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         part = workpiece.to_part()
         if part is None:
@@ -232,8 +230,8 @@ class CncAssemblerStep(Step):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict[str, Any]:
         """Return a JSON-serialisable view of ``build_spec``'s params.
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/flat_spiral_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/flat_spiral_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/helix_plunge_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/helix_plunge_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/ramp_entry_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/ramp_entry_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/slot_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/slot_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any
 

--- a/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/toroidal_clear_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-cnc/cnc_essentials/steps/toroidal_clear_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any, cast
 
@@ -66,7 +64,7 @@ class ToroidalClearStep(CncAssemblerStep):
         return result
 
     @classmethod
-    def from_dict(cls, data) -> ToroidalClearStep:
+    def from_dict(cls, data) -> "ToroidalClearStep":
         step = cast("ToroidalClearStep", super().from_dict(data))
         step.step_over = data.get("step_over", step.step_over)
         return step

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/contour_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/contour_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -102,8 +100,8 @@ class ContourStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         kwargs: dict = {}
         kwargs["cut_side"] = str(self.cut_side).lower()
@@ -118,8 +116,8 @@ class ContourStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` (from the workpiece's vector
         geometry) and a :class:`ComputePayload` carrying a
@@ -151,8 +149,8 @@ class ContourStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         """Expose the resolved assembler kwargs for the compute token."""
         return self.get_assembler_kwargs(machine, workpiece)
@@ -176,7 +174,7 @@ class ContourStep(LaserStep):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> ContourStep:
+    def from_dict(cls, data: dict) -> "ContourStep":
         step = cast("ContourStep", super().from_dict(data))
         legacy = legacy_producer_params(data)
         step.cut_side = data.get(
@@ -241,11 +239,11 @@ class ContourStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         optimize: bool = True,
         **kwargs,
-    ) -> ContourStep:
+    ) -> "ContourStep":
         machine = context.machine
         assert machine is not None
         default_head = machine.get_default_laser_head()

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/frame_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/frame_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -75,8 +73,8 @@ class FrameStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         kwargs: dict = {}
         kwargs["cut_side"] = str(self.cut_side).lower()
@@ -85,8 +83,8 @@ class FrameStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` (from the workpiece's vector
         geometry) and a :class:`ComputePayload` carrying a
@@ -107,8 +105,8 @@ class FrameStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         return self.get_assembler_kwargs(machine, workpiece)
 
@@ -126,7 +124,7 @@ class FrameStep(LaserStep):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> FrameStep:
+    def from_dict(cls, data: dict) -> "FrameStep":
         step = cast("FrameStep", super().from_dict(data))
         legacy = legacy_producer_params(data)
         step.cut_side = data.get(
@@ -176,10 +174,10 @@ class FrameStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         **kwargs,
-    ) -> FrameStep:
+    ) -> "FrameStep":
         machine = context.machine
         assert machine is not None
         default_head = machine.get_default_laser_head()

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/material_test.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -54,8 +52,8 @@ class MaterialTestStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         _spot_x, spot_y = LaserHead.get_spot_size(
             self.get_selected_laser(machine)
@@ -90,8 +88,8 @@ class MaterialTestStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` (empty — the material-test grid
         needs no geometry) and a :class:`ComputePayload` carrying a
@@ -126,8 +124,8 @@ class MaterialTestStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         return self.get_assembler_kwargs(machine, workpiece)
 
@@ -151,7 +149,7 @@ class MaterialTestStep(LaserStep):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> MaterialTestStep:
+    def from_dict(cls, data: dict) -> "MaterialTestStep":
         step = cast("MaterialTestStep", super().from_dict(data))
         legacy = legacy_producer_params(data)
         step.test_type = data.get("test_type", legacy.get("test_type", "Cut"))
@@ -227,10 +225,10 @@ class MaterialTestStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         **kwargs,
-    ) -> MaterialTestStep:
+    ) -> "MaterialTestStep":
         machine = context.machine
         assert machine is not None
 

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/raster_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import (
     TYPE_CHECKING,
@@ -151,8 +149,8 @@ class EngraveStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         _spot_x, spot_y = LaserHead.get_spot_size(
             self.get_selected_laser(machine)
@@ -196,8 +194,8 @@ class EngraveStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` with the preprocessed raster image
         attached as a :class:`WholeImageSource`, and a
@@ -250,8 +248,8 @@ class EngraveStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         return self.get_assembler_kwargs(machine, workpiece)
 
@@ -284,7 +282,7 @@ class EngraveStep(LaserStep):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> EngraveStep:
+    def from_dict(cls, data: dict) -> "EngraveStep":
         step = cast("EngraveStep", super().from_dict(data))
         legacy = legacy_producer_params(data)
         # Legacy type names implied a depth mode when none was saved.
@@ -431,10 +429,10 @@ class EngraveStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         **kwargs,
-    ) -> EngraveStep:
+    ) -> "EngraveStep":
         machine = context.machine
         assert machine is not None
         default_head = machine.get_default_laser_head()
@@ -476,8 +474,8 @@ class EngraveStep(LaserStep):
 
 def _build_raster_part(
     step: EngraveStep,
-    machine: Machine,
-    workpiece: WorkPiece,
+    machine: "Machine",
+    workpiece: "WorkPiece",
 ) -> tuple[Part, np.ndarray | None]:
     """Render and preprocess the workpiece into a :class:`Part`
     carrying a :class:`WholeImageSource`, and return the alpha

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/shrinkwrap_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/shrinkwrap_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -91,8 +89,8 @@ class ShrinkWrapStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         kwargs: dict = {}
         kwargs["cut_side"] = self.cut_side.lower()
@@ -105,8 +103,8 @@ class ShrinkWrapStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` with vector geometry and a boolean
         image, and a :class:`ComputePayload` carrying a
@@ -125,8 +123,8 @@ class ShrinkWrapStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         return self.get_assembler_kwargs(machine, workpiece)
 
@@ -145,7 +143,7 @@ class ShrinkWrapStep(LaserStep):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> ShrinkWrapStep:
+    def from_dict(cls, data: dict) -> "ShrinkWrapStep":
         step = cast("ShrinkWrapStep", super().from_dict(data))
         legacy = legacy_producer_params(data)
         step.gravity = data.get("gravity", legacy.get("gravity", 0.0))
@@ -199,10 +197,10 @@ class ShrinkWrapStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         **kwargs,
-    ) -> ShrinkWrapStep:
+    ) -> "ShrinkWrapStep":
         machine = context.machine
         assert machine is not None
         default_head = machine.get_default_laser_head()
@@ -242,7 +240,7 @@ class ShrinkWrapStep(LaserStep):
         return step
 
 
-def _build_shrinkwrap_part(workpiece: WorkPiece) -> Part:
+def _build_shrinkwrap_part(workpiece: "WorkPiece") -> Part:
     """Build a :class:`Part` for the shrinkwrap assembler.
 
     The shrinkwrap assembler needs both vector geometry (for the

--- a/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/wavefront_step.py
+++ b/rayforge/builtin_addons/rayforge-addon-laser/laser_essentials/steps/wavefront_step.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, cast
 
@@ -63,8 +61,8 @@ class WavefrontStep(LaserStep):
 
     def get_assembler_kwargs(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict:
         spot_x, _spot_y = LaserHead.get_spot_size(
             self.get_selected_laser(machine)
@@ -82,8 +80,8 @@ class WavefrontStep(LaserStep):
 
     def build_compute_payload(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> tuple[Part, ComputePayload]:
         """Build a :class:`Part` with normalised-winding vector
         geometry and a :class:`ComputePayload` carrying an
@@ -109,8 +107,8 @@ class WavefrontStep(LaserStep):
 
     def assembler_token_params(
         self,
-        machine: Machine,
-        workpiece: WorkPiece,
+        machine: "Machine",
+        workpiece: "WorkPiece",
     ) -> dict | None:
         return self.get_assembler_kwargs(machine, workpiece)
 
@@ -122,7 +120,7 @@ class WavefrontStep(LaserStep):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> WavefrontStep:
+    def from_dict(cls, data: dict) -> "WavefrontStep":
         step = cast("WavefrontStep", super().from_dict(data))
         # Projects saved before the raygeo-pipeline refactor stored the
         # producer parameters inside ``opsproducer_dict.params``.  Migrate
@@ -158,10 +156,10 @@ class WavefrontStep(LaserStep):
     @classmethod
     def create(
         cls,
-        context: RayforgeContext,
+        context: "RayforgeContext",
         name: str | None = None,
         **kwargs,
-    ) -> WavefrontStep:
+    ) -> "WavefrontStep":
         machine = context.machine
         assert machine is not None
         default_head = machine.get_default_laser_head()

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/bidir_scan_offset_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/bidir_scan_offset_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -44,8 +42,8 @@ class BidirScanOffsetTransformer(OpsTransformer):
 
     def to_spec(
         self,
-        workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        workpiece: "WorkPiece | None",
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> BidirScanOffsetSpec:
         offset = settings.get("bidir_x_offset_mm", 0.0) if settings else 0.0
@@ -55,5 +53,5 @@ class BidirScanOffsetTransformer(OpsTransformer):
         return {**super().to_dict()}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> BidirScanOffsetTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "BidirScanOffsetTransformer":
         return cls(enabled=data.get("enabled", True))

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/crop_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/crop_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -69,7 +67,7 @@ class CropTransformer(OpsTransformer):
     def to_spec(
         self,
         workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> CropSpec:
         if not stock_geometries or workpiece is None:
@@ -88,7 +86,7 @@ class CropTransformer(OpsTransformer):
     def _resolve_regions(
         self,
         workpiece: WorkPiece,
-        stock_geometries: list[Geometry],
+        stock_geometries: "list[Geometry]",
     ) -> list[list[tuple[float, float]]]:
         world_to_local = workpiece.get_world_transform().invert()
         regions: list[list[tuple[float, float]]] = []
@@ -117,7 +115,7 @@ class CropTransformer(OpsTransformer):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CropTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "CropTransformer":
         return cls(
             enabled=data.get("enabled", True),
             tolerance=data.get("tolerance", 0.03),

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/lead_in_out_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/lead_in_out_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _
@@ -115,8 +113,8 @@ class LeadInOutTransformer(OpsTransformer):
 
     def to_spec(
         self,
-        workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        workpiece: "WorkPiece | None",
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> LeadInOutSpec:
         return LeadInOutSpec(
@@ -132,7 +130,7 @@ class LeadInOutTransformer(OpsTransformer):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> LeadInOutTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "LeadInOutTransformer":
         return cls(
             enabled=data.get("enabled", True),
             lead_in_mm=data.get("lead_in_mm", 2.0),

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/merge_lines_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/merge_lines_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from gettext import gettext as _
 from typing import (
@@ -57,7 +55,7 @@ class MergeLinesTransformer(OpsTransformer):
     def to_spec(
         self,
         workpiece: WorkPiece | None,
-        stock_geometries: Sequence[Geometry] | None,
+        stock_geometries: "Sequence[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> MergeLinesSpec:
         return MergeLinesSpec(tolerance=self._tolerance)
@@ -68,7 +66,7 @@ class MergeLinesTransformer(OpsTransformer):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> MergeLinesTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "MergeLinesTransformer":
         if data.get("name") != cls.__name__:
             raise ValueError(
                 f"Mismatched transformer name: expected {cls.__name__},"

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/multipass_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/multipass_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -84,7 +82,7 @@ class MultiPassTransformer(OpsTransformer):
     def to_spec(
         self,
         workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> MultiPassSpec:
         return MultiPassSpec(passes=self.passes, z_step_down=self.z_step_down)
@@ -98,7 +96,7 @@ class MultiPassTransformer(OpsTransformer):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> MultiPassTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "MultiPassTransformer":
         """Creates a MultiPassTransformer instance from a dictionary."""
         if data.get("name") != cls.__name__:
             raise ValueError(

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/overscan_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/overscan_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _
@@ -102,8 +100,8 @@ class OverscanTransformer(OpsTransformer):
 
     def to_spec(
         self,
-        workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        workpiece: "WorkPiece | None",
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> OverscanSpec:
         if settings and settings.get("driver_native_overscan"):
@@ -118,7 +116,7 @@ class OverscanTransformer(OpsTransformer):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> OverscanTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "OverscanTransformer":
         return cls(
             enabled=data.get("enabled", True),
             distance_mm=data.get("distance_mm", 2.0),

--- a/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/tabs_transformer.py
+++ b/rayforge/builtin_addons/rayforge-addon-post/post_processors/transformers/tabs_transformer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import (
@@ -109,7 +107,7 @@ class TabOpsTransformer(OpsTransformer):
     def to_spec(
         self,
         workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        stock_geometries: "list[Geometry] | None",
         settings: dict | None,
     ) -> TabsSpec:
         tab_power = settings.get("tab_power", 0.0) if settings else 0.0
@@ -145,7 +143,7 @@ class TabOpsTransformer(OpsTransformer):
         )
 
     @classmethod
-    def from_dict(cls, data: dict) -> TabOpsTransformer:
+    def from_dict(cls, data: dict) -> "TabOpsTransformer":
         if data.get("name") != cls.__name__:
             raise ValueError(
                 f"Mismatched transformer name: expected {cls.__name__},"

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/angle_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/angle_constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from dataclasses import dataclass
@@ -29,7 +27,7 @@ class AngleConstraintParams:
 class AngleConstraintCommand:
     @staticmethod
     def calculate_constraint_params(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         e1_id: EntityID,
         e2_id: EntityID,
     ) -> AngleConstraintParams | None:

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/arc.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/arc.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -57,7 +55,7 @@ class ArcPreviewState(PreviewState):
         """Returns True if start point has been set."""
         return self.start_id is not None
 
-    def set_radius(self, registry: EntityRegistry, radius: float) -> None:
+    def set_radius(self, registry: "EntityRegistry", radius: float) -> None:
         """
         Sets the arc radius from numeric input.
 
@@ -85,7 +83,9 @@ class ArcPreviewState(PreviewState):
         end.x = center.x + radius * math.cos(end_angle)
         end.y = center.y + radius * math.sin(end_angle)
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         """
         Returns the arc radius dimension for preview.
 
@@ -135,7 +135,7 @@ class ArcCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         center_id: EntityID,
         start_id: EntityID,
         end_pos: GeoPoint,
@@ -164,7 +164,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def start_center_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -195,7 +195,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def set_start_point(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -235,7 +235,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -277,7 +277,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -335,7 +335,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes preview entities from the registry.
@@ -375,7 +375,7 @@ class ArcCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_center_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes center point preview (when only center is set).

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -51,7 +49,9 @@ class PreviewState:
         """
         return set()
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> "list[DimensionData]":
         """
         Returns dimension data for live preview rendering.
 
@@ -74,7 +74,7 @@ class SketchChangeCommand(Command):
     Includes functionality to snapshot geometry state for precise undo.
     """
 
-    def __init__(self, sketch: Sketch, name: str):
+    def __init__(self, sketch: "Sketch", name: str):
         super().__init__(name)
         self.sketch = sketch
         # Stores ( {point_id: (x, y)}, {entity_id: state_dict} )
@@ -82,7 +82,7 @@ class SketchChangeCommand(Command):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: int | None = None,
@@ -108,7 +108,7 @@ class SketchChangeCommand(Command):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -128,7 +128,7 @@ class SketchChangeCommand(Command):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes all preview entities and points from the registry.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/bezier.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/bezier.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -59,7 +57,7 @@ class BezierPreviewState(PreviewState):
         return result
 
     def get_virtual_cp_absolute(
-        self, registry: EntityRegistry
+        self, registry: "EntityRegistry"
     ) -> GeoPoint | None:
         if self.virtual_cp is None or self.end_id is None:
             return None
@@ -68,7 +66,9 @@ class BezierPreviewState(PreviewState):
             return None
         return (end_pt.x + self.virtual_cp[0], end_pt.y + self.virtual_cp[1])
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         return []
 
 
@@ -82,7 +82,7 @@ class BezierCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         start_id: EntityID,
         end_pos: GeoPoint,
         end_pid: EntityID | None = None,
@@ -111,7 +111,7 @@ class BezierCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: int | None = None,
@@ -179,7 +179,7 @@ class BezierCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -200,7 +200,7 @@ class BezierCommand(SketchChangeCommand):
 
     @staticmethod
     def convert_to_bezier(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: BezierPreviewState,
         waypoint_x: float,
         waypoint_y: float,
@@ -295,7 +295,7 @@ class BezierCommand(SketchChangeCommand):
 
     @staticmethod
     def update_control_point(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: BezierPreviewState,
         x: float,
         y: float,
@@ -323,7 +323,7 @@ class BezierCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         if not isinstance(preview_state, BezierPreviewState):
             raise TypeError("Expected BezierPreviewState")

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/chamfer.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/chamfer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _
@@ -26,7 +24,7 @@ class ChamferCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         corner_pid: EntityID,
         line1_id: EntityID,
         line2_id: EntityID,
@@ -45,7 +43,7 @@ class ChamferCommand(SketchChangeCommand):
 
     @staticmethod
     def calculate_geometry(
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         corner_pid: EntityID,
         line1_id: EntityID,
         line2_id: EntityID,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/circle.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/circle.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -42,7 +40,9 @@ class CirclePreviewState(PreviewState):
         """
         return {self.radius_id}
 
-    def set_diameter(self, registry: EntityRegistry, diameter: float) -> None:
+    def set_diameter(
+        self, registry: "EntityRegistry", diameter: float
+    ) -> None:
         """
         Sets the circle diameter from numeric input.
 
@@ -71,7 +71,9 @@ class CirclePreviewState(PreviewState):
         radius_pt.x = center.x + dx * scale
         radius_pt.y = center.y + dy * scale
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         """
         Returns the circle diameter dimension for preview.
 
@@ -107,7 +109,7 @@ class CircleCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         center_id: EntityID,
         end_pos: GeoPoint,
         end_pid: EntityID | None = None,
@@ -132,7 +134,7 @@ class CircleCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -168,7 +170,7 @@ class CircleCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -199,7 +201,7 @@ class CircleCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes preview entities from the registry.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -20,8 +18,8 @@ class ModifyConstraintCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
-        constraint: Constraint,
+        sketch: "Sketch",
+        constraint: "Constraint",
         new_value: float,
         new_expression: str | None = None,
         name: str = _("Edit Constraint"),

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint_create.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint_create.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -28,7 +26,7 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         entity: Entity,
         name: str = _("Add Constraint"),
     ):
@@ -40,9 +38,9 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
 
     @staticmethod
     def get_constraint_for_entity(
-        sketch: Sketch,
+        sketch: "Sketch",
         entity: Entity,
-    ) -> Constraint | None:
+    ) -> "Constraint | None":
         """
         Returns existing constraint for entity, or None.
 
@@ -84,10 +82,10 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
 
     @staticmethod
     def create_constraint_for_entity(
-        sketch: Sketch,
+        sketch: "Sketch",
         entity: Entity,
         initial_value: float | None = None,
-    ) -> Constraint | None:
+    ) -> "Constraint | None":
         """
         Creates and returns a new constraint for the entity.
 
@@ -134,7 +132,7 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
         return None
 
     @property
-    def constraint(self) -> Constraint | None:
+    def constraint(self) -> "Constraint | None":
         """
         Returns the constraint involved in this operation.
 
@@ -184,5 +182,5 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
         if self._add_cmd is not None:
             self._add_cmd._do_undo()
 
-    def _get_command_label(self, constraint: Constraint) -> str:
+    def _get_command_label(self, constraint: "Constraint") -> str:
         return _("Add {}").format(constraint.get_type_name())

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/construction.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/construction.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING
 
@@ -14,7 +12,7 @@ logger = logging.getLogger(__name__)
 class ToggleConstructionCommand(SketchChangeCommand):
     """Command to toggle the construction state of multiple entities."""
 
-    def __init__(self, sketch: Sketch, name: str, entity_ids: list[int]):
+    def __init__(self, sketch: "Sketch", name: str, entity_ids: list[int]):
         super().__init__(sketch, name)
         self.entity_ids = entity_ids
         self.original_states: dict[int, bool] = {}

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/dimension.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/dimension.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from raygeo.geo.types import Point

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/distance_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/distance_constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -22,7 +20,7 @@ class DistanceConstraintParams:
 class DistanceConstraintCommand:
     @staticmethod
     def calculate_distance(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         point_ids: list[EntityID],
         entity_ids: list[EntityID],
     ) -> DistanceConstraintParams | None:
@@ -55,7 +53,7 @@ class DistanceConstraintCommand:
 
     @staticmethod
     def calculate_distance_from_points(
-        p1: Point,
-        p2: Point,
+        p1: "Point",
+        p2: "Point",
     ) -> float:
         return math.hypot(p1.x - p2.x, p1.y - p2.y)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/ellipse.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/ellipse.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
@@ -51,7 +49,7 @@ class EllipseCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         start_id: EntityID,
         end_pos: GeoPoint,
         end_pid: EntityID | None = None,
@@ -106,7 +104,7 @@ class EllipseCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -135,7 +133,7 @@ class EllipseCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -166,7 +164,7 @@ class EllipseCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         if not isinstance(preview_state, EllipsePreviewState):
             raise TypeError("Expected EllipsePreviewState")

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/equal_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/equal_constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -13,13 +11,13 @@ if TYPE_CHECKING:
 @dataclass
 class EqualConstraintMergeResult:
     final_entity_ids: list[int]
-    constraints_to_remove: list[Constraint]
+    constraints_to_remove: "list[Constraint]"
 
 
 class EqualConstraintCommand:
     @staticmethod
     def find_and_merge_constraints(
-        sketch: Sketch,
+        sketch: "Sketch",
         selected_entity_ids: list[int],
     ) -> EqualConstraintMergeResult | None:
         selected_ids = set(selected_entity_ids)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/fill.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/fill.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import uuid
 from gettext import gettext as _
@@ -23,7 +21,7 @@ class AddFillCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         boundary: list[tuple[int, bool]],
         style: FillStyle = FillStyle.SOLID,
         color: ColorRGBA = DEFAULT_FILL_COLOR,
@@ -61,7 +59,7 @@ class RemoveFillCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         fill: Fill,
         name: str = _("Remove Fill"),
     ):
@@ -81,7 +79,7 @@ class SetTextFillCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         entity_id: int,
         fill_color: ColorRGBA | None,
         name: str = _("Set Text Fill"),

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/fillet.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/fillet.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _
@@ -27,7 +25,7 @@ class FilletCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         corner_pid: EntityID,
         line1_id: EntityID,
         line2_id: EntityID,
@@ -46,7 +44,7 @@ class FilletCommand(SketchChangeCommand):
 
     @staticmethod
     def calculate_geometry(
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         corner_pid: EntityID,
         line1_id: EntityID,
         line2_id: EntityID,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/grid.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/grid.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +15,7 @@ class GridCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         rows: int,
         cols: int,
         origin: tuple[float, float] = (0, 0),

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/items.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/items.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -20,11 +18,11 @@ class AddItemsCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         name: str,
-        points: Sequence[Point] | None = None,
-        entities: Sequence[Entity] | None = None,
-        constraints: Sequence[Constraint] | None = None,
+        points: "Sequence[Point] | None" = None,
+        entities: "Sequence[Entity] | None" = None,
+        constraints: "Sequence[Constraint] | None" = None,
     ):
         super().__init__(sketch, name)
         self.points = list(points) if points else []
@@ -102,11 +100,11 @@ class RemoveItemsCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         name: str,
-        points: list[Point] | None = None,
-        entities: Sequence[Entity] | None = None,
-        constraints: list[Constraint] | None = None,
+        points: "list[Point] | None" = None,
+        entities: "Sequence[Entity] | None" = None,
+        constraints: "list[Constraint] | None" = None,
     ):
         super().__init__(sketch, name)
         self.points = points or []
@@ -115,8 +113,8 @@ class RemoveItemsCommand(SketchChangeCommand):
 
     @staticmethod
     def calculate_dependencies(
-        sketch: Sketch, selection
-    ) -> tuple[list[Point], list[Entity], list[Constraint]]:
+        sketch: "Sketch", selection
+    ) -> "tuple[list[Point], list[Entity], list[Constraint]]":
         """
         Calculates the full set of items to be deleted based on the current
         selection, including dependent items.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/line.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/line.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -42,7 +40,7 @@ class LinePreviewState(PreviewState):
         """
         return {self.end_id}
 
-    def set_length(self, registry: EntityRegistry, length: float) -> None:
+    def set_length(self, registry: "EntityRegistry", length: float) -> None:
         """
         Sets the line length from numeric input.
 
@@ -70,7 +68,9 @@ class LinePreviewState(PreviewState):
         end_p.x = start_p.x + dx * scale
         end_p.y = start_p.y + dy * scale
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         """
         Returns the line length dimension for preview.
 
@@ -101,7 +101,7 @@ class LineCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         start_id: EntityID,
         end_pos: GeoPoint,
         end_pid: EntityID | None = None,
@@ -126,7 +126,7 @@ class LineCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -162,7 +162,7 @@ class LineCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -193,7 +193,7 @@ class LineCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes preview entities from the registry.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/live_text_edit.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/live_text_edit.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import time
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
 class LiveTextEditCommand(Command):
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         text_entity_id: EntityID,
     ):
         super().__init__(_("Edit Text"))

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/point.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/point.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -24,14 +22,14 @@ class MovePointCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         point_id: EntityID,
         start_pos: GeoPoint,
         end_pos: GeoPoint,
         # snapshot is: (points_dict, entities_dict)
         snapshot: tuple[dict[EntityID, GeoPoint], dict[EntityID, Any]]
         | None = None,
-        snap_constraints: list[Constraint] | None = None,
+        snap_constraints: "list[Constraint] | None" = None,
     ):
         super().__init__(sketch, _("Move Point"))
         self.point_id = point_id
@@ -82,13 +80,13 @@ class MovePointCommand(SketchChangeCommand):
                 self.sketch.constraints.remove(constraint)
         self._created_constraints.clear()
 
-    def can_coalesce_with(self, next_command: Command) -> bool:
+    def can_coalesce_with(self, next_command: "Command") -> bool:
         return (
             isinstance(next_command, MovePointCommand)
             and self.point_id == next_command.point_id
         )
 
-    def coalesce_with(self, next_command: Command) -> bool:
+    def coalesce_with(self, next_command: "Command") -> bool:
         if not self.can_coalesce_with(next_command):
             return False
 
@@ -105,7 +103,7 @@ class MoveControlPointCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         bezier_id: EntityID,
         cp_index: int,
         start_offset: GeoPoint | None,
@@ -144,7 +142,7 @@ class MoveControlPointCommand(SketchChangeCommand):
 class UnstickJunctionCommand(SketchChangeCommand):
     """Command to separate entities at a shared point."""
 
-    def __init__(self, sketch: Sketch, junction_pid: EntityID):
+    def __init__(self, sketch: "Sketch", junction_pid: EntityID):
         super().__init__(sketch, _("Unstick Junction"))
         self.junction_pid = junction_pid
         self.new_point: Point | None = None

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/rectangle.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/rectangle.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -53,7 +51,7 @@ class RectanglePreviewState(PreviewState):
 
     def set_dimensions(
         self,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         width: float | None = None,
         height: float | None = None,
     ) -> None:
@@ -99,7 +97,9 @@ class RectanglePreviewState(PreviewState):
             preview_ids=self.preview_ids,
         )
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         """
         Returns width and height dimensions for preview.
 
@@ -136,7 +136,7 @@ class RectangleCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         start_pid: EntityID,
         end_pos: GeoPoint,
         end_pid: EntityID | None = None,
@@ -241,7 +241,7 @@ class RectangleCommand(SketchChangeCommand):
 
     @staticmethod
     def create_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         start_pid: EntityID,
         end_pid: EntityID,
         preview_ids: dict[str, EntityID] | None = None,
@@ -298,7 +298,7 @@ class RectangleCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -339,7 +339,7 @@ class RectangleCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -397,7 +397,7 @@ class RectangleCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes all preview entities and points from the registry.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/rounded_rect.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/rounded_rect.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -60,7 +58,7 @@ class RoundedRectPreviewState(PreviewState):
 
     def set_dimensions(
         self,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         width: float | None = None,
         height: float | None = None,
         radius: float | None = None,
@@ -112,7 +110,9 @@ class RoundedRectPreviewState(PreviewState):
             preview_ids=self.preview_ids,
         )
 
-    def get_dimensions(self, registry: EntityRegistry) -> list[DimensionData]:
+    def get_dimensions(
+        self, registry: "EntityRegistry"
+    ) -> list[DimensionData]:
         """
         Returns width, height and radius dimensions for preview.
 
@@ -165,7 +165,7 @@ class RoundedRectCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         start_pid: EntityID,
         end_pos: GeoPoint,
         radius: float,
@@ -347,7 +347,7 @@ class RoundedRectCommand(SketchChangeCommand):
 
     @staticmethod
     def create_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         start_pid: EntityID,
         end_pid: EntityID,
         radius: float,
@@ -462,7 +462,7 @@ class RoundedRectCommand(SketchChangeCommand):
 
     @staticmethod
     def start_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         x: float,
         y: float,
         snapped_pid: EntityID | None = None,
@@ -506,7 +506,7 @@ class RoundedRectCommand(SketchChangeCommand):
 
     @staticmethod
     def update_preview(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         preview_state: PreviewState,
         x: float,
         y: float,
@@ -565,7 +565,7 @@ class RoundedRectCommand(SketchChangeCommand):
 
     @staticmethod
     def cleanup_preview(
-        registry: EntityRegistry, preview_state: PreviewState
+        registry: "EntityRegistry", preview_state: PreviewState
     ) -> None:
         """
         Removes all preview entities and points from the registry.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/straighten.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/straighten.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
@@ -18,7 +16,7 @@ class StraightenBezierCommand(SketchChangeCommand):
     Removes control points and replaces the Bezier entity with a Line entity.
     """
 
-    def __init__(self, sketch: Sketch, bezier_id: EntityID):
+    def __init__(self, sketch: "Sketch", bezier_id: EntityID):
         label = _("Straighten")
         super().__init__(sketch, label)
         self.bezier_id = bezier_id

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/symmetry_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/symmetry_constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from ..types import EntityID

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/tangent_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/tangent_constraint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -19,7 +17,7 @@ class TangentConstraintParams:
 class TangentConstraintCommand:
     @staticmethod
     def identify_entities(
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         entity_ids: list[EntityID],
     ) -> TangentConstraintParams | None:
         sel_line: Line | None = None

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/text_box.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/text_box.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -24,7 +22,7 @@ class TextBoxCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         origin: GeoPoint,
         width: float = 10.0,
         height: float = 10.0,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/text_property.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/text_property.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -25,7 +23,7 @@ if TYPE_CHECKING:
 class ModifyTextPropertyCommand(SketchChangeCommand):
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         text_entity_id: EntityID,
         new_content: str,
         new_font_config: FontConfig,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/waypoint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/waypoint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _
@@ -37,7 +35,7 @@ class SetWaypointTypeCommand(SketchChangeCommand):
 
     def __init__(
         self,
-        sketch: Sketch,
+        sketch: "Sketch",
         waypoint_id: EntityID,
         new_type: WaypointType,
     ):
@@ -53,7 +51,7 @@ class SetWaypointTypeCommand(SketchChangeCommand):
         self._added_bezier_ids: list[int] | None = None
 
     def _get_segment_directions(
-        self, registry: EntityRegistry, waypoint: Point
+        self, registry: "EntityRegistry", waypoint: "Point"
     ) -> tuple[GeoPoint | None, GeoPoint | None]:
         """
         Get the incoming and outgoing direction vectors at this waypoint.
@@ -127,7 +125,7 @@ class SetWaypointTypeCommand(SketchChangeCommand):
         return incoming_dir, outgoing_dir
 
     def _find_connected_lines(
-        self, registry: EntityRegistry, waypoint_id: EntityID
+        self, registry: "EntityRegistry", waypoint_id: EntityID
     ) -> list[tuple[EntityID, EntityID, EntityID]]:
         """Find Line entities connected to this waypoint.
 
@@ -146,7 +144,7 @@ class SetWaypointTypeCommand(SketchChangeCommand):
 
     def _convert_lines_to_beziers(
         self,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         lines: list[tuple[EntityID, EntityID, EntityID]],
     ) -> list[EntityID]:
         """Remove Line entities and add Bezier entities in their place."""
@@ -162,7 +160,7 @@ class SetWaypointTypeCommand(SketchChangeCommand):
 
     def _restore_lines(
         self,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         lines: list[tuple[EntityID, EntityID, EntityID]],
         bezier_ids: list[EntityID],
     ):

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/angle.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/angle.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from collections.abc import Callable
@@ -80,7 +78,7 @@ class AngleConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 2:
             return False
@@ -98,7 +96,7 @@ class AngleConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return f"{self.get_type_name()} {self._format_value()}°"
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained entities."""
         e1 = registry.get_entity(self.e1_id)
         e2 = registry.get_entity(self.e2_id)
@@ -121,7 +119,7 @@ class AngleConstraint(Constraint):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> AngleConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "AngleConstraint":
         return cls(
             e1_id=data["e1_id"],
             e2_id=data["e2_id"],
@@ -133,7 +131,7 @@ class AngleConstraint(Constraint):
         )
 
     def _get_line_params(
-        self, reg: EntityRegistry
+        self, reg: "EntityRegistry"
     ) -> tuple[Line, Line, Any, Any, Any, Any] | None:
         e1 = reg.get_entity(self.e1_id)
         e2 = reg.get_entity(self.e2_id)
@@ -169,7 +167,9 @@ class AngleConstraint(Constraint):
 
         return far1, far2
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         result = self._get_line_params(reg)
         if result is None:
             logger.warning("_get_line_params returned None")
@@ -219,7 +219,7 @@ class AngleConstraint(Constraint):
         return diff * ANGLE_WEIGHT
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         result = self._get_line_params(reg)
         if result is None:
@@ -324,7 +324,7 @@ class AngleConstraint(Constraint):
 
     def get_visuals(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
     ):
         result = self._get_line_params(reg)
@@ -359,7 +359,7 @@ class AngleConstraint(Constraint):
 
     def get_label_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
     ):
@@ -382,7 +382,7 @@ class AngleConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -407,8 +407,8 @@ class AngleConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/aspect_ratio.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/aspect_ratio.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -44,7 +42,7 @@ class AspectRatioConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 2:
             return False
@@ -63,7 +61,7 @@ class AspectRatioConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return f"{self.get_type_name()} {self.ratio:.2f}"
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained segments."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -86,7 +84,7 @@ class AspectRatioConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> AspectRatioConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "AspectRatioConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
@@ -96,7 +94,9 @@ class AspectRatioConstraint(Constraint):
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
         dist1 = math.hypot(pt2.x - pt1.x, pt2.y - pt1.y)
@@ -110,7 +110,7 @@ class AspectRatioConstraint(Constraint):
         return dist1 - dist2 * self.ratio
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
@@ -147,7 +147,7 @@ class AspectRatioConstraint(Constraint):
 
     def _get_icon_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
     ) -> Point | None:
         """Calculates the screen position of the constraint icon."""
@@ -212,7 +212,7 @@ class AspectRatioConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -226,7 +226,7 @@ class AspectRatioConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from enum import Enum, auto
 from locale import format_string
@@ -46,7 +44,7 @@ class Constraint:
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         """
         Returns True if this constraint can be applied to the current
@@ -78,13 +76,13 @@ class Constraint:
         return False
 
     def error(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> float | tuple[float, ...] | list[float]:
         """Calculates the error of the constraint."""
         return 0.0
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         """
         Calculates the partial derivatives (Jacobian entries) of the error.
@@ -95,7 +93,7 @@ class Constraint:
         return {}
 
     def constrains_radius(
-        self, registry: EntityRegistry, entity_id: EntityID
+        self, registry: "EntityRegistry", entity_id: EntityID
     ) -> bool:
         """
         Returns True if this constraint explicitly defines or links the
@@ -113,7 +111,7 @@ class Constraint:
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -121,7 +119,7 @@ class Constraint:
         """Checks if the constraint's visual representation is hit."""
         return False
 
-    def _set_color(self, ctx: cairo.Context, is_hovered: bool) -> None:
+    def _set_color(self, ctx: "cairo.Context", is_hovered: bool) -> None:
         """
         Sets the standard drawing color for constraints based on hover and
         status.
@@ -138,7 +136,7 @@ class Constraint:
             ctx.set_source_rgb(0.0, 0.6, 0.0)  # Green for valid
 
     def _draw_selection_underlay(
-        self, ctx: cairo.Context, width_scale: float = 3.0
+        self, ctx: "cairo.Context", width_scale: float = 3.0
     ) -> None:
         """Draws a semi-transparent blue underlay for the current path."""
         ctx.save()
@@ -148,7 +146,7 @@ class Constraint:
         ctx.restore()
 
     def _draw_conflict_underlay(
-        self, ctx: cairo.Context, width_scale: float = 3.5
+        self, ctx: "cairo.Context", width_scale: float = 3.5
     ) -> None:
         """Draws a semi-transparent red underlay for conflicting items."""
         ctx.save()
@@ -168,7 +166,7 @@ class Constraint:
         """
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """
         Returns a human-readable subtitle describing the constrained entities.
         Subclasses should override to provide meaningful descriptions.
@@ -181,8 +179,8 @@ class Constraint:
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/coincident.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/coincident.py
@@ -1,6 +1,5 @@
 # constraints/coincident.py
 
-from __future__ import annotations
 
 import math
 from collections.abc import Callable
@@ -35,7 +34,7 @@ class CoincidentConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         return len(selection.point_ids) == 2 and not selection.entity_ids
 
@@ -48,7 +47,7 @@ class CoincidentConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained points."""
         p1 = registry.get_point(self.p1)
         if p1:
@@ -64,20 +63,22 @@ class CoincidentConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CoincidentConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "CoincidentConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> Point:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> Point:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
         return (pt1.x - pt2.x, pt1.y - pt2.y)
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         return {
             self.p1: [(1.0, 0.0), (0.0, 1.0)],
@@ -88,7 +89,7 @@ class CoincidentConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -106,8 +107,8 @@ class CoincidentConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/collinear.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/collinear.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -32,7 +30,7 @@ class CollinearConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         return len(selection.point_ids) == 3 and not selection.entity_ids
 
@@ -45,7 +43,7 @@ class CollinearConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained points."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -68,7 +66,7 @@ class CollinearConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CollinearConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "CollinearConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
@@ -76,7 +74,9 @@ class CollinearConstraint(Constraint):
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
         pt3 = reg.get_point(self.p3)
@@ -86,7 +86,7 @@ class CollinearConstraint(Constraint):
         )
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         p1 = reg.get_point(self.p1)
         p2 = reg.get_point(self.p2)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/diameter.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/diameter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -50,7 +48,7 @@ class DiameterConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 1:
             return False
@@ -68,7 +66,7 @@ class DiameterConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return f"{self.get_type_name()} {self._format_value()}"
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained entity."""
         entity = registry.get_entity(self.circle_id)
         if isinstance(entity, Circle):
@@ -96,7 +94,7 @@ class DiameterConstraint(Constraint):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> DiameterConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "DiameterConstraint":
         return cls(
             circle_id=data["circle_id"],
             value=data["value"],
@@ -105,11 +103,13 @@ class DiameterConstraint(Constraint):
         )
 
     def constrains_radius(
-        self, registry: EntityRegistry, entity_id: EntityID
+        self, registry: "EntityRegistry", entity_id: EntityID
     ) -> bool:
         return self.circle_id == entity_id
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         circle_entity = reg.get_entity(self.circle_id)
 
         if not isinstance(circle_entity, Circle):
@@ -123,7 +123,7 @@ class DiameterConstraint(Constraint):
         return 2 * curr_r - target_diameter
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         entity = reg.get_entity(self.circle_id)
         if isinstance(entity, Circle):
@@ -145,7 +145,7 @@ class DiameterConstraint(Constraint):
 
     def get_label_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
     ):
@@ -157,7 +157,7 @@ class DiameterConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -185,8 +185,8 @@ class DiameterConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/distance.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/distance.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -55,7 +53,7 @@ class DistanceConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if len(selection.point_ids) == 2 and not selection.entity_ids:
             return True
@@ -81,7 +79,7 @@ class DistanceConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return f"{self.get_type_name()} {self._format_value()}"
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a subtitle describing the constrained points."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -110,7 +108,7 @@ class DistanceConstraint(Constraint):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> DistanceConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "DistanceConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
@@ -119,7 +117,9 @@ class DistanceConstraint(Constraint):
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
         # We use self.value which is cached/updated via update_from_context
@@ -128,7 +128,7 @@ class DistanceConstraint(Constraint):
         return dist - target
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
@@ -148,7 +148,7 @@ class DistanceConstraint(Constraint):
 
     def get_label_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
     ):
@@ -169,7 +169,7 @@ class DistanceConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -219,8 +219,8 @@ class DistanceConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/drag.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/drag.py
@@ -1,6 +1,5 @@
 # constraints/drag.py
 
-from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
@@ -38,18 +37,20 @@ class DragConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         return False
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> Point:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> Point:
         p = reg.get_point(self.point_id)
         err_x = (p.x - self.target_x) * self.weight
         err_y = (p.y - self.target_y) * self.weight
         return err_x, err_y
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         return {
             self.point_id: [(self.weight, 0.0), (0.0, self.weight)],

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/equal_distance.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/equal_distance.py
@@ -1,6 +1,5 @@
 # constraints/equal_distance.py
 
-from __future__ import annotations
 
 import math
 from collections.abc import Callable
@@ -41,7 +40,7 @@ class EqualDistanceConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) < 2:
             return False
@@ -62,7 +61,7 @@ class EqualDistanceConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained segments."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -94,7 +93,7 @@ class EqualDistanceConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> EqualDistanceConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "EqualDistanceConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
@@ -103,7 +102,9 @@ class EqualDistanceConstraint(Constraint):
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
         dist1 = math.hypot(pt2.x - pt1.x, pt2.y - pt1.y)
@@ -115,7 +116,7 @@ class EqualDistanceConstraint(Constraint):
         return dist1 - dist2
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
@@ -153,7 +154,7 @@ class EqualDistanceConstraint(Constraint):
 
     def _get_symbol_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
     ):
         """Calculates screen position for the equality symbol."""
@@ -192,7 +193,7 @@ class EqualDistanceConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -204,8 +205,8 @@ class EqualDistanceConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/equal_length.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/equal_length.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -42,7 +40,7 @@ class EqualLengthConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) < 2:
             return False
@@ -65,7 +63,7 @@ class EqualLengthConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained entities."""
         if len(self.entity_ids) >= 2:
             return _("{} entities").format(len(self.entity_ids))
@@ -86,14 +84,14 @@ class EqualLengthConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> EqualLengthConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "EqualLengthConstraint":
         return cls(
             entity_ids=data["entity_ids"],
             user_visible=data.get("user_visible", True),
         )
 
     def constrains_radius(
-        self, registry: EntityRegistry, entity_id: EntityID
+        self, registry: "EntityRegistry", entity_id: EntityID
     ) -> bool:
         return entity_id in self.entity_ids
 
@@ -119,7 +117,7 @@ class EqualLengthConstraint(Constraint):
         pb = reg.get_point(pb_idx)
         return math.hypot(pb.x - pa.x, pb.y - pa.y)
 
-    def _get_length(self, entity, reg: EntityRegistry) -> float:
+    def _get_length(self, entity, reg: "EntityRegistry") -> float:
         if isinstance(entity, Line):
             p1 = reg.get_point(entity.p1_idx)
             p2 = reg.get_point(entity.p2_idx)
@@ -138,7 +136,7 @@ class EqualLengthConstraint(Constraint):
         return 0.0
 
     def error(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> list[float]:
         if len(self.entity_ids) < 2:
             return []
@@ -165,7 +163,7 @@ class EqualLengthConstraint(Constraint):
         return errors
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         if len(self.entity_ids) < 2:
             return {}
@@ -235,7 +233,7 @@ class EqualLengthConstraint(Constraint):
     def _get_symbol_pos(
         self,
         entity,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
     ):
         """Calculates screen pos for an equality symbol on an entity."""
@@ -273,7 +271,7 @@ class EqualLengthConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -291,8 +289,8 @@ class EqualLengthConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/horizontal.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/horizontal.py
@@ -1,6 +1,5 @@
 # constraints/horizontal.py
 
-from __future__ import annotations
 
 import math
 from collections.abc import Callable
@@ -36,7 +35,7 @@ class HorizontalConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if len(selection.point_ids) == 2 and not selection.entity_ids:
             return True
@@ -61,7 +60,7 @@ class HorizontalConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a subtitle describing the constrained points."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -81,18 +80,20 @@ class HorizontalConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> HorizontalConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "HorizontalConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         return reg.get_point(self.p1).y - reg.get_point(self.p2).y
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         return {
             self.p1: [(0.0, 1.0)],
@@ -103,7 +104,7 @@ class HorizontalConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -124,8 +125,8 @@ class HorizontalConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/parallelogram.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/parallelogram.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -34,7 +32,7 @@ class ParallelogramConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         return len(selection.point_ids) == 4 and not selection.entity_ids
 
@@ -47,7 +45,7 @@ class ParallelogramConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained points."""
         p_origin = registry.get_point(self.p_origin)
         if p_origin:
@@ -67,7 +65,7 @@ class ParallelogramConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ParallelogramConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "ParallelogramConstraint":
         return cls(
             p_origin=data["p_origin"],
             p_width=data["p_width"],
@@ -76,7 +74,9 @@ class ParallelogramConstraint(Constraint):
             user_visible=data.get("user_visible", False),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> Point:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> Point:
         """Returns the difference between vectors (p_width-p_origin) and
         (p4-p_height).
         """
@@ -94,7 +94,7 @@ class ParallelogramConstraint(Constraint):
         return (v1_x - v2_x, v1_y - v2_y)
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         """Returns the gradient of the error with respect to each point."""
         return {

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/perpendicular.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/perpendicular.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -52,7 +50,7 @@ class PerpendicularConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 2:
             return False
@@ -73,7 +71,7 @@ class PerpendicularConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained entities."""
         e1 = registry.get_entity(self.e1_id)
         e2 = registry.get_entity(self.e2_id)
@@ -92,7 +90,7 @@ class PerpendicularConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> PerpendicularConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "PerpendicularConstraint":
         return cls(
             e1_id=data["e1_id"],
             e2_id=data["e2_id"],
@@ -100,7 +98,7 @@ class PerpendicularConstraint(Constraint):
         )
 
     def _get_radius_sq(
-        self, shape: Arc | Circle, reg: EntityRegistry
+        self, shape: Arc | Circle, reg: "EntityRegistry"
     ) -> float:
         """Helper to get squared radius of an Arc or Circle."""
         center = reg.get_point(shape.center_idx)
@@ -114,7 +112,9 @@ class PerpendicularConstraint(Constraint):
             ) ** 2
         return 0.0
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         e1 = reg.get_entity(self.e1_id)
         e2 = reg.get_entity(self.e2_id)
 
@@ -175,7 +175,7 @@ class PerpendicularConstraint(Constraint):
         return 0.0
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         e1 = reg.get_entity(self.e1_id)
         e2 = reg.get_entity(self.e2_id)
@@ -273,7 +273,7 @@ class PerpendicularConstraint(Constraint):
 
     def get_visuals(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
     ) -> tuple[float, float, float | None, float | None] | None:
         """Calculates screen position and angles for visualization."""
@@ -448,7 +448,7 @@ class PerpendicularConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -485,8 +485,8 @@ class PerpendicularConstraint(Constraint):
 
     def draw(
         self,
-        ctx: cairo.Context,
-        registry: EntityRegistry,
+        ctx: "cairo.Context",
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/point_on_line.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/point_on_line.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -35,7 +33,7 @@ class PointOnLineConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if len(selection.point_ids) != 1 or len(selection.entity_ids) != 1:
             return False
@@ -70,7 +68,7 @@ class PointOnLineConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained entities."""
         pt = registry.get_point(self.point_id)
         if pt:
@@ -86,7 +84,7 @@ class PointOnLineConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> PointOnLineConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "PointOnLineConstraint":
         return cls(
             point_id=data["point_id"],
             shape_id=data["shape_id"],
@@ -94,7 +92,7 @@ class PointOnLineConstraint(Constraint):
         )
 
     def constrains_radius(
-        self, registry: EntityRegistry, entity_id: EntityID
+        self, registry: "EntityRegistry", entity_id: EntityID
     ) -> bool:
         """
         If this constraint forces a point onto the target entity (circle/arc),
@@ -110,7 +108,9 @@ class PointOnLineConstraint(Constraint):
         except IndexError:
             return False
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         pt = reg.get_point(self.point_id)
         shape = reg.get_entity(self.shape_id)
 
@@ -150,7 +150,7 @@ class PointOnLineConstraint(Constraint):
         return 0.0
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         pt = reg.get_point(self.point_id)
         shape = reg.get_entity(self.shape_id)
@@ -244,7 +244,7 @@ class PointOnLineConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -258,7 +258,7 @@ class PointOnLineConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/radius.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/radius.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -48,7 +46,7 @@ class RadiusConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 1:
             return False
@@ -66,7 +64,7 @@ class RadiusConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return f"{self.get_type_name()} {self._format_value()}"
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained entity."""
         entity = registry.get_entity(self.entity_id)
         if isinstance(entity, (Arc, Circle)):
@@ -95,7 +93,7 @@ class RadiusConstraint(Constraint):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RadiusConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "RadiusConstraint":
         return cls(
             entity_id=data["entity_id"],
             value=data["value"],
@@ -104,11 +102,13 @@ class RadiusConstraint(Constraint):
         )
 
     def constrains_radius(
-        self, registry: EntityRegistry, entity_id: EntityID
+        self, registry: "EntityRegistry", entity_id: EntityID
     ) -> bool:
         return self.entity_id == entity_id
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         entity = reg.get_entity(self.entity_id)
         if entity is None:
             return 0.0
@@ -130,7 +130,7 @@ class RadiusConstraint(Constraint):
         return curr_r - target
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         entity = reg.get_entity(self.entity_id)
 
@@ -165,7 +165,7 @@ class RadiusConstraint(Constraint):
 
     def get_label_pos(
         self,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
     ):
@@ -233,7 +233,7 @@ class RadiusConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -262,7 +262,7 @@ class RadiusConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/symmetry.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/symmetry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -80,7 +78,7 @@ class SymmetryConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if len(selection.point_ids) == 3 and not selection.entity_ids:
             return True
@@ -100,7 +98,7 @@ class SymmetryConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a human-readable subtitle describing constrained points."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -122,7 +120,7 @@ class SymmetryConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SymmetryConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "SymmetryConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
@@ -132,7 +130,7 @@ class SymmetryConstraint(Constraint):
         )
 
     def error(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> list[float]:
         pt1 = reg.get_point(self.p1)
         pt2 = reg.get_point(self.p2)
@@ -177,7 +175,7 @@ class SymmetryConstraint(Constraint):
         return [0.0, 0.0]
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         if self.center is not None:
             # P1+P2 - 2C = 0. Safe to use dict literal as keys are distinct.
@@ -232,7 +230,7 @@ class SymmetryConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -258,7 +256,7 @@ class SymmetryConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/tangent.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/tangent.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -39,7 +37,7 @@ class TangentConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if selection.point_ids or len(selection.entity_ids) != 2:
             return False
@@ -62,7 +60,7 @@ class TangentConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns subtitle describing constrained entities."""
         line = registry.get_entity(self.line_id)
         shape = registry.get_entity(self.shape_id)
@@ -84,14 +82,16 @@ class TangentConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> TangentConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "TangentConstraint":
         return cls(
             line_id=data["line_id"],
             shape_id=data["shape_id"],
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         line = reg.get_entity(self.line_id)
         shape = reg.get_entity(self.shape_id)
 
@@ -124,7 +124,7 @@ class TangentConstraint(Constraint):
         return dist_val - radius
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         line = reg.get_entity(self.line_id)
         shape = reg.get_entity(self.shape_id)
@@ -216,7 +216,7 @@ class TangentConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -261,7 +261,7 @@ class TangentConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/vertical.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/vertical.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
 from gettext import gettext as _
@@ -33,7 +31,7 @@ class VerticalConstraint(Constraint):
 
     @classmethod
     def can_apply_to(
-        cls, selection: SketchSelection, sketch: Sketch | None = None
+        cls, selection: "SketchSelection", sketch: "Sketch | None" = None
     ) -> bool:
         if len(selection.point_ids) == 2 and not selection.entity_ids:
             return True
@@ -58,7 +56,7 @@ class VerticalConstraint(Constraint):
         """Returns a human-readable title for this constraint."""
         return self.get_type_name()
 
-    def get_subtitle(self, registry: EntityRegistry) -> str:
+    def get_subtitle(self, registry: "EntityRegistry") -> str:
         """Returns a subtitle describing the constrained points."""
         p1 = registry.get_point(self.p1)
         p2 = registry.get_point(self.p2)
@@ -78,18 +76,20 @@ class VerticalConstraint(Constraint):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> VerticalConstraint:
+    def from_dict(cls, data: dict[str, Any]) -> "VerticalConstraint":
         return cls(
             p1=data["p1"],
             p2=data["p2"],
             user_visible=data.get("user_visible", True),
         )
 
-    def error(self, reg: EntityRegistry, params: ParameterContext) -> float:
+    def error(
+        self, reg: "EntityRegistry", params: "ParameterContext"
+    ) -> float:
         return reg.get_point(self.p1).x - reg.get_point(self.p2).x
 
     def gradient(
-        self, reg: EntityRegistry, params: ParameterContext
+        self, reg: "EntityRegistry", params: "ParameterContext"
     ) -> dict[EntityID, list[Point]]:
         return {
             self.p1: [(1.0, 0.0)],
@@ -100,7 +100,7 @@ class VerticalConstraint(Constraint):
         self,
         sx: float,
         sy: float,
-        reg: EntityRegistry,
+        reg: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         element: Any,
         threshold: float,
@@ -122,7 +122,7 @@ class VerticalConstraint(Constraint):
     def draw(
         self,
         ctx: cairo.Context,
-        registry: EntityRegistry,
+        registry: "EntityRegistry",
         to_screen: Callable[[Point], Point],
         is_selected: bool = False,
         is_hovered: bool = False,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/image/exporter.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/image/exporter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from gettext import gettext as _
 from typing import TYPE_CHECKING, cast
@@ -22,7 +20,7 @@ class SketchExporter(Exporter):
     extensions = (".rfs",)
     mime_types = (const.MIME_TYPE_SKETCH,)
 
-    def __init__(self, doc_item: WorkPiece):
+    def __init__(self, doc_item: "WorkPiece"):
         """
         Initializes the exporter for a specific sketch-based WorkPiece.
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/image/importer.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/image/importer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import Iterator
@@ -172,7 +170,7 @@ class SketchImporter(Importer):
         )
 
     def vectorize(
-        self, parse_result: ParsingResult, spec: VectorizationSpec
+        self, parse_result: ParsingResult, spec: "VectorizationSpec"
     ) -> VectorizationResult:
         """Phase 3: Extract geometry from the solved sketch."""
         if not self.parsed_sketch:

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketch_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketch_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -16,7 +14,7 @@ logger = logging.getLogger(__name__)
 class SketchCmd:
     """Handles commands related to sketch-based workpieces."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     def set_workpiece_parameters(

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum, auto
@@ -42,7 +40,7 @@ class SketchTool(ABC):
     SHORTCUTS: ClassVar[list[str]] = []
     CURSOR_ICON: str | None = None
 
-    def __init__(self, element: SketchElement):
+    def __init__(self, element: "SketchElement"):
         self.element = element
 
     @abstractmethod
@@ -86,7 +84,7 @@ class SketchTool(ABC):
         transient UI (like selection boxes) in screen space.
         """
 
-    def get_preview_state(self) -> PreviewState | None:
+    def get_preview_state(self) -> "PreviewState | None":
         """
         Returns the current preview state for tools that support live preview.
         Override in subclasses that have a _preview_state attribute.
@@ -121,7 +119,7 @@ class SketchTool(ABC):
 
     def is_available(
         self,
-        target: Point | Entity | Constraint | None,
+        target: "Point | Entity | Constraint | None",
         target_type: str | None,
     ) -> bool:
         """

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/dimension_input.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/dimension_input.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import locale
 from collections.abc import Callable
 from dataclasses import dataclass, field

--- a/rayforge/core/capability.py
+++ b/rayforge/core/capability.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 from gettext import gettext as _
 

--- a/rayforge/core/color_preset.py
+++ b/rayforge/core/color_preset.py
@@ -8,8 +8,6 @@ layer is given the corresponding step type, after which the regular
 recipe matching applies its settings.
 """
 
-from __future__ import annotations
-
 import logging
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -45,7 +43,7 @@ class ColorPreset:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ColorPreset:
+    def from_dict(cls, data: dict[str, Any]) -> "ColorPreset":
         """Deserializes a preset from a dictionary."""
         return cls(
             color=data.get("color", ""),

--- a/rayforge/core/cut_side.py
+++ b/rayforge/core/cut_side.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from enum import Enum, auto
 from gettext import gettext as _
 

--- a/rayforge/core/expression/errors.py
+++ b/rayforge/core/expression/errors.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 from gettext import gettext as _
 
@@ -80,11 +78,11 @@ class ValidationResult:
         return self.status == ValidationStatus.OK
 
     @classmethod
-    def success(cls) -> ValidationResult:
+    def success(cls) -> "ValidationResult":
         """Factory method for a successful result."""
         return cls(ValidationStatus.OK)
 
     @classmethod
-    def failure(cls, error_info: ErrorInfo) -> ValidationResult:
+    def failure(cls, error_info: ErrorInfo) -> "ValidationResult":
         """Factory method for a failed result."""
         return cls(ValidationStatus.ERROR, error_info)

--- a/rayforge/core/group.py
+++ b/rayforge/core/group.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -22,7 +20,7 @@ logger = logging.getLogger(__name__)
 class GroupingResult:
     """A container for the results of the group creation calculation."""
 
-    new_group: Group
+    new_group: "Group"
     child_matrices: dict[str, Matrix]
 
 
@@ -39,7 +37,7 @@ class Group(DocItem):
         self.extra: dict[str, Any] = {}
 
     @property
-    def layer(self) -> Layer | None:
+    def layer(self) -> "Layer | None":
         """Traverses the hierarchy to find the parent Layer."""
         from .layer import Layer  # Local import to avoid circular dependency
 
@@ -137,7 +135,7 @@ class Group(DocItem):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> Group:
+    def from_dict(cls, data: dict) -> "Group":
         """Deserializes a dictionary into a Group instance."""
         known_keys = {"uid", "type", "name", "matrix", "children"}
         extra = {k: v for k, v in data.items() if k not in known_keys}

--- a/rayforge/core/item.py
+++ b/rayforge/core/item.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import uuid
 import weakref
@@ -46,7 +44,7 @@ class _RevisionSignal(Signal):
     def __init__(
         self,
         owner_ref: weakref.ref,
-        bump: Callable[[DocItem], None],
+        bump: "Callable[[DocItem], None]",
     ):
         super().__init__()
         self._owner_ref = owner_ref
@@ -153,7 +151,7 @@ class DocItem(ABC):
             self._name = new_name
             self.updated.send(self)
 
-    def depends_on_asset(self, asset: IAsset) -> bool:
+    def depends_on_asset(self, asset: "IAsset") -> bool:
         """
         Checks if this item has a direct dependency on the given asset.
         Subclasses should override this to check their specific asset links.
@@ -177,12 +175,12 @@ class DocItem(ABC):
 
     @classmethod
     @abstractmethod
-    def from_dict(cls, data: dict) -> DocItem:
+    def from_dict(cls, data: dict) -> "DocItem":
         """Deserializes the item from a dictionary."""
         raise NotImplementedError
 
     @staticmethod
-    def create_from_dict(data: dict) -> DocItem:
+    def create_from_dict(data: dict) -> "DocItem":
         """
         Factory method that deserializes a dictionary into the appropriate
         DocItem subclass based on the 'type' field.
@@ -204,7 +202,7 @@ class DocItem(ABC):
         else:
             raise ValueError(f"Unknown item type: {item_type}")
 
-    def duplicate(self) -> DocItem:
+    def duplicate(self) -> "DocItem":
         """
         Creates a deep copy of this item with new UIDs.
 
@@ -215,7 +213,7 @@ class DocItem(ABC):
         item_dict = self.to_dict()
         new_item = self.__class__.from_dict(item_dict)
 
-        def assign_new_uids(item: DocItem):
+        def assign_new_uids(item: "DocItem"):
             item.uid = str(uuid.uuid4())
             for child in item.children:
                 assign_new_uids(child)
@@ -230,12 +228,12 @@ class DocItem(ABC):
         return iter(self.children)
 
     @property
-    def parent(self) -> DocItem | None:
+    def parent(self) -> "DocItem | None":
         """The parent DocItem in the hierarchy."""
         return self._parent
 
     @parent.setter
-    def parent(self, new_parent: DocItem | None):
+    def parent(self, new_parent: "DocItem | None"):
         """
         Sets the parent of this item. This is typically managed by the
         parent's add/remove_child methods and should not be set directly.
@@ -243,7 +241,7 @@ class DocItem(ABC):
         self._parent = new_parent
 
     @property
-    def doc(self) -> Doc | None:
+    def doc(self) -> "Doc | None":
         """The root Doc object, accessed via the parent hierarchy."""
         if self.parent:
             return self.parent.doc
@@ -587,7 +585,7 @@ class DocItem(ABC):
         self.descendant_added.send(self, origin=child, parent_of_origin=self)
         return child
 
-    def remove_child(self, child: DocItem):
+    def remove_child(self, child: "DocItem"):
         if child not in self.children:
             return
 
@@ -598,7 +596,7 @@ class DocItem(ABC):
         self._recalculate_natural_size()
 
     def add_children(
-        self, children_to_add: Iterable[DocItem], index: int | None = None
+        self, children_to_add: "Iterable[DocItem]", index: int | None = None
     ):
         """
         Adds multiple children in a bulk operation to improve performance,
@@ -640,7 +638,7 @@ class DocItem(ABC):
         self._recalculate_natural_size()
         self.updated.send(self)
 
-    def remove_children(self, children_to_remove: Iterable[DocItem]):
+    def remove_children(self, children_to_remove: "Iterable[DocItem]"):
         """
         Removes multiple children in a bulk operation to improve performance,
         sending a single `updated` signal after all are removed.
@@ -667,7 +665,7 @@ class DocItem(ABC):
         self._recalculate_natural_size()
         self.updated.send(self)
 
-    def set_children(self, new_children: Iterable[DocItem]):
+    def set_children(self, new_children: "Iterable[DocItem]"):
         """
         Correctly updates the list of children by mutating state first,
         then sending notifications.
@@ -724,7 +722,7 @@ class DocItem(ABC):
         return depth
 
     @overload
-    def get_descendants(self) -> list[DocItem]: ...
+    def get_descendants(self) -> "list[DocItem]": ...
 
     @overload
     def get_descendants(self, of_type: type[T_Desc]) -> list[T_Desc]: ...
@@ -748,7 +746,7 @@ class DocItem(ABC):
 
         return all_descendants
 
-    def get_child_by_uid(self, uid: str) -> DocItem | None:
+    def get_child_by_uid(self, uid: str) -> "DocItem | None":
         """
         Finds a direct child of this item by its unique identifier.
 
@@ -763,7 +761,7 @@ class DocItem(ABC):
                 return child
         return None
 
-    def find_descendant_by_uid(self, uid: str) -> DocItem | None:
+    def find_descendant_by_uid(self, uid: str) -> "DocItem | None":
         """
         Recursively searches the subtree for a descendant with a matching UID.
 
@@ -781,7 +779,7 @@ class DocItem(ABC):
                 return found
         return None
 
-    def _connect_child_signals(self, child: DocItem):
+    def _connect_child_signals(self, child: "DocItem"):
         child.updated.connect(self._on_child_updated)
         child.transform_changed.connect(self._on_child_transform_changed)
         child.descendant_added.connect(self._on_descendant_added)
@@ -791,7 +789,7 @@ class DocItem(ABC):
             self._on_descendant_transform_changed
         )
 
-    def _disconnect_child_signals(self, child: DocItem):
+    def _disconnect_child_signals(self, child: "DocItem"):
         child.updated.disconnect(self._on_child_updated)
         child.transform_changed.disconnect(self._on_child_transform_changed)
         child.descendant_added.disconnect(self._on_descendant_added)
@@ -801,34 +799,46 @@ class DocItem(ABC):
             self._on_descendant_transform_changed
         )
 
-    def _on_child_updated(self, sender: DocItem):
+    def _on_child_updated(self, sender: "DocItem"):
         self.descendant_updated.send(
             self, origin=sender, parent_of_origin=self
         )
 
     def _on_child_transform_changed(
-        self, sender: DocItem, *, old_matrix: Matrix | None = None
+        self, sender: "DocItem", *, old_matrix: Matrix | None = None
     ):
         self.descendant_transform_changed.send(
             self, origin=sender, parent_of_origin=self, old_matrix=old_matrix
         )
 
     def _on_descendant_added(
-        self, sender: DocItem, *, origin: DocItem, parent_of_origin: DocItem
+        self,
+        sender: "DocItem",
+        *,
+        origin: "DocItem",
+        parent_of_origin: "DocItem",
     ):
         self.descendant_added.send(
             self, origin=origin, parent_of_origin=parent_of_origin
         )
 
     def _on_descendant_removed(
-        self, sender: DocItem, *, origin: DocItem, parent_of_origin: DocItem
+        self,
+        sender: "DocItem",
+        *,
+        origin: "DocItem",
+        parent_of_origin: "DocItem",
     ):
         self.descendant_removed.send(
             self, origin=origin, parent_of_origin=parent_of_origin
         )
 
     def _on_descendant_updated(
-        self, sender: DocItem, *, origin: DocItem, parent_of_origin: DocItem
+        self,
+        sender: "DocItem",
+        *,
+        origin: "DocItem",
+        parent_of_origin: "DocItem",
     ):
         self.descendant_updated.send(
             self, origin=origin, parent_of_origin=parent_of_origin
@@ -836,10 +846,10 @@ class DocItem(ABC):
 
     def _on_descendant_transform_changed(
         self,
-        sender: DocItem,
+        sender: "DocItem",
         *,
-        origin: DocItem,
-        parent_of_origin: DocItem,
+        origin: "DocItem",
+        parent_of_origin: "DocItem",
         old_matrix: Matrix | None = None,
     ):
         self.descendant_transform_changed.send(
@@ -873,7 +883,7 @@ class DocItem(ABC):
             return parent_transform @ self.matrix
         return self.matrix
 
-    def get_ancestor_by_type(self, ancestor_type: type) -> DocItem | None:
+    def get_ancestor_by_type(self, ancestor_type: type) -> "DocItem | None":
         """
         Traverses the parent hierarchy to find the first ancestor of the
         specified type.

--- a/rayforge/core/layer.py
+++ b/rayforge/core/layer.py
@@ -3,8 +3,6 @@ Defines the Layer class, a central component for organizing and processing
 workpieces within a document.
 """
 
-from __future__ import annotations
-
 import logging
 import math
 from collections.abc import Iterable
@@ -85,7 +83,7 @@ class Layer(DocItem):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Layer:
+    def from_dict(cls, data: dict[str, Any]) -> "Layer":
         """Deserializes a dictionary into a Layer instance."""
         known_keys = {
             "uid",

--- a/rayforge/core/source_asset.py
+++ b/rayforge/core/source_asset.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import logging
 import uuid
@@ -40,7 +38,7 @@ class SourceAsset(IAsset):
 
     source_file: Path
     original_data: bytes = field(repr=False)
-    renderer: Renderer
+    renderer: "Renderer"
     base_render_data: bytes | None = field(default=None, repr=False)
     thumbnail_data: bytes | None = field(default=None, repr=False)
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -170,7 +168,7 @@ class SourceAsset(IAsset):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SourceAsset:
+    def from_dict(cls, data: dict[str, Any]) -> "SourceAsset":
         """Deserializes a dictionary into a SourceAsset instance."""
         from ..image import renderer_registry
         from ..image.base_renderer import UnknownRenderer

--- a/rayforge/core/source_asset_segment.py
+++ b/rayforge/core/source_asset_segment.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import Any
@@ -54,7 +52,7 @@ class SourceAssetSegment:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SourceAssetSegment:
+    def from_dict(cls, data: dict[str, Any]) -> "SourceAssetSegment":
         """Deserializes a dictionary into a SourceAssetSegment instance."""
         # Handle tuple conversion for crop_window_px if it's a list from JSON
         crop_window = data.get("crop_window_px")
@@ -89,7 +87,7 @@ class SourceAssetSegment:
 
     def clone_with_geometry(
         self, new_y_down_geometry: Geometry
-    ) -> SourceAssetSegment:
+    ) -> "SourceAssetSegment":
         """
         Creates a deep copy of this segment for use in splitting operations.
 

--- a/rayforge/core/stock.py
+++ b/rayforge/core/stock.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any, cast
@@ -31,12 +29,12 @@ class StockItem(DocItem):
         self.visible: bool = True
         self.extra: dict[str, Any] = {}
 
-    def depends_on_asset(self, asset: IAsset) -> bool:
+    def depends_on_asset(self, asset: "IAsset") -> bool:
         """Checks if this stock item is an instance of the given asset."""
         return self.stock_asset_uid == asset.uid
 
     @property
-    def stock_asset(self) -> StockAsset | None:
+    def stock_asset(self) -> "StockAsset | None":
         """Retrieves the StockAsset this item is an instance of."""
         doc = self.doc
         if doc:
@@ -79,7 +77,7 @@ class StockItem(DocItem):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> StockItem:
+    def from_dict(cls, data: dict[str, Any]) -> "StockItem":
         """
         Deserializes a dictionary into a StockItem instance.
         Assumes the new format with 'stock_asset_uid'. Legacy file handling
@@ -106,7 +104,7 @@ class StockItem(DocItem):
 
         return new_item
 
-    def duplicate(self) -> StockItem:
+    def duplicate(self) -> "StockItem":
         """
         Creates a deep copy of this StockItem with a new UID.
 
@@ -244,7 +242,7 @@ class StockItem(DocItem):
         return 1.0, 1.0
 
     @property
-    def material(self) -> Material | None:
+    def material(self) -> "Material | None":
         """
         Gets the Material object for this stock item via its StockAsset.
 

--- a/rayforge/core/stock_asset.py
+++ b/rayforge/core/stock_asset.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import uuid
 from gettext import gettext as _
@@ -91,7 +89,7 @@ class StockAsset(IAsset):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> StockAsset:
+    def from_dict(cls, data: dict[str, Any]) -> "StockAsset":
         """Deserializes a dictionary into a StockAsset instance."""
         known_keys = {
             "uid",
@@ -124,7 +122,7 @@ class StockAsset(IAsset):
             self._updated.send(self)
 
     @property
-    def material(self) -> Material | None:
+    def material(self) -> "Material | None":
         """
         Gets the Material object for this stock asset.
 

--- a/rayforge/core/tab.py
+++ b/rayforge/core/tab.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 from dataclasses import dataclass, field
 

--- a/rayforge/core/undo/command.py
+++ b/rayforge/core/undo/command.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -27,7 +25,7 @@ class Command(ABC):
     def undo(self) -> None:
         raise NotImplementedError
 
-    def can_coalesce_with(self, next_command: Command) -> bool:
+    def can_coalesce_with(self, next_command: "Command") -> bool:
         """
         Checks if the 'next_command' can be merged into this one without
         modifying the state of either command.
@@ -39,7 +37,7 @@ class Command(ABC):
         """
         return False
 
-    def coalesce_with(self, next_command: Command) -> bool:
+    def coalesce_with(self, next_command: "Command") -> bool:
         """
         Attempts to merge the 'next_command' into this one. If successful,
         this command's state is updated with the newer command's state,

--- a/rayforge/core/undo/history.py
+++ b/rayforge/core/undo/history.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -23,7 +21,7 @@ class _TransactionContextProxy:
     within the current transaction.
     """
 
-    def __init__(self, manager: HistoryManager):
+    def __init__(self, manager: "HistoryManager"):
         self._manager = manager
 
     def set_label(self, name: str) -> None:

--- a/rayforge/core/vectorization_spec.py
+++ b/rayforge/core/vectorization_spec.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -35,7 +33,7 @@ class VectorizationSpec(ABC):
         raise NotImplementedError
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> VectorizationSpec:
+    def from_dict(cls, data: dict[str, Any]) -> "VectorizationSpec":
         """Factory to create a VectorizationSpec instance from a dictionary."""
         spec_type = data.get("type")
         if not spec_type:
@@ -69,7 +67,7 @@ class TraceSpec(VectorizationSpec):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> TraceSpec:
+    def from_dict(cls, data: dict[str, Any]) -> "TraceSpec":
         return cls(
             threshold=data.get("threshold", 0.5),
             auto_threshold=data.get("auto_threshold", True),
@@ -102,7 +100,7 @@ class PassthroughSpec(VectorizationSpec):
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> PassthroughSpec:
+    def from_dict(cls, data: dict[str, Any]) -> "PassthroughSpec":
         mode_str = data.get("layer_import_mode")
         if mode_str:
             mode = LayerImportMode(mode_str)
@@ -150,5 +148,5 @@ class ProceduralSpec(VectorizationSpec):
         return {"type": "ProceduralSpec", "ppi": self.ppi}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ProceduralSpec:
+    def from_dict(cls, data: dict[str, Any]) -> "ProceduralSpec":
         return cls(ppi=data.get("ppi", 96.0))

--- a/rayforge/core/workflow.py
+++ b/rayforge/core/workflow.py
@@ -2,8 +2,6 @@
 Defines the Workflow class, which holds an ordered sequence of Steps.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterable
 from typing import Any, TypeVar
@@ -56,7 +54,7 @@ class Workflow(DocItem):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Workflow:
+    def from_dict(cls, data: dict[str, Any]) -> "Workflow":
         """Deserializes a dictionary into a Workflow instance."""
         known_keys = {
             "uid",

--- a/rayforge/core/workpiece.py
+++ b/rayforge/core/workpiece.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 import warnings
@@ -51,11 +49,11 @@ class RenderContext(NamedTuple):
 
     data: bytes | Any
     original_data: bytes | None
-    renderer: Renderer
+    renderer: "Renderer"
     source_pixel_dims: tuple[int, int] | None
     metadata: dict[str, Any]
     boundaries: Geometry | None
-    fills: list[FillRenderData] | None
+    fills: "list[FillRenderData] | None"
 
 
 class WorkPiece(DocItem):
@@ -114,7 +112,7 @@ class WorkPiece(DocItem):
         # Forward compatibility: store unknown attributes
         self.extra: dict[str, Any] = {}
 
-    def depends_on_asset(self, asset: IAsset) -> bool:
+    def depends_on_asset(self, asset: "IAsset") -> bool:
         """
         Checks if this workpiece depends on the given asset, either through
         its geometry provider or its source file.
@@ -130,7 +128,9 @@ class WorkPiece(DocItem):
         )
 
     @classmethod
-    def from_geometry_provider(cls, provider: IGeometryProvider) -> WorkPiece:
+    def from_geometry_provider(
+        cls, provider: IGeometryProvider
+    ) -> "WorkPiece":
         """
         Factory method to create a WorkPiece from an IGeometryProvider.
 
@@ -246,7 +246,7 @@ class WorkPiece(DocItem):
         self._fills_cache = None
 
     @property
-    def source(self) -> SourceAsset | None:
+    def source(self) -> "SourceAsset | None":
         """
         Convenience property to retrieve the full SourceAsset object from the
         document's central registry.
@@ -314,7 +314,7 @@ class WorkPiece(DocItem):
         return None
 
     @property
-    def _active_renderer(self) -> Renderer | None:
+    def _active_renderer(self) -> "Renderer | None":
         """Retrieves the renderer (internal use)."""
         if self._renderer is not None:
             return self._renderer
@@ -446,7 +446,7 @@ class WorkPiece(DocItem):
         return None
 
     @property
-    def fills(self) -> list[FillRenderData] | None:
+    def fills(self) -> "list[FillRenderData] | None":
         """
         The fill geometry data for this workpiece, if any.
 
@@ -544,14 +544,14 @@ class WorkPiece(DocItem):
             self.updated.send(self)
 
     @property
-    def layer(self) -> Layer | None:
+    def layer(self) -> "Layer | None":
         """Traverses the hierarchy to find the parent Layer."""
         from .layer import Layer  # Local import to avoid circular dependency
 
         ancestor = self.get_ancestor_by_type(Layer)
         return ancestor if isinstance(ancestor, Layer) else None
 
-    def in_world(self) -> WorkPiece:
+    def in_world(self) -> "WorkPiece":
         """
         Returns a new, unparented WorkPiece instance whose local
         transformation matrix is the world transformation matrix of this one.
@@ -717,7 +717,7 @@ class WorkPiece(DocItem):
     def _process_rendered_image_from_spec(
         self,
         image: pyvips.Image,
-        spec: RenderSpecification,
+        spec: "RenderSpecification",
         target_size: tuple[int, int],
         source_px_dims: tuple[int, int] | None,
     ) -> pyvips.Image | None:
@@ -913,7 +913,7 @@ class WorkPiece(DocItem):
         return state
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> WorkPiece:
+    def from_dict(cls, data: dict[str, Any]) -> "WorkPiece":
         """
         Restores a WorkPiece instance from a dictionary.
         """
@@ -1383,7 +1383,7 @@ class WorkPiece(DocItem):
 
         self.pos = (model_x, model_y)
 
-    def apply_split(self, fragments: list[Geometry]) -> list[WorkPiece]:
+    def apply_split(self, fragments: list[Geometry]) -> "list[WorkPiece]":
         """
         Creates new WorkPiece instances from a list of normalized geometry
         fragments. Each fragment represents a subset of this workpiece's

--- a/rayforge/doceditor/array/base.py
+++ b/rayforge/doceditor/array/base.py
@@ -8,8 +8,6 @@ returned list is always the identity matrix, representing the original
 selection that stays in place.
 """
 
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 
 from raygeo.geo import Matrix

--- a/rayforge/doceditor/array/circular.py
+++ b/rayforge/doceditor/array/circular.py
@@ -1,7 +1,5 @@
 """Circular array strategy."""
 
-from __future__ import annotations
-
 import math
 
 from raygeo.geo import Matrix

--- a/rayforge/doceditor/array/grid.py
+++ b/rayforge/doceditor/array/grid.py
@@ -1,7 +1,5 @@
 """Grid (rows x columns) array strategy."""
 
-from __future__ import annotations
-
 from raygeo.geo import Matrix
 
 from .base import ArrayStrategy

--- a/rayforge/doceditor/array/params.py
+++ b/rayforge/doceditor/array/params.py
@@ -12,8 +12,6 @@ pattern. Three arrangements are supported:
 Each duplicate preserves the layer membership of its source item.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -61,7 +59,7 @@ class GridArrayParams:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> GridArrayParams:
+    def from_dict(cls, data: dict[str, Any]) -> "GridArrayParams":
         try:
             spacing = SpacingMode(data.get("spacing_mode", "gap"))
         except ValueError:
@@ -93,7 +91,7 @@ class PointRotationParams:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> PointRotationParams:
+    def from_dict(cls, data: dict[str, Any]) -> "PointRotationParams":
         return cls(
             count=int(data.get("count", 6)),
             total_angle_deg=float(data.get("total_angle_deg", 360.0)),
@@ -127,7 +125,7 @@ class CircularArrayParams:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> CircularArrayParams:
+    def from_dict(cls, data: dict[str, Any]) -> "CircularArrayParams":
         center = data.get("center_mm", [0.0, 0.0])
         return cls(
             count=int(data.get("count", 6)),
@@ -158,7 +156,7 @@ class ArrayParams:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any] | None) -> ArrayParams:
+    def from_dict(cls, data: dict[str, Any] | None) -> "ArrayParams":
         if not data:
             return cls()
         try:

--- a/rayforge/doceditor/array/point_rotation.py
+++ b/rayforge/doceditor/array/point_rotation.py
@@ -1,7 +1,5 @@
 """Point-rotation array strategy."""
 
-from __future__ import annotations
-
 from raygeo.geo import Matrix
 
 from .base import ArrayStrategy

--- a/rayforge/doceditor/array_cmd.py
+++ b/rayforge/doceditor/array_cmd.py
@@ -6,8 +6,6 @@ regular pattern. Each duplicate is placed on the same layer as its
 source item, preserving the document's layer structure.
 """
 
-from __future__ import annotations
-
 import logging
 import math
 from collections.abc import Sequence
@@ -34,7 +32,7 @@ logger = logging.getLogger(__name__)
 class ArrayCmd:
     """Handles undoable creation of item arrays."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     # ------------------------------------------------------------------

--- a/rayforge/doceditor/asset_cmd.py
+++ b/rayforge/doceditor/asset_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -27,7 +25,7 @@ class UpdateAssetCommand(Command):
 
     def __init__(
         self,
-        doc: Doc,
+        doc: "Doc",
         asset_uid: str,
         new_data: dict[str, Any],
         name: str = _("Update Asset"),
@@ -71,7 +69,7 @@ class UpdateAssetCommand(Command):
         self.doc.updated.send(self.doc)
 
     def _update_dependent_workpieces(
-        self, provider: IGeometryProvider
+        self, provider: "IGeometryProvider"
     ) -> None:
         """Update all workpieces that depend on this geometry provider."""
         for workpiece in self.doc.all_workpieces:
@@ -125,7 +123,7 @@ class UpdateAssetCommand(Command):
 class AssetCmd:
     """Handles commands related to document assets."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     @property

--- a/rayforge/doceditor/editor.py
+++ b/rayforge/doceditor/editor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 import threading
@@ -54,8 +52,8 @@ class DocEditor:
 
     def __init__(
         self,
-        task_manager: TaskManager,
-        context: RayforgeContext,
+        task_manager: "TaskManager",
+        context: "RayforgeContext",
         doc: Doc | None = None,
     ):
         """

--- a/rayforge/doceditor/layer_cmd.py
+++ b/rayforge/doceditor/layer_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -96,7 +94,7 @@ class AddLayerAndSetActiveCommand(Command):
 
     def __init__(
         self,
-        editor: DocEditor,
+        editor: "DocEditor",
         new_layer: Layer | None = None,
         name: str = "Add layer",
     ):
@@ -160,7 +158,7 @@ class AddLayerAndSetActiveCommand(Command):
 class LayerCmd:
     """Handles commands related to layer manipulation."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     def move_workpieces_to_layer(
@@ -184,7 +182,7 @@ class LayerCmd:
         self._editor.history_manager.execute(cmd)
 
     def move_selected_to_adjacent_layer(
-        self, surface: WorkSurface, direction: int
+        self, surface: "WorkSurface", direction: int
     ):
         """
         Creates an undoable command to move selected workpieces to the

--- a/rayforge/doceditor/layout/align.py
+++ b/rayforge/doceditor/layout/align.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -16,8 +14,8 @@ class BboxAlignLeftStrategy(LayoutStrategy):
     """Aligns the left edges of the selection's bounding boxes."""
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_x: float
         if len(self.items) == 1:
             # For a single item, align to the world origin's left edge.
@@ -44,15 +42,15 @@ class BboxAlignCenterStrategy(LayoutStrategy):
 
     def __init__(
         self,
-        items: Sequence[DocItem],
+        items: "Sequence[DocItem]",
         surface_width_mm: float | None = None,
     ):
         super().__init__(items)
         self.surface_width_mm = surface_width_mm
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_center_x: float
         if len(self.items) == 1 and self.surface_width_mm is not None:
             target_center_x = self.surface_width_mm / 2
@@ -79,15 +77,15 @@ class BboxAlignRightStrategy(LayoutStrategy):
 
     def __init__(
         self,
-        items: Sequence[DocItem],
+        items: "Sequence[DocItem]",
         surface_width_mm: float | None = None,
     ):
         super().__init__(items)
         self.surface_width_mm = surface_width_mm
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_x: float
         if len(self.items) == 1 and self.surface_width_mm is not None:
             target_x = self.surface_width_mm
@@ -113,15 +111,15 @@ class BboxAlignTopStrategy(LayoutStrategy):
 
     def __init__(
         self,
-        items: Sequence[DocItem],
+        items: "Sequence[DocItem]",
         surface_height_mm: float | None = None,
     ):
         super().__init__(items)
         self.surface_height_mm = surface_height_mm
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_y: float
         if len(self.items) == 1 and self.surface_height_mm is not None:
             target_y = self.surface_height_mm
@@ -147,15 +145,15 @@ class BboxAlignMiddleStrategy(LayoutStrategy):
 
     def __init__(
         self,
-        items: Sequence[DocItem],
+        items: "Sequence[DocItem]",
         surface_height_mm: float | None = None,
     ):
         super().__init__(items)
         self.surface_height_mm = surface_height_mm
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_center_y: float
         if len(self.items) == 1 and self.surface_height_mm is not None:
             target_center_y = self.surface_height_mm / 2
@@ -181,8 +179,8 @@ class BboxAlignBottomStrategy(LayoutStrategy):
     """Aligns the bottom edges of the selection's bounding boxes."""
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         target_y: float
         if len(self.items) == 1:
             target_y = 0.0
@@ -210,15 +208,15 @@ class PositionAtStrategy(LayoutStrategy):
 
     def __init__(
         self,
-        items: Sequence[DocItem],
+        items: "Sequence[DocItem]",
         position_mm: tuple[float, float],
     ):
         super().__init__(items)
         self.position_mm = position_mm
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         bbox = self._get_selection_world_bbox()
         if not bbox:
             return {}

--- a/rayforge/doceditor/layout/auto.py
+++ b/rayforge/doceditor/layout/auto.py
@@ -2,8 +2,6 @@
 Implements a pixel-based layout strategy for dense packing of workpieces.
 """
 
-from __future__ import annotations
-
 import logging
 import math
 from collections.abc import Sequence
@@ -92,7 +90,7 @@ class PixelPerfectLayoutStrategy(LayoutStrategy):
         self.allow_rotation = allow_rotation
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
+        self, context: "ExecutionContext | None" = None
     ) -> dict[DocItem, Matrix]:
         """
         Calculates the transform for each workpiece for a dense layout. The
@@ -412,7 +410,7 @@ class PixelPerfectLayoutStrategy(LayoutStrategy):
         self,
         item_groups: list[list[WorkpieceVariant]],
         canvas: np.ndarray,
-        context: ExecutionContext | None = None,
+        context: "ExecutionContext | None" = None,
     ) -> tuple[list[PlacedItem], list[DocItem]]:
         """
         Places workpiece variants onto the canvas greedily.

--- a/rayforge/doceditor/layout/base.py
+++ b/rayforge/doceditor/layout/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -130,7 +128,7 @@ class LayoutStrategy(ABC):
 
     @abstractmethod
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
+        self, context: "ExecutionContext | None" = None
     ) -> dict[DocItem, Matrix]:
         """
         Calculates the required delta transformation matrix for each
@@ -144,8 +142,8 @@ class LayoutStrategy(ABC):
 
     async def calculate_deltas_async(
         self,
-        context: ExecutionContext | None = None,
-        task_manager: TaskManager | None = None,
+        context: "ExecutionContext | None" = None,
+        task_manager: "TaskManager | None" = None,
     ) -> dict[DocItem, Matrix]:
         """
         Asynchronous version of calculate_deltas.

--- a/rayforge/doceditor/layout/spread.py
+++ b/rayforge/doceditor/layout/spread.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from raygeo.geo import Matrix
@@ -15,8 +13,8 @@ class SpreadHorizontallyStrategy(LayoutStrategy):
     """Distributes items evenly in the horizontal direction."""
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         if len(self.items) < 3:
             return {}
 
@@ -60,8 +58,8 @@ class SpreadVerticallyStrategy(LayoutStrategy):
     """Distributes items evenly in the vertical direction."""
 
     def calculate_deltas(
-        self, context: ExecutionContext | None = None
-    ) -> dict[DocItem, Matrix]:
+        self, context: "ExecutionContext | None" = None
+    ) -> "dict[DocItem, Matrix]":
         if len(self.items) < 3:
             return {}
 

--- a/rayforge/doceditor/layout_cmd.py
+++ b/rayforge/doceditor/layout_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -32,7 +30,7 @@ logger = logging.getLogger(__name__)
 class LayoutCmd:
     """Handles alignment, distribution, and automatic layout of items."""
 
-    def __init__(self, editor: DocEditor, task_manager: TaskManager):
+    def __init__(self, editor: "DocEditor", task_manager: "TaskManager"):
         self._editor = editor
         self._task_manager = task_manager
 
@@ -74,7 +72,7 @@ class LayoutCmd:
         # Connect the handler before running the task.
         strategy.error_reported.connect(on_error_reported)
 
-        def when_done(task: Task):
+        def when_done(task: "Task"):
             """
             This callback runs on the main thread after the task finishes.
             It disconnects the signal handler and safely applies the

--- a/rayforge/doceditor/step_cmd.py
+++ b/rayforge/doceditor/step_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
@@ -21,7 +19,7 @@ logger = logging.getLogger(__name__)
 class StepCmd:
     """Handles commands related to step settings."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
         self._doc = editor.doc
         self._context = editor.context
@@ -66,7 +64,7 @@ class StepCmd:
         )
         self._editor.history_manager.execute(command)
 
-    def apply_best_recipe_to_step(self, step: Step):
+    def apply_best_recipe_to_step(self, step: "Step"):
         """
         Finds the best matching recipe for a given step and applies its
         settings. This modifies the step object directly and is not undoable
@@ -106,7 +104,9 @@ class StepCmd:
             step.applied_recipe_uid = best_recipe.uid
 
     @staticmethod
-    def _apply_recipe_transformers_to_step(step: Step, recipe: Recipe) -> None:
+    def _apply_recipe_transformers_to_step(
+        step: "Step", recipe: "Recipe"
+    ) -> None:
         """Apply a recipe's transformer settings to a fresh step.
 
         Direct mutation of the step's per-workpiece and per-step
@@ -137,7 +137,7 @@ class StepCmd:
                     continue
                 step_dict[key] = value
 
-    def rename_step(self, step: Step, new_name: str):
+    def rename_step(self, step: "Step", new_name: str):
         """Renames a step with an undoable command."""
         if new_name == step.name:
             return
@@ -227,7 +227,7 @@ class StepCmd:
                     f"layer '{layer.name}' (has fills)."
                 )
 
-    def _step_class_from_color_rule(self, layer) -> type[Step] | None:
+    def _step_class_from_color_rule(self, layer) -> "type[Step] | None":
         """
         Resolve the step class a color rule maps to for a layer.
 

--- a/rayforge/doceditor/stock_cmd.py
+++ b/rayforge/doceditor/stock_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -27,7 +25,7 @@ class _AddStockCommand(Command):
 
     def __init__(
         self,
-        doc: Doc,
+        doc: "Doc",
         name: str,
         geometry: Geometry,
         pos: tuple[float, float],
@@ -56,7 +54,7 @@ class _AddStockCommand(Command):
 class RemoveStockAssetCommand(Command):
     """Command to remove a StockAsset from the document."""
 
-    def __init__(self, doc: Doc, asset_uid: str):
+    def __init__(self, doc: "Doc", asset_uid: str):
         super().__init__(name=_("Remove Stock Asset"))
         self.doc = doc
         self.asset_uid = asset_uid
@@ -77,7 +75,7 @@ class ConvertToStockCommand(Command):
     Command to convert a WorkPiece to a StockItem with its own StockAsset.
     """
 
-    def __init__(self, doc: Doc, workpiece: WorkPiece):
+    def __init__(self, doc: "Doc", workpiece: WorkPiece):
         super().__init__(name=_("Convert to Stock"))
         self.doc = doc
         self.workpiece = workpiece
@@ -121,7 +119,7 @@ class ConvertToStockCommand(Command):
 class StockCmd:
     """Handles commands related to stock material."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     def add_stock(self):

--- a/rayforge/doceditor/tab_cmd.py
+++ b/rayforge/doceditor/tab_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from copy import deepcopy
 from dataclasses import replace
@@ -24,7 +22,7 @@ class SetWorkpieceTabsCommand(Command):
 
     def __init__(
         self,
-        editor: DocEditor,
+        editor: "DocEditor",
         workpiece: WorkPiece,
         new_tabs: list[Tab],
         name: str = "Set Tabs",
@@ -59,7 +57,7 @@ class SetWorkpieceTabsCommand(Command):
 class TabCmd:
     """Handles commands related to creating and managing workpiece tabs."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     def _calculate_equidistant_tabs(

--- a/rayforge/doceditor/transform_cmd.py
+++ b/rayforge/doceditor/transform_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -19,7 +17,7 @@ logger = logging.getLogger(__name__)
 class TransformCmd:
     """Handles undoable transformations of document items."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
 
     def create_transform_transaction(

--- a/rayforge/image/base_exporter.py
+++ b/rayforge/image/base_exporter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -38,7 +36,7 @@ class Exporter(BaseExporter):
     extensions: tuple[str, ...]
     mime_types: tuple[str, ...]
 
-    def __init__(self, doc_item: DocItem):
+    def __init__(self, doc_item: "DocItem"):
         """
         Initializes the exporter with the document item to be exported.
 

--- a/rayforge/image/base_importer.py
+++ b/rayforge/image/base_importer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 import logging
 from abc import ABC, abstractmethod
@@ -167,7 +165,7 @@ class Importer(ABC):
         self._errors.append(message)
 
     @abstractmethod
-    def scan(self) -> ImportManifest:
+    def scan(self) -> "ImportManifest":
         """
         Phase 1: Lightweight file scan.
 
@@ -194,7 +192,7 @@ class Importer(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def parse(self) -> ParsingResult | None:
+    def parse(self) -> "ParsingResult | None":
         """
         Phase 2: Parse raw data into geometric facts.
 
@@ -233,8 +231,8 @@ class Importer(ABC):
 
     @abstractmethod
     def vectorize(
-        self, parse_result: ParsingResult, spec: VectorizationSpec
-    ) -> VectorizationResult:
+        self, parse_result: "ParsingResult", spec: "VectorizationSpec"
+    ) -> "VectorizationResult":
         """
         Phase 3: Convert parsed data to vector geometry.
 
@@ -268,7 +266,9 @@ class Importer(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def create_source_asset(self, parse_result: ParsingResult) -> SourceAsset:
+    def create_source_asset(
+        self, parse_result: "ParsingResult"
+    ) -> "SourceAsset":
         """
         Creates a SourceAsset representing the imported file.
 
@@ -290,7 +290,7 @@ class Importer(ABC):
         """
         raise NotImplementedError
 
-    def _stamp_importer_identity(self, source_asset: SourceAsset) -> None:
+    def _stamp_importer_identity(self, source_asset: "SourceAsset") -> None:
         source_asset.metadata["_importer_class"] = type(self).__name__
         if self.mime_types:
             source_asset.metadata["_importer_mime"] = self.mime_types[0]
@@ -319,7 +319,7 @@ class Importer(ABC):
             logger.debug("Failed to render thumbnail", exc_info=True)
         return None
 
-    def _resolve_default_spec(self) -> VectorizationSpec:
+    def _resolve_default_spec(self) -> "VectorizationSpec":
         if ImporterFeature.DIRECT_VECTOR in self.features:
             return PassthroughSpec()
         elif ImporterFeature.BITMAP_TRACING in self.features:
@@ -329,10 +329,10 @@ class Importer(ABC):
 
     def _run_pipeline(
         self,
-        vectorization_spec: VectorizationSpec,
-        source_asset: SourceAsset,
-        parse_result: ParsingResult | None = None,
-    ) -> ImportResult:
+        vectorization_spec: "VectorizationSpec",
+        source_asset: "SourceAsset",
+        parse_result: "ParsingResult | None" = None,
+    ) -> "ImportResult":
         """
         Shared phases 2–5 of the import pipeline.
 
@@ -414,8 +414,8 @@ class Importer(ABC):
         )
 
     def get_doc_items(
-        self, vectorization_spec: VectorizationSpec | None = None
-    ) -> ImportResult | None:
+        self, vectorization_spec: "VectorizationSpec | None" = None
+    ) -> "ImportResult | None":
         """
         Template method that orchestrates the full five-phase import pipeline.
 
@@ -471,7 +471,9 @@ class Importer(ABC):
 
         return self._run_pipeline(spec, source_asset, parse_result)
 
-    def _post_process_payload(self, payload: ImportPayload) -> ImportPayload:
+    def _post_process_payload(
+        self, payload: "ImportPayload"
+    ) -> "ImportPayload":
         """
         An optional hook for subclasses to modify the final payload after
         assembly. This is useful for importers that need to add extra data
@@ -481,9 +483,9 @@ class Importer(ABC):
 
     def get_doc_items_for_reimport(
         self,
-        existing_source_asset: SourceAsset,
-        vectorization_spec: VectorizationSpec,
-    ) -> ImportResult | None:
+        existing_source_asset: "SourceAsset",
+        vectorization_spec: "VectorizationSpec",
+    ) -> "ImportResult | None":
         """
         Re-run the import pipeline using an existing SourceAsset.
 

--- a/rayforge/image/base_renderer.py
+++ b/rayforge/image/base_renderer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import warnings
 from abc import ABC, abstractmethod
@@ -41,9 +39,9 @@ class Renderer(ABC):
 
     def compute_render_spec(
         self,
-        segment: SourceAssetSegment | None,
+        segment: "SourceAssetSegment | None",
         target_size: tuple[int, int],
-        source_context: RenderContext,
+        source_context: "RenderContext",
     ) -> RenderSpecification:
         """
         Calculates the strategy for rendering. Subclasses will override this.
@@ -84,7 +82,7 @@ class Renderer(ABC):
 
     def render_preview_image(
         self,
-        import_result: ImportResult,
+        import_result: "ImportResult",
         target_width: int,
         target_height: int,
     ) -> pyvips.Image | None:
@@ -128,9 +126,9 @@ class RasterRenderer(Renderer):
 
     def compute_render_spec(
         self,
-        segment: SourceAssetSegment | None,
+        segment: "SourceAssetSegment | None",
         target_size: tuple[int, int],
-        source_context: RenderContext,
+        source_context: "RenderContext",
     ) -> RenderSpecification:
         """
         Calculates the render specification for a raster source. If the
@@ -200,9 +198,9 @@ class UnknownRenderer(Renderer):
 
     def compute_render_spec(
         self,
-        segment: SourceAssetSegment | None,
+        segment: "SourceAssetSegment | None",
         target_size: tuple[int, int],
-        source_context: RenderContext,
+        source_context: "RenderContext",
     ) -> RenderSpecification:
         """
         Always returns minimal render spec to avoid crashes.
@@ -233,7 +231,7 @@ class UnknownRenderer(Renderer):
 
     def render_preview_image(
         self,
-        import_result: ImportResult,
+        import_result: "ImportResult",
         target_width: int,
         target_height: int,
     ) -> pyvips.Image | None:

--- a/rayforge/image/dxf/exporter.py
+++ b/rayforge/image/dxf/exporter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import io
 import math
 from gettext import gettext as _

--- a/rayforge/image/lightburn/importer.py
+++ b/rayforge/image/lightburn/importer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import binascii
 import logging

--- a/rayforge/image/material_test_grid_renderer.py
+++ b/rayforge/image/material_test_grid_renderer.py
@@ -5,8 +5,6 @@ Renders a preview visualization of a material test grid for display on the
 canvas. The actual ops generation is handled by MaterialTestGridProducer.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import warnings

--- a/rayforge/image/pdf/pdf_vector.py
+++ b/rayforge/image/pdf/pdf_vector.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 import re

--- a/rayforge/image/svg/exporter.py
+++ b/rayforge/image/svg/exporter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from gettext import gettext as _
 

--- a/rayforge/image/svg/svg_base.py
+++ b/rayforge/image/svg/svg_base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from pathlib import Path

--- a/rayforge/image/svg/svg_trace.py
+++ b/rayforge/image/svg/svg_trace.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from gettext import gettext as _

--- a/rayforge/image/svg/svg_vector.py
+++ b/rayforge/image/svg/svg_vector.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import ClassVar
 

--- a/rayforge/machine/cmd.py
+++ b/rayforge/machine/cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable, Coroutine
 from gettext import gettext as _
@@ -34,7 +32,7 @@ logger = logging.getLogger(__name__)
 class MachineCmd:
     """Handles commands sent to the machine driver."""
 
-    def __init__(self, editor: DocEditor):
+    def __init__(self, editor: "DocEditor"):
         self._editor = editor
         self._scheduler = editor.task_manager.schedule_on_main_thread
         self.job_started = Signal()
@@ -46,7 +44,7 @@ class MachineCmd:
         """Returns True if a monitored job is currently running."""
         return self._current_monitor is not None
 
-    def select_tool(self, machine: Machine, head_index: int):
+    def select_tool(self, machine: "Machine", head_index: int):
         """Adds a 'select_head' task to the task manager."""
         if not (0 <= head_index < len(machine.heads)):
             logger.error(f"Invalid head index {head_index} for tool selection")
@@ -68,7 +66,7 @@ class MachineCmd:
     async def _execute_monitored_job(
         self,
         ops: Ops,
-        machine: Machine,
+        machine: "Machine",
         on_progress: Callable[[dict], None] | None = None,
         encoded: EncodedOutput | None = None,
     ):
@@ -154,7 +152,7 @@ class MachineCmd:
     async def _run_frame_action(
         self,
         artifact: JobArtifact,
-        machine: Machine,
+        machine: "Machine",
         on_progress: Callable[[dict], None] | None,
     ):
         """The specific machine action for a framing job."""
@@ -223,7 +221,7 @@ class MachineCmd:
     async def _run_send_action(
         self,
         artifact: JobArtifact,
-        machine: Machine,
+        machine: "Machine",
         on_progress: Callable[[dict], None] | None,
     ):
         """The specific machine action for a send job."""
@@ -239,7 +237,7 @@ class MachineCmd:
 
     async def _start_job(
         self,
-        machine: Machine,
+        machine: "Machine",
         job_name: str,
         final_job_action: Callable[..., Coroutine],
         on_progress: Callable[[dict], None] | None = None,
@@ -286,7 +284,7 @@ class MachineCmd:
 
     async def frame_job(
         self,
-        machine: Machine,
+        machine: "Machine",
         on_progress: Callable[[dict], None] | None = None,
     ):
         """
@@ -302,7 +300,7 @@ class MachineCmd:
 
     async def send_job(
         self,
-        machine: Machine,
+        machine: "Machine",
         on_progress: Callable[[dict], None] | None = None,
     ):
         """
@@ -316,7 +314,7 @@ class MachineCmd:
             on_progress=on_progress,
         )
 
-    def run_send_job(self, machine: Machine):
+    def run_send_job(self, machine: "Machine"):
         """
         Schedules the send_job coroutine to run via the task manager.
         """
@@ -330,7 +328,7 @@ class MachineCmd:
             key="send-job",
         )
 
-    def set_hold(self, machine: Machine, is_requesting_hold: bool):
+    def set_hold(self, machine: "Machine", is_requesting_hold: bool):
         """
         Adds a task to set the machine's hold state (pause/resume).
         """
@@ -339,21 +337,21 @@ class MachineCmd:
             lambda ctx: driver.set_hold(is_requesting_hold), key="set-hold"
         )
 
-    def cancel_job(self, machine: Machine):
+    def cancel_job(self, machine: "Machine"):
         """Adds a task to cancel the currently running job on the machine."""
         driver = machine.driver
         self._editor.task_manager.add_coroutine(
             lambda ctx: driver.cancel(), key="cancel-job"
         )
 
-    def clear_alarm(self, machine: Machine):
+    def clear_alarm(self, machine: "Machine"):
         """Adds a task to clear any active alarm on the machine."""
         driver = machine.driver
         self._editor.task_manager.add_coroutine(
             lambda ctx: driver.clear_alarm(), key="clear-alarm"
         )
 
-    def jog(self, machine: Machine, deltas: dict[Axis, float], speed: int):
+    def jog(self, machine: "Machine", deltas: "dict[Axis, float]", speed: int):
         """
         Adds a task to jog the machine along specific axes.
         """
@@ -361,7 +359,7 @@ class MachineCmd:
             lambda ctx: machine.jog(deltas, speed)
         )
 
-    def execute_macro_by_uid(self, machine: Machine, macro_uid: str):
+    def execute_macro_by_uid(self, machine: "Machine", macro_uid: str):
         """Finds a macro by UID, expands it, and runs it on the machine."""
         macro = machine.macros.get(macro_uid)
         if not macro or not macro.enabled:
@@ -390,9 +388,9 @@ class MachineCmd:
 
     def set_power(
         self,
-        head: Laser,
+        head: "Laser",
         percent: float,
-        machine: Machine | None = None,
+        machine: "Machine | None" = None,
     ):
         """
         Adds a task to set the laser power to a specific percentage.
@@ -411,9 +409,9 @@ class MachineCmd:
 
     def set_focus_power(
         self,
-        head: Laser,
+        head: "Laser",
         percent: float,
-        machine: Machine | None = None,
+        machine: "Machine | None" = None,
     ):
         """
         Adds a task to set the laser power for focus mode.
@@ -430,11 +428,11 @@ class MachineCmd:
                 lambda ctx: machine.set_focus_power(head, percent)
             )
 
-    def home(self, machine: Machine, axis: Axis | None = None):
+    def home(self, machine: "Machine", axis: "Axis | None" = None):
         """Adds a task to home a specific axis."""
         self._editor.task_manager.add_coroutine(lambda ctx: machine.home(axis))
 
-    def move_to(self, machine: Machine, x: float, y: float):
+    def move_to(self, machine: "Machine", x: float, y: float):
         """Adds a task to move to an absolute position."""
         driver = machine.driver
         if driver:
@@ -443,7 +441,7 @@ class MachineCmd:
             )
 
 
-def _create_driver_encoder(machine: Machine):
+def _create_driver_encoder(machine: "Machine"):
     """Instantiate the machine's driver encoder."""
     if machine.driver_name:
         try:

--- a/rayforge/machine/job_monitor.py
+++ b/rayforge/machine/job_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import time
 from collections import deque
@@ -25,7 +23,7 @@ class JobMonitor:
     with detailed metrics whenever the progress changes.
     """
 
-    def __init__(self, ops: Ops):
+    def __init__(self, ops: "Ops"):
         """
         Initializes the JobMonitor.
 

--- a/rayforge/machine/kinematic_mapping.py
+++ b/rayforge/machine/kinematic_mapping.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
@@ -54,11 +52,11 @@ class RotaryAxisConfig:
 
     source_axis: Axis
     rotary_axis: Axis | None
-    module: RotaryModule | None = None
+    module: "RotaryModule | None" = None
 
 
 def resolve_layer_rotary(
-    layer: Layer | None, machine: Machine
+    layer: Layer | None, machine: "Machine"
 ) -> RotaryAxisConfig:
     """Resolve the rotary axis configuration for *layer*.
 
@@ -82,9 +80,9 @@ def resolve_layer_rotary(
 
 
 def build_layer_assembly(
-    machine: Machine,
+    machine: "Machine",
     layer: Layer | None = None,
-) -> Assembly:
+) -> "Assembly":
     """Build a throwaway assembly for *layer*'s rotary config.
 
     Reads only: it resolves the layer's rotary module via
@@ -140,10 +138,10 @@ class KinematicMapping:
     @classmethod
     def from_rotary_module(
         cls,
-        module: RotaryModule,
+        module: "RotaryModule",
         diameter: float,
         apply_gear_ratio: bool = True,
-    ) -> KinematicMapping | None:
+    ) -> "KinematicMapping | None":
         if module.mode == RotaryMode.TRUE_4TH_AXIS:
             rotary_axis = module.axis
             replaced_axis = None
@@ -227,8 +225,8 @@ class KinematicMapping:
     @staticmethod
     def apply_to_job_ops(
         ops: Ops,
-        doc: Doc,
-        machine: Machine,
+        doc: "Doc",
+        machine: "Machine",
         apply_scaled_mu: bool = False,
         apply_gear_ratio: bool = True,
     ) -> None:

--- a/rayforge/machine/models/dialect/base.py
+++ b/rayforge/machine/models/dialect/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import uuid
 from dataclasses import (
@@ -209,7 +207,7 @@ class GcodeDialect:
             "scripts": scripts_vs,
         }
 
-    def copy_as_custom(self, new_label: str) -> GcodeDialect:
+    def copy_as_custom(self, new_label: str) -> "GcodeDialect":
         """
         Creates a new, custom dialect instance from this one, generating a
         new UID.
@@ -232,8 +230,8 @@ class GcodeDialect:
     def from_dict(
         cls,
         data: dict[str, Any],
-        registry: dict[str, GcodeDialect] | None = None,
-    ) -> GcodeDialect:
+        registry: "dict[str, GcodeDialect] | None" = None,
+    ) -> "GcodeDialect":
         """
         Creates a dialect instance from a dictionary, correctly handling
         missing fields by inheriting from parent dialect.
@@ -343,7 +341,7 @@ class GcodeDialect:
     @classmethod
     def from_template_dict(
         cls, data: dict[str, Any], **overrides
-    ) -> GcodeDialect:
+    ) -> "GcodeDialect":
         """
         Create a dialect from a device profile template dict.
 

--- a/rayforge/machine/models/macro.py
+++ b/rayforge/machine/models/macro.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
@@ -58,7 +56,7 @@ class Macro:
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Macro:
+    def from_dict(cls, data: dict[str, Any]) -> "Macro":
         """Creates a macro instance from a dictionary."""
         known_keys = {"uid", "name", "code", "enabled"}
         extra = {k: v for k, v in data.items() if k not in known_keys}

--- a/rayforge/machine/sanity/checker.py
+++ b/rayforge/machine/sanity/checker.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
@@ -20,7 +18,7 @@ from .checks.workarea_2d import WorkareaCheck2D
 @dataclass
 class SanityContext:
     ops: Ops
-    machine: Machine
+    machine: "Machine"
     work_area: Rect
     axis_extents: tuple[float, float]
     enabled_zones: dict[str, Zone]
@@ -38,7 +36,7 @@ class SanityChecker:
         NoGoZoneCheck2D,
     ]
 
-    def __init__(self, machine: Machine):
+    def __init__(self, machine: "Machine"):
         self._machine = machine
 
     def check(

--- a/rayforge/pipeline/artifact/base.py
+++ b/rayforge/pipeline/artifact/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 

--- a/rayforge/pipeline/artifact/handle.py
+++ b/rayforge/pipeline/artifact/handle.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 from abc import ABC
 from typing import Any
 
-_handle_registry: dict[str, type[BaseArtifactHandle]] = {}
+_handle_registry: "dict[str, type[BaseArtifactHandle]]" = {}
 
 
 class BaseArtifactHandle(ABC):
@@ -56,7 +54,9 @@ class BaseArtifactHandle(ABC):
         return hash(self.key)
 
     @classmethod
-    def from_dict(cls: type[Any], data: dict[str, Any]) -> BaseArtifactHandle:
+    def from_dict(
+        cls: type[Any], data: dict[str, Any]
+    ) -> "BaseArtifactHandle":
         # This simple deserialization works for direct instantiation, but the
         # factory function below should be used for polymorphic
         # deserialization.

--- a/rayforge/pipeline/artifact/job.py
+++ b/rayforge/pipeline/artifact/job.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Any
 
 from raygeo.ops import Ops
@@ -57,7 +55,7 @@ class JobArtifact(BaseArtifact):
         generation_id: int,
         time_estimate: float | None = None,
         mapped_ops: Ops | None = None,
-        encoded_output: EncodedOutput | None = None,
+        encoded_output: "EncodedOutput | None" = None,
     ):
         super().__init__()
         self.ops = ops
@@ -86,7 +84,7 @@ class JobArtifact(BaseArtifact):
         return encoded.text if encoded else None
 
     @property
-    def op_map(self) -> MachineCodeOpMap | None:
+    def op_map(self) -> "MachineCodeOpMap | None":
         """
         Lazily decodes and caches the MachineCodeOpMap from encoded_output.
         """
@@ -94,7 +92,7 @@ class JobArtifact(BaseArtifact):
         return encoded.op_map if encoded else None
 
     @property
-    def encoded_output(self) -> EncodedOutput | None:
+    def encoded_output(self) -> "EncodedOutput | None":
         """Returns the cached EncodedOutput, if any."""
         return self._encoded_output
 
@@ -111,7 +109,7 @@ class JobArtifact(BaseArtifact):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> JobArtifact:
+    def from_dict(cls, data: dict[str, Any]) -> "JobArtifact":
         """Creates an artifact from a dictionary."""
         ops = Ops.from_dict(data["ops"])
         common_args = {

--- a/rayforge/pipeline/artifact/step_ops.py
+++ b/rayforge/pipeline/artifact/step_ops.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Any
 
 from .base import BaseArtifact
@@ -36,7 +34,7 @@ class StepOpsArtifact(BaseArtifact):
 
     def __init__(
         self,
-        ops: Ops,
+        ops: "Ops",
         generation_id: int,
     ):
         super().__init__()

--- a/rayforge/pipeline/artifact/store.py
+++ b/rayforge/pipeline/artifact/store.py
@@ -9,8 +9,6 @@ Lifecycle is managed through reference counting via
 :meth:`retain` / :meth:`release`.
 """
 
-from __future__ import annotations
-
 import logging
 import uuid
 from collections.abc import Generator

--- a/rayforge/pipeline/artifact/workpiece.py
+++ b/rayforge/pipeline/artifact/workpiece.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -47,7 +45,7 @@ class WorkPieceArtifact(BaseArtifact):
 
     def __init__(
         self,
-        ops: Ops,
+        ops: "Ops",
         is_scalable: bool,
         generation_size: tuple[float, float],
         generation_id: int,

--- a/rayforge/pipeline/artifact/workpiece_view.py
+++ b/rayforge/pipeline/artifact/workpiece_view.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -42,7 +40,7 @@ class RenderContext:
         return d
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RenderContext:
+    def from_dict(cls, data: dict[str, Any]) -> "RenderContext":
         """Deserializes a RenderContext from a dictionary."""
         OpsColorMode = _get_ops_color_mode_enum()
         mode = data.get("ops_color_mode", OpsColorMode.LASER.value)

--- a/rayforge/pipeline/intent_builder.py
+++ b/rayforge/pipeline/intent_builder.py
@@ -33,8 +33,6 @@ representation of the inputs that affect a node's output:
   transformer_params + position_sensitive())``.
 """
 
-from __future__ import annotations
-
 import asyncio
 import hashlib
 import json
@@ -146,7 +144,7 @@ class IntentBuilder:
 
     def __init__(
         self,
-        machine: Machine,
+        machine: "Machine",
         generation_id: int = 0,
         loop: asyncio.AbstractEventLoop | None = None,
     ):
@@ -159,7 +157,7 @@ class IntentBuilder:
     def generation_id(self) -> int:
         return self._generation_id
 
-    def build(self, doc: Doc) -> list[NodeRequest]:
+    def build(self, doc: "Doc") -> list[NodeRequest]:
         """
         Walk *doc* and produce one NodeRequest per workpiece-step pair,
         one per step, and one final job aggregate.
@@ -213,10 +211,10 @@ class IntentBuilder:
 
     def _build_workpiece_nodes(
         self,
-        step: Step,
-        workpieces: Sequence[WorkPiece],
+        step: "Step",
+        workpieces: "Sequence[WorkPiece]",
         out: list[NodeRequest],
-    ) -> list[tuple[str, int, WorkPiece]]:
+    ) -> "list[tuple[str, int, WorkPiece]]":
         """
         Append one compute NodeRequest per workpiece for *step* and
         return the list of ``(node_key, version_token, workpiece)``
@@ -261,9 +259,9 @@ class IntentBuilder:
 
     def _build_step_node(
         self,
-        step: Step,
-        layer: Layer,
-        upstream: list[tuple[str, int, WorkPiece]],
+        step: "Step",
+        layer: "Layer",
+        upstream: "list[tuple[str, int, WorkPiece]]",
         out: list[NodeRequest],
     ) -> None:
         key = step_key(step.uid)
@@ -277,7 +275,7 @@ class IntentBuilder:
 
     def _build_job_node(
         self,
-        doc: Doc,
+        doc: "Doc",
         out: list[NodeRequest],
         step_tokens: dict[str, int],
     ) -> None:
@@ -291,7 +289,7 @@ class IntentBuilder:
 
     def _build_machine_transform_node(
         self,
-        doc: Doc,
+        doc: "Doc",
         out: list[NodeRequest],
         step_tokens: dict[str, int],
     ) -> None:
@@ -318,7 +316,7 @@ class IntentBuilder:
 
     def _build_encoder_node(
         self,
-        doc: Doc,
+        doc: "Doc",
         out: list[NodeRequest],
         step_tokens: dict[str, int],
     ) -> None:
@@ -365,7 +363,7 @@ class IntentBuilder:
         return _hash_int({"kind": "stock", "items": payload})
 
     def _compute_token(
-        self, step: Step, wp: WorkPiece, pos_sensitive: bool
+        self, step: "Step", wp: "WorkPiece", pos_sensitive: bool
     ) -> int:
         payload = {
             "kind": "compute",
@@ -395,9 +393,9 @@ class IntentBuilder:
 
     def _aggregate_token(
         self,
-        step: Step,
-        layer: Layer,
-        upstream: list[tuple[str, int, WorkPiece]],
+        step: "Step",
+        layer: "Layer",
+        upstream: "list[tuple[str, int, WorkPiece]]",
     ) -> int:
         # Fold the per-workpiece placement matrix and target dimensions
         # into the token. The aggregate applies the placement matrix
@@ -427,7 +425,7 @@ class IntentBuilder:
             payload["stock_rev"] = self._stock_revision()
         return _hash_int(payload)
 
-    def _job_token(self, doc: Doc, step_tokens: dict[str, int]) -> int:
+    def _job_token(self, doc: "Doc", step_tokens: dict[str, int]) -> int:
         # The job aggregate concatenates the step aggregates' outputs
         # verbatim (identity placement at the job level). Its token
         # therefore folds in the per-step aggregate tokens so that any
@@ -472,7 +470,7 @@ class IntentBuilder:
     # Compute stage construction
     # ------------------------------------------------------------------
 
-    def _wp_stage(self, step: Step, wp: WorkPiece) -> StageSpec.Compute:
+    def _wp_stage(self, step: "Step", wp: "WorkPiece") -> StageSpec.Compute:
         """
         Build a compute :class:`StageSpec.Compute` for the workpiece
         node by delegating to :meth:`Step.build_compute_payload`.
@@ -508,7 +506,7 @@ class IntentBuilder:
                         ]
         return StageSpec.Compute(part=part, params=payload)
 
-    def _assembler_params(self, step: Step, wp: WorkPiece) -> Any:
+    def _assembler_params(self, step: "Step", wp: "WorkPiece") -> Any:
         """
         Return a JSON-serialisable representation of the assembler spec
         parameters that the step resolves for its machine.
@@ -535,7 +533,7 @@ class IntentBuilder:
         self,
         transformer_dicts: list[dict[str, Any]],
         *,
-        workpiece: WorkPiece | None = None,
+        workpiece: "WorkPiece | None" = None,
     ) -> list[Any]:
         """Build typed Rust ``*Spec`` pyclasses from a list of
         serialised transformer dicts.
@@ -648,8 +646,8 @@ class IntentBuilder:
 
     def _step_stage(
         self,
-        step: Step,
-        upstream: list[tuple[str, int, WorkPiece]],
+        step: "Step",
+        upstream: "list[tuple[str, int, WorkPiece]]",
     ) -> StageSpec.Aggregate:
         """
         Build an aggregate :class:`StageSpec.Aggregate` for the step
@@ -718,7 +716,7 @@ class IntentBuilder:
     # ------------------------------------------------------------------
 
     def _job_stage(
-        self, doc: Doc, step_tokens: dict[str, int]
+        self, doc: "Doc", step_tokens: dict[str, int]
     ) -> StageSpec.Aggregate:
         """
         Build the final job aggregate :class:`StageSpec.Aggregate`.
@@ -773,7 +771,7 @@ class IntentBuilder:
     # Encoder stage
     # ------------------------------------------------------------------
 
-    def _encode_stage(self, doc: Doc) -> EncodeSpec:
+    def _encode_stage(self, doc: "Doc") -> EncodeSpec:
         """Build the encoder :class:`EncodeSpec` for the job encode
         node.
 
@@ -789,7 +787,7 @@ class IntentBuilder:
             source_key=job_machinexform_key(), encoder=Encoder(encoder)
         )
 
-    def _build_encoder(self, doc: Doc) -> Any:
+    def _build_encoder(self, doc: "Doc") -> Any:
         """Resolve the encoder for the configured machine.
 
         Routes Grbl machines to the native Rust ``GcodeSpec`` and
@@ -810,7 +808,7 @@ class IntentBuilder:
             "driver.encode",
         )
 
-    def _grbl_encoder_spec(self, doc: Doc) -> GcodeSpec:
+    def _grbl_encoder_spec(self, doc: "Doc") -> GcodeSpec:
         """Build a native ``GcodeSpec`` for a Grbl machine.
 
         Receives machine-space ops from the upstream
@@ -833,7 +831,9 @@ class IntentBuilder:
             context_json=json.dumps(context),
         )
 
-    def _build_machine_transform_stage(self, doc: Doc) -> MachineTransformSpec:
+    def _build_machine_transform_stage(
+        self, doc: "Doc"
+    ) -> MachineTransformSpec:
         """Build the :class:`MachineTransformSpec` for the machine-
         transform pipeline node.
 
@@ -884,8 +884,8 @@ class IntentBuilder:
 
     @staticmethod
     def _build_rotary_mappings(
-        doc: Doc,
-        machine: Machine,
+        doc: "Doc",
+        machine: "Machine",
     ) -> list:
         """Build per-layer :class:`RotaryMappingSpec` entries."""
         mappings: list = []
@@ -939,7 +939,7 @@ class IntentBuilder:
         return mappings
 
     def _make_python_encoder_callable(
-        self, machine: Machine, doc: Doc
+        self, machine: "Machine", doc: "Doc"
     ) -> Callable[[Any], Any]:
         """Build a Python callable ``(ops) -> EncodeOutput`` that
         invokes the driver-specific encoder directly on
@@ -979,7 +979,7 @@ class IntentBuilder:
     # Encoder token
     # ------------------------------------------------------------------
 
-    def _encode_token(self, doc: Doc, step_tokens: dict[str, int]) -> int:
+    def _encode_token(self, doc: "Doc", step_tokens: dict[str, int]) -> int:
         """Compute the version token for the job encode node.
 
         Folds in the machine-transform node's token plus the encoder
@@ -994,7 +994,7 @@ class IntentBuilder:
         return _hash_int(payload)
 
     def _machine_transform_token(
-        self, doc: Doc, step_tokens: dict[str, int]
+        self, doc: "Doc", step_tokens: dict[str, int]
     ) -> int:
         """Compute the version token for the machine-transform node.
 
@@ -1018,7 +1018,7 @@ class IntentBuilder:
 # ----------------------------------------------------------------------
 
 
-def _workpiece_placement_matrix(wp: WorkPiece) -> list[list[float]]:
+def _workpiece_placement_matrix(wp: "WorkPiece") -> list[list[float]]:
     """
     Build the 4×4 placement matrix for a workpiece's aggregate input.
 
@@ -1079,12 +1079,12 @@ _IDENTITY_4X4: list[list[float]] = [
 ]
 
 
-def _is_grbl(dialect: GcodeDialect) -> bool:
+def _is_grbl(dialect: "GcodeDialect") -> bool:
     """Return True if *dialect* is the Grbl G-code dialect."""
     return dialect.uid == GRBL_DIALECT.uid
 
 
-def _machine_token_payload(machine: Machine | None) -> Any:
+def _machine_token_payload(machine: "Machine | None") -> Any:
     """Build a JSON-serialisable representation of the machine
     identity for the encode token."""
     if machine is None:
@@ -1104,7 +1104,7 @@ def _machine_token_payload(machine: Machine | None) -> Any:
 
 
 def _machine_transform_config_payload(
-    machine: Machine, doc: Doc
+    machine: "Machine", doc: "Doc"
 ) -> dict[str, Any]:
     """Build a JSON-serialisable payload of machine transform config
     for the machine-transform token."""
@@ -1131,7 +1131,7 @@ def _machine_transform_config_payload(
     return payload
 
 
-def _approximate_job_ops(doc: Doc) -> Ops:
+def _approximate_job_ops(doc: "Doc") -> Ops:
     """Build a minimal Ops spanning the estimated job extents.
 
     Used by :meth:`IntentBuilder._grbl_encoder_spec` so that

--- a/rayforge/pipeline/intent_controller.py
+++ b/rayforge/pipeline/intent_controller.py
@@ -24,8 +24,6 @@ On each debounced rebuild:
    application main thread via the shared task manager.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 from gettext import gettext as _
@@ -115,9 +113,9 @@ class IntentController:
 
     def __init__(
         self,
-        doc: Doc | None,
+        doc: "Doc | None",
         task_manager: _DelayedScheduler,
-        machine: Machine | None = None,
+        machine: "Machine | None" = None,
         raygeo_pipeline: RaygeoPipeline | None = None,
     ):
         self._doc: Doc | None = doc
@@ -252,7 +250,7 @@ class IntentController:
             return
         self._schedule_rebuild()
 
-    def set_doc(self, doc: Doc | None) -> None:
+    def set_doc(self, doc: "Doc | None") -> None:
         """Replace the document and trigger a rebuild.
 
         Preserves the existing :class:`RaygeoPipeline` and
@@ -265,7 +263,7 @@ class IntentController:
             self.connect()
         self.force_rebuild()
 
-    def set_machine(self, machine: Machine | None) -> None:
+    def set_machine(self, machine: "Machine | None") -> None:
         """Replace the machine and trigger a rebuild.
 
         Preserves the existing :class:`RaygeoPipeline` and
@@ -508,7 +506,7 @@ class IntentController:
             )
         return text
 
-    def _reattach(self, key: str, item: DocItem, output: Any) -> None:
+    def _reattach(self, key: str, item: "DocItem", output: Any) -> None:
         """
         Reattach a completed node's output onto the owning DocItem and
         emit the corresponding signal so the UI can update.
@@ -611,10 +609,10 @@ class IntentController:
             elif key == "job" or key == "job:encode":
                 self._key_to_item[key] = self._doc
 
-    def _find_workpiece(self, uid: str) -> WorkPiece | None:
+    def _find_workpiece(self, uid: str) -> "WorkPiece | None":
         return self._workpieces_by_uid.get(uid)
 
-    def _find_step(self, uid: str) -> Step | None:
+    def _find_step(self, uid: str) -> "Step | None":
         return self._steps_by_uid.get(uid)
 
     def shutdown(self) -> None:

--- a/rayforge/pipeline/pipeline.py
+++ b/rayforge/pipeline/pipeline.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 from collections.abc import Callable, Generator
@@ -52,9 +50,9 @@ class Pipeline:
     def __init__(
         self,
         doc: Doc | None,
-        task_manager: TaskManager,
+        task_manager: "TaskManager",
         artifact_store: ArtifactStore,
-        machine: Machine | None,
+        machine: "Machine | None",
         cache_budget_bytes: int = 2 * 1024 * 1024 * 1024,
     ):
         if machine is None:
@@ -160,11 +158,11 @@ class Pipeline:
         self._intent_ctl.set_doc(new_doc)
 
     @property
-    def machine(self) -> Machine | None:
+    def machine(self) -> "Machine | None":
         return self._machine
 
     @property
-    def task_manager(self) -> TaskManager:
+    def task_manager(self) -> "TaskManager":
         return self._task_manager
 
     @property
@@ -224,7 +222,7 @@ class Pipeline:
     # Machine
     # ------------------------------------------------------------------
 
-    def set_machine(self, machine: Machine) -> None:
+    def set_machine(self, machine: "Machine") -> None:
         if self._machine is machine:
             return
         if self._machine is not None:
@@ -406,7 +404,7 @@ class Pipeline:
     ) -> BaseArtifactHandle | None:
         return self._wp_handles.get((workpiece_uid, step_uid))
 
-    def get_artifact(self, step: Step, workpiece: WorkPiece) -> Any:
+    def get_artifact(self, step: "Step", workpiece: WorkPiece) -> Any:
         handle = self._wp_handles.get((workpiece.uid, step.uid))
         if handle is None:
             return None

--- a/rayforge/pipeline/stage/assembler_helpers.py
+++ b/rayforge/pipeline/stage/assembler_helpers.py
@@ -7,8 +7,6 @@ and result-wrapping logic that currently lives inside each producer's
 directly without needing producer class instances.
 """
 
-from __future__ import annotations
-
 import logging
 from enum import Enum, auto
 from gettext import gettext as _
@@ -98,8 +96,8 @@ class DepthMode(Enum):
 
 
 def _trace_surface_to_mm_geometry(
-    surface: cairo.ImageSurface,
-    workpiece: WorkPiece,
+    surface: "cairo.ImageSurface",
+    workpiece: "WorkPiece",
     threshold: float = 0.5,
     auto_threshold: bool = True,
     invert: bool = False,
@@ -141,8 +139,8 @@ def _trace_surface_to_mm_geometry(
 
 
 def build_part_vector(
-    workpiece: WorkPiece,
-    surface: cairo.ImageSurface | None = None,
+    workpiece: "WorkPiece",
+    surface: "cairo.ImageSurface | None" = None,
     *,
     override_threshold: bool = False,
     threshold: float = 0.5,
@@ -220,7 +218,7 @@ MAX_VECTOR_TRACE_PIXELS = 16 * 1024 * 1024
 
 
 def build_part_vector_with_raster_fallback(
-    workpiece: WorkPiece,
+    workpiece: "WorkPiece",
     pixels_per_mm: tuple[float, float],
     *,
     override_threshold: bool = False,
@@ -283,7 +281,7 @@ def build_part_vector_with_raster_fallback(
 
 
 def preprocess_raster_image(
-    surface: cairo.ImageSurface,
+    surface: "cairo.ImageSurface",
     *,
     mode: DepthMode,
     invert: bool = False,
@@ -396,7 +394,7 @@ def _apply_raster_levels(
 
 
 def compute_raster_auto_levels(
-    workpiece: WorkPiece,
+    workpiece: "WorkPiece",
     pixels_per_mm: tuple[float, float],
     *,
     invert: bool = False,

--- a/rayforge/pipeline/transformer/base.py
+++ b/rayforge/pipeline/transformer/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -60,7 +58,7 @@ class OpsTransformer(ABC):
     def to_spec(
         self,
         workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ) -> Any:
         """Return the typed Rust spec for this transformer.
@@ -81,7 +79,7 @@ class OpsTransformer(ABC):
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> OpsTransformer:
+    def from_dict(cls, data: dict[str, Any]) -> "OpsTransformer":
         """
         Acts as a factory to create a transformer instance from a dictionary.
         This method should be called on the base class, e.g.,

--- a/rayforge/pipeline/transformer/placeholder.py
+++ b/rayforge/pipeline/transformer/placeholder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -48,8 +46,8 @@ class PlaceholderTransformer(OpsTransformer):
 
     def to_spec(
         self,
-        workpiece: WorkPiece | None,
-        stock_geometries: list[Geometry] | None,
+        workpiece: "WorkPiece | None",
+        stock_geometries: "list[Geometry] | None",
         settings: dict[str, Any] | None,
     ):
         raise RuntimeError(
@@ -58,6 +56,6 @@ class PlaceholderTransformer(OpsTransformer):
         )
 
     @classmethod
-    def from_dict(cls, data: dict) -> PlaceholderTransformer:
+    def from_dict(cls, data: dict) -> "PlaceholderTransformer":
         original_name = data.get("name", "Unknown")
         return cls(original_name, data)

--- a/rayforge/pipeline/view/view_compute.py
+++ b/rayforge/pipeline/view/view_compute.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 

--- a/rayforge/pipeline/view/view_manager.py
+++ b/rayforge/pipeline/view/view_manager.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import threading
 import uuid
@@ -79,9 +77,9 @@ class ViewManager:
 
     def __init__(
         self,
-        pipeline: Pipeline,
-        artifact_store: ArtifactStore,
-        machine: Machine | None,
+        pipeline: "Pipeline",
+        artifact_store: "ArtifactStore",
+        machine: "Machine | None",
     ):
         self._pipeline = pipeline
         self._store = artifact_store
@@ -226,7 +224,7 @@ class ViewManager:
         return self._view_generation_id
 
     @property
-    def store(self) -> ArtifactStore:
+    def store(self) -> "ArtifactStore":
         """Returns the artifact store."""
         return self._store
 
@@ -392,8 +390,8 @@ class ViewManager:
         self,
         sender,
         *,
-        step: Step,
-        workpiece: WorkPiece,
+        step: "Step",
+        workpiece: "WorkPiece",
         handle: BaseArtifactHandle,
         **kwargs,
     ) -> None:
@@ -623,7 +621,7 @@ class ViewManager:
         # pure computation — no store access.
         artifact = self._store.get(source_handle)
 
-        def when_done_callback(task: Task):
+        def when_done_callback(task: "Task"):
             logger.debug(
                 f"[{key}] when_done_callback called, "
                 f"task_status={task.get_status()}"
@@ -747,7 +745,7 @@ class ViewManager:
 
     def _on_render_complete(
         self,
-        task: Task,
+        task: "Task",
         key: str,
         view_id: int,
         workpiece_uid: str,
@@ -770,7 +768,7 @@ class ViewManager:
 
     def allocate_live_buffer(
         self,
-        workpiece: WorkPiece,
+        workpiece: "WorkPiece",
         step_uid: str,
         view_id: int,
         generation_id: int,
@@ -837,8 +835,8 @@ class ViewManager:
         self,
         sender,
         *,
-        step: Step,
-        workpiece: WorkPiece,
+        step: "Step",
+        workpiece: "WorkPiece",
         generation_id: int,
     ):
         """

--- a/rayforge/shared/gcodeedit/editor.py
+++ b/rayforge/shared/gcodeedit/editor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from blinker import Signal
 from gi.repository import Gdk, GLib, Gtk
 

--- a/rayforge/shared/gcodeedit/highlighter.py
+++ b/rayforge/shared/gcodeedit/highlighter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 
 from gi.repository import Gtk

--- a/rayforge/shared/gcodeedit/viewer.py
+++ b/rayforge/shared/gcodeedit/viewer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
@@ -125,7 +123,7 @@ class GcodeViewer(Gtk.Box):
         self.clear_highlight()
         self._update_status_bar()
 
-    def set_op_map(self, op_map: MachineCodeOpMap):
+    def set_op_map(self, op_map: "MachineCodeOpMap"):
         self.op_map = op_map
 
     def highlight_line(self, line_number: int, use_align: bool = True):

--- a/rayforge/shared/tasker/__init__.py
+++ b/rayforge/shared/tasker/__init__.py
@@ -2,8 +2,6 @@
 Tasker package for managing tasks, contexts, and execution.
 """
 
-from __future__ import annotations
-
 from .manager import TaskManager, TaskManagerProxy
 from .task import Task
 

--- a/rayforge/shared/tasker/manager.py
+++ b/rayforge/shared/tasker/manager.py
@@ -2,8 +2,6 @@
 TaskManager module for managing task execution.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import threading
@@ -36,7 +34,7 @@ class TaskManager:
         main_thread_scheduler: Callable,
         worker_initializer: Callable[..., None] | None = None,
         worker_initargs: tuple = (),
-        shared_state: DictProxy[str, Any] | None = None,
+        shared_state: "DictProxy[str, Any] | None" = None,
     ) -> None:
         logger.debug("Initializing TaskManager")
         self._tasks: dict[Any, Task] = {}
@@ -570,7 +568,7 @@ class TaskManager:
         task_id,
         event_name,
         data,
-        adoption_signals: DictProxy[str, bool],
+        adoption_signals: "DictProxy[str, bool]",
     ):
         signal_key = f"{task_id}:{event_name}"
         logger.debug(
@@ -658,7 +656,7 @@ class TaskManager:
         task_id: int,
         event_name: str,
         data: dict,
-        adoption_signals: DictProxy[str, Any],
+        adoption_signals: "DictProxy[str, Any]",
     ):
         """Dispatches a task event from the main thread."""
         with self._lock:

--- a/rayforge/shared/tasker/pool.py
+++ b/rayforge/shared/tasker/pool.py
@@ -3,8 +3,6 @@ Defines the WorkerPoolManager, a class for managing a pool of long-lived
 worker processes to execute tasks efficiently.
 """
 
-from __future__ import annotations
-
 import builtins
 import logging
 import os
@@ -65,8 +63,8 @@ def _worker_main_loop(
     log_level: int,
     initializer: Callable[..., None] | None,
     initargs: tuple[Any, ...],
-    adoption_signals: DictProxy[str, bool],
-    shared_state: DictProxy[str, Any],
+    adoption_signals: "DictProxy[str, bool]",
+    shared_state: "DictProxy[str, Any]",
 ):
     """
     The main function for a worker process.
@@ -256,7 +254,7 @@ class WorkerPoolManager:
         num_workers: int | None = None,
         initializer: Callable[..., None] | None = None,
         initargs: tuple[Any, ...] = (),
-        shared_state: DictProxy[str, Any] | None = None,
+        shared_state: "DictProxy[str, Any] | None" = None,
     ):
         if num_workers is None:
             env_max = os.environ.get("RAYFORGE_MAX_WORKERS")

--- a/rayforge/shared/tasker/task.py
+++ b/rayforge/shared/tasker/task.py
@@ -2,8 +2,6 @@
 Task module for managing individual tasks.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 from asyncio.exceptions import CancelledError
@@ -23,7 +21,7 @@ class Task:
         coro: Callable[..., Coroutine[Any, Any, Any]],
         *args: Any,
         key: Any | None = None,
-        when_done: Callable[[Task], None] | None = None,
+        when_done: "Callable[[Task], None] | None" = None,
         task_type: str = "asyncio",
         **kwargs: Any,
     ):

--- a/rayforge/shared/util/debug.py
+++ b/rayforge/shared/util/debug.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import logging
 

--- a/rayforge/simulator/machine_state.py
+++ b/rayforge/simulator/machine_state.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
@@ -37,7 +35,7 @@ class MachineState:
         self.current_layer_uid: str | None = None
 
     @classmethod
-    def from_axis_set(cls, axis_set: AxisSet) -> MachineState:
+    def from_axis_set(cls, axis_set: "AxisSet") -> "MachineState":
         axes = (cfg.letter for cfg in axis_set.configs)
         return cls(axis_letters=axes)
 
@@ -75,7 +73,7 @@ class MachineState:
         elif ct == CommandType.LAYER_START:
             self.current_layer_uid = ops.layer_uid(idx)
 
-    def copy(self) -> MachineState:
+    def copy(self) -> "MachineState":
         new = MachineState.__new__(MachineState)
         new.power = self.power
         new.air_assist = self.air_assist

--- a/rayforge/simulator/scene3d/compiled_scene.py
+++ b/rayforge/simulator/scene3d/compiled_scene.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -14,10 +12,10 @@ if TYPE_CHECKING:
 
 @dataclass
 class VertexLayer:
-    powered_verts: CompressedArray
-    powered_attrib: CompressedArray
-    travel_verts: CompressedArray
-    zero_power_verts: CompressedArray
+    powered_verts: "CompressedArray"
+    powered_attrib: "CompressedArray"
+    travel_verts: "CompressedArray"
+    zero_power_verts: "CompressedArray"
     powered_cmd_offsets: np.ndarray = field(
         default_factory=lambda: np.array([], dtype=np.int32)
     )
@@ -29,7 +27,7 @@ class VertexLayer:
 
 @dataclass
 class TextureLayer:
-    power_texture: CompressedArray
+    power_texture: "CompressedArray"
     width_px: int
     height_px: int
     model_matrix: np.ndarray
@@ -42,8 +40,8 @@ class TextureLayer:
 
 @dataclass
 class ScanlineOverlayLayer:
-    positions: CompressedArray
-    overlay_attrib: CompressedArray
+    positions: "CompressedArray"
+    overlay_attrib: "CompressedArray"
     cmd_offsets: np.ndarray
     is_rotary: bool = False
 

--- a/rayforge/simulator/scene3d/render_config.py
+++ b/rayforge/simulator/scene3d/render_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 
@@ -29,7 +27,7 @@ class LayerRenderConfig:
         return d
 
     @classmethod
-    def from_dict(cls, data: dict) -> LayerRenderConfig:
+    def from_dict(cls, data: dict) -> "LayerRenderConfig":
         ap3d = data.get("axis_position_3d")
         if ap3d is not None:
             ap3d = tuple(ap3d)
@@ -71,7 +69,7 @@ class RenderConfig3D:
         return d
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RenderConfig3D:
+    def from_dict(cls, data: dict[str, Any]) -> "RenderConfig3D":
         w2v = (
             np.frombuffer(data["world_to_visual"], dtype=np.float32)
             .reshape(4, 4)

--- a/rayforge/simulator/scene3d/scene_compiler.py
+++ b/rayforge/simulator/scene3d/scene_compiler.py
@@ -3,8 +3,6 @@ Scene compiler: thin wrapper that delegates vertex compilation to
 raygeo's Rust ``compile_scene_3d`` and handles texture generation.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 

--- a/rayforge/simulator/scene3d/scene_compiler_runner.py
+++ b/rayforge/simulator/scene3d/scene_compiler_runner.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import time
 from typing import Any

--- a/rayforge/ui_gtk/canvas/canvas.py
+++ b/rayforge/ui_gtk/canvas/canvas.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from collections.abc import Generator
@@ -168,7 +166,7 @@ class Canvas(Gtk.DrawingArea):
         """Gets the (width, height) of the canvas."""
         return self.root.size()
 
-    def _get_world_coords(self, widget_x: float, widget_y: float) -> Point:
+    def _get_world_coords(self, widget_x: float, widget_y: float) -> "Point":
         """
         Converts widget pixel coordinates to canvas world coordinates using
         the active view_transform.

--- a/rayforge/ui_gtk/canvas/element.py
+++ b/rayforge/ui_gtk/canvas/element.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Generator
@@ -56,8 +54,8 @@ class CanvasElement:
         selectable: bool = True,
         visible: bool = True,
         background: tuple[float, float, float, float] = (0, 0, 0, 0),
-        canvas: Canvas | None = None,
-        parent: Canvas | CanvasElement | None = None,
+        canvas: "Canvas | None" = None,
+        parent: "Canvas | CanvasElement | None" = None,
         data: Any = None,
         clip: bool = True,
         buffered: bool = False,
@@ -247,7 +245,7 @@ class CanvasElement:
         if isinstance(self.parent, CanvasElement):
             self.parent.on_child_transform_changed(self)
 
-    def on_child_transform_changed(self, child: CanvasElement):
+    def on_child_transform_changed(self, child: "CanvasElement"):
         """
         Callback triggered by a child when its transform has changed.
         Subclasses can override this to react, e.g., by updating bounds.
@@ -313,7 +311,7 @@ class CanvasElement:
         self._transform_dirty = False
         return self._world_transform
 
-    def get_world_bounding_box(self) -> Rect:
+    def get_world_bounding_box(self) -> "Rect":
         """
         Calculates the element's axis-aligned bounding box in world
         coordinates.
@@ -496,7 +494,7 @@ class CanvasElement:
         region: ElementRegion,
         base_handle_size: float,
         scale_compensation: float | tuple[float, float] = 1.0,
-    ) -> Rect:
+    ) -> "Rect":
         """
         Gets the rect (x, y, w, h) for a region in local coordinates.
 
@@ -582,11 +580,11 @@ class CanvasElement:
             for child in self.children:
                 child.mark_dirty(ancestors=False, recursive=True)
 
-    def copy(self) -> CanvasElement:
+    def copy(self) -> "CanvasElement":
         """Creates a deep copy of the element."""
         return deepcopy(self)
 
-    def _attach_to_canvas_recursive(self, canvas: Canvas | None):
+    def _attach_to_canvas_recursive(self, canvas: "Canvas | None"):
         """
         Recursively sets the canvas for self and all children, and calls
         the on_attached lifecycle hook.
@@ -606,7 +604,7 @@ class CanvasElement:
             child._detach_from_canvas_recursive()
         self.canvas = None
 
-    def _reparent(self, elem: CanvasElement):
+    def _reparent(self, elem: "CanvasElement"):
         """Removes an element from its current parent before adding it here."""
         if elem.parent:
             # Check parent type to call the correct removal method.
@@ -617,7 +615,7 @@ class CanvasElement:
             ):
                 elem.parent.remove(elem)
 
-    def add(self, elem: CanvasElement):
+    def add(self, elem: "CanvasElement"):
         """
         Adds a child element.
 
@@ -640,7 +638,7 @@ class CanvasElement:
         if self.canvas:
             self.canvas.queue_draw()
 
-    def insert(self, index: int, elem: CanvasElement):
+    def insert(self, index: int, elem: "CanvasElement"):
         """
         Inserts a child element at a specific index.
 
@@ -668,7 +666,7 @@ class CanvasElement:
         if self.canvas:
             self.canvas.queue_draw()
 
-    def find_by_data(self, data: Any) -> CanvasElement | None:
+    def find_by_data(self, data: Any) -> "CanvasElement | None":
         """
         Finds the first element (self or descendant) with matching data.
 
@@ -688,7 +686,7 @@ class CanvasElement:
 
     def find_by_type(
         self, thetype: Any
-    ) -> Generator[CanvasElement, None, None]:
+    ) -> "Generator[CanvasElement, None, None]":
         """
         Finds all elements (self or descendant) of a given type.
 
@@ -718,7 +716,7 @@ class CanvasElement:
 
     def get_all_children_recursive(
         self,
-    ) -> Generator[CanvasElement, None, None]:
+    ) -> "Generator[CanvasElement, None, None]":
         """
         Recursively yields all descendant elements.
         """
@@ -748,7 +746,7 @@ class CanvasElement:
         elif self.canvas and isinstance(self.parent, self.canvas.__class__):
             self.parent.remove(self)
 
-    def remove_child(self, elem: CanvasElement):
+    def remove_child(self, elem: "CanvasElement"):
         """
         Removes a direct child element. This is not recursive.
 
@@ -764,7 +762,7 @@ class CanvasElement:
             self.mark_dirty()
             self.on_child_list_changed()
 
-    def get_selected(self) -> Generator[CanvasElement, None, None]:
+    def get_selected(self) -> "Generator[CanvasElement, None, None]":
         """Recursively finds and yields all selected elements."""
         if self.selected:
             yield self
@@ -801,7 +799,7 @@ class CanvasElement:
         new_transform = self.transform.set_translation(x, y)
         self.set_transform(new_transform)
 
-    def pos_abs(self) -> Point:
+    def pos_abs(self) -> "Point":
         """
         Gets the absolute position on the canvas.
 
@@ -832,14 +830,14 @@ class CanvasElement:
             # Use set_transform to apply the change and notify parent
             self.set_transform(self.transform)
 
-    def rect(self) -> Rect:
+    def rect(self) -> "Rect":
         """
         Gets the local rect (x, y, width, height).
         """
         x, y = self.transform.get_translation()
         return x, y, self.width, self.height
 
-    def rect_abs(self) -> Rect:
+    def rect_abs(self) -> "Rect":
         """
         Gets the absolute rect (x, y, width, height).
 
@@ -866,7 +864,7 @@ class CanvasElement:
         world_transform = self.get_world_transform()
         return world_transform.get_rotation()
 
-    def get_world_center(self) -> Point:
+    def get_world_center(self) -> "Point":
         """
         Calculates the element's center point in world coordinates.
         """
@@ -1002,7 +1000,7 @@ class CanvasElement:
 
     def get_elem_hit(
         self, world_x: float, world_y: float, selectable: bool = False
-    ) -> CanvasElement | None:
+    ) -> "CanvasElement | None":
         """
         Checks for a hit on this element or its children given world
         coordinates.
@@ -1167,7 +1165,7 @@ class CanvasElement:
         """
         return False
 
-    def handle_drag_move(self, world_dx: float, world_dy: float) -> Point:
+    def handle_drag_move(self, world_dx: float, world_dy: float) -> "Point":
         """
         Intercepts a drag move to apply constraints. Subclasses can
         override this to customize drag behavior.

--- a/rayforge/ui_gtk/canvas/hittest.py
+++ b/rayforge/ui_gtk/canvas/hittest.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 import cairo
@@ -11,7 +9,7 @@ if TYPE_CHECKING:
 
 def check_pixel_hit(
     surface: cairo.ImageSurface,
-    content_transform: Matrix,
+    content_transform: "Matrix",
     element_width: float,
     element_height: float,
     hit_distance: float,

--- a/rayforge/ui_gtk/canvas/multiselect.py
+++ b/rayforge/ui_gtk/canvas/multiselect.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 from typing import (
@@ -23,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class MultiSelectionGroup:
-    def __init__(self, elements: list[CanvasElement], canvas: Canvas):
+    def __init__(self, elements: "list[CanvasElement]", canvas: "Canvas"):
         if not elements:
             raise ValueError(
                 "MultiSelectionGroup cannot be initialized with an "
@@ -60,7 +58,7 @@ class MultiSelectionGroup:
         return self._bounding_box[3]
 
     @property
-    def center(self) -> Point:
+    def center(self) -> "Point":
         return self._center
 
     def _calculate_bounding_box(self):
@@ -143,7 +141,7 @@ class MultiSelectionGroup:
         region: ElementRegion,
         base_handle_size: float,
         scale_compensation: float | tuple[float, float] = 1.0,
-    ) -> Rect:
+    ) -> "Rect":
         return get_region_rect(
             region,
             self.width,
@@ -189,8 +187,8 @@ class MultiSelectionGroup:
 
     def apply_resize(
         self,
-        new_box: Rect,
-        original_box: Rect,
+        new_box: "Rect",
+        original_box: "Rect",
     ):
         """
         Calculates a scale/translate transform that maps the original
@@ -217,7 +215,7 @@ class MultiSelectionGroup:
         )
         self._update_element_transforms()
 
-    def apply_rotate(self, angle_delta: float, center: Point | None = None):
+    def apply_rotate(self, angle_delta: float, center: "Point | None" = None):
         """
         Sets the group transform to a rotation around the group's initial
         center and updates elements.
@@ -232,7 +230,7 @@ class MultiSelectionGroup:
         active_region: ElementRegion,
         offset_x: float,
         offset_y: float,
-        active_origin: Rect,
+        active_origin: "Rect",
         ctrl_pressed: bool,
         shift_pressed: bool,
     ):
@@ -267,7 +265,7 @@ class MultiSelectionGroup:
         self,
         current_x: float,
         current_y: float,
-        rotation_pivot: Point,
+        rotation_pivot: "Point",
         drag_start_angle: float,
     ):
         """
@@ -290,7 +288,7 @@ class MultiSelectionGroup:
         active_region: ElementRegion,
         world_dx: float,
         world_dy: float,
-        active_origin: Rect,
+        active_origin: "Rect",
     ):
         """Shears the entire selection group."""
         shx, shy = 0.0, 0.0

--- a/rayforge/ui_gtk/canvas/overlays.py
+++ b/rayforge/ui_gtk/canvas/overlays.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from typing import (
     TYPE_CHECKING,
@@ -311,7 +309,7 @@ HANDLE_DRAW_INFO.update(
 
 def render_selection_frame(
     ctx: cairo.Context,
-    target: CanvasElement | MultiSelectionGroup,
+    target: "CanvasElement | MultiSelectionGroup",
     transform_to_screen: Matrix,
 ):
     """
@@ -346,7 +344,7 @@ def render_selection_frame(
 
 def _render_handles(
     ctx: cairo.Context,
-    target: CanvasElement | MultiSelectionGroup,
+    target: "CanvasElement | MultiSelectionGroup",
     transform_to_screen: Matrix,
     regions: list[ElementRegion],
     hovered_region: ElementRegion,
@@ -425,9 +423,9 @@ def _render_handles(
 
 def render_selection_handles(
     ctx: cairo.Context,
-    target: CanvasElement | MultiSelectionGroup,
+    target: "CanvasElement | MultiSelectionGroup",
     transform_to_screen: Matrix,
-    mode: SelectionMode,
+    mode: "SelectionMode",
     hovered_region: ElementRegion,
     base_handle_size: float,
     with_labels: bool = False,

--- a/rayforge/ui_gtk/canvas/region.py
+++ b/rayforge/ui_gtk/canvas/region.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
@@ -104,7 +102,7 @@ def get_region_rect(
     height: float,
     base_handle_size: float,
     scale_compensation: float | tuple[float, float] = 1.0,
-) -> Rect:
+) -> "Rect":
     """
     A generic function to calculate the rectangle (x, y, w, h) for a given
     region, relative to a bounding box of a given width and height.

--- a/rayforge/ui_gtk/canvas/shrinkwrap.py
+++ b/rayforge/ui_gtk/canvas/shrinkwrap.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from typing import cast
 

--- a/rayforge/ui_gtk/canvas/transform.py
+++ b/rayforge/ui_gtk/canvas/transform.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from typing import TYPE_CHECKING
 
@@ -25,14 +23,14 @@ RESIZE_BEHAVIORS = {
 
 
 def calculate_resized_box(
-    original_box: Rect,
+    original_box: "Rect",
     active_region: ElementRegion,
-    drag_delta: Point,
+    drag_delta: "Point",
     is_flipped: bool,
     constrain_aspect: bool = False,
     from_center: bool = False,
     min_size: tuple[float, float] = (0.0, 0.0),
-) -> Rect:
+) -> "Rect":
     """
     Calculates a new bounding box based on a resize operation.
     This is the central, data-driven logic for all resizing, and it
@@ -199,7 +197,7 @@ def rotate_element(
     world_x: float,
     world_y: float,
     initial_world_transform: Matrix,
-    rotation_pivot: Point,
+    rotation_pivot: "Point",
     drag_start_angle: float,
 ):
     """

--- a/rayforge/ui_gtk/canvas2d/context_menu.py
+++ b/rayforge/ui_gtk/canvas2d/context_menu.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 from gettext import gettext as _
@@ -73,8 +71,8 @@ class ContextMenuExtensionRegistry:
 
     def invoke_all(
         self,
-        surface: WorkSurface,
-        item: DocItem | None,
+        surface: "WorkSurface",
+        item: "DocItem | None",
         gesture: Gtk.Gesture,
         menu: Gio.Menu,
     ):
@@ -152,7 +150,7 @@ _MENU_MODELS = {
 
 
 def _show_popover(
-    surface: WorkSurface, gesture: Gtk.Gesture, menu_model: Gio.Menu
+    surface: "WorkSurface", gesture: Gtk.Gesture, menu_model: Gio.Menu
 ):
     """Helper to create and show a popover menu from a model."""
     popover = Gtk.PopoverMenu.new_from_model(menu_model)
@@ -171,9 +169,9 @@ def _show_popover(
 
 
 def show_item_context_menu(
-    surface: WorkSurface,
+    surface: "WorkSurface",
     gesture: Gtk.Gesture,
-    item: DocItem | None = None,
+    item: "DocItem | None" = None,
 ):
     """
     Displays the context menu for general items like WorkPieces or Groups.
@@ -196,17 +194,17 @@ def show_item_context_menu(
     _show_popover(surface, gesture, menu)
 
 
-def show_geometry_context_menu(surface: WorkSurface, gesture: Gtk.Gesture):
+def show_geometry_context_menu(surface: "WorkSurface", gesture: Gtk.Gesture):
     """Displays the context menu for adding a tab to a geometry path."""
     _show_popover(surface, gesture, _MENU_MODELS["geometry"])
 
 
-def show_tab_context_menu(surface: WorkSurface, gesture: Gtk.Gesture):
+def show_tab_context_menu(surface: "WorkSurface", gesture: Gtk.Gesture):
     """Displays the context menu for an existing tab."""
     _show_popover(surface, gesture, _MENU_MODELS["tab"])
 
 
-def show_background_context_menu(surface: WorkSurface, gesture: Gtk.Gesture):
+def show_background_context_menu(surface: "WorkSurface", gesture: Gtk.Gesture):
     """Displays the context menu for empty canvas space."""
     menu = Gio.Menu.new()
     menu.append_item(Gio.MenuItem.new(_("New Sketch"), "win.new_sketch"))

--- a/rayforge/ui_gtk/canvas2d/elements/camera_image.py
+++ b/rayforge/ui_gtk/canvas2d/elements/camera_image.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING, cast
 

--- a/rayforge/ui_gtk/canvas2d/projection.py
+++ b/rayforge/ui_gtk/canvas2d/projection.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from raygeo.ops.axis import Axis

--- a/rayforge/ui_gtk/doceditor/add_tabs_popover.py
+++ b/rayforge/ui_gtk/doceditor/add_tabs_popover.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
@@ -19,8 +17,8 @@ logger = logging.getLogger(__name__)
 class AddTabsPopover(Gtk.Popover):
     def __init__(
         self,
-        editor: DocEditor,
-        workpieces: list[WorkPiece],
+        editor: "DocEditor",
+        workpieces: "list[WorkPiece]",
     ):
         super().__init__()
         self.editor = editor

--- a/rayforge/ui_gtk/doceditor/import_handler.py
+++ b/rayforge/ui_gtk/doceditor/import_handler.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from gettext import gettext as _
 from pathlib import Path
@@ -23,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 def _start_interactive_import(
-    win: MainWindow,
-    editor: DocEditor,
+    win: "MainWindow",
+    editor: "DocEditor",
     file_path: Path,
     mime_type: str,
     position_mm: tuple[float, float] | None = None,
@@ -65,8 +63,8 @@ def _on_import_dialog_response(
     dialog,
     response_id: str,
     spec: VectorizationSpec,
-    win: MainWindow,
-    editor: DocEditor,
+    win: "MainWindow",
+    editor: "DocEditor",
     file_path: Path,
     mime_type: str,
     position_mm: tuple[float, float] | None = None,
@@ -124,7 +122,7 @@ def _on_file_selected(dialog, result, user_data):
         logger.exception("Error opening file")
 
 
-def start_interactive_import(win: MainWindow, editor: DocEditor):
+def start_interactive_import(win: "MainWindow", editor: "DocEditor"):
     """
     Initiates the full interactive file import process, starting with a
     file chooser dialog.
@@ -136,8 +134,8 @@ def start_interactive_import(win: MainWindow, editor: DocEditor):
 
 
 def import_file_at_position(
-    win: MainWindow,
-    editor: DocEditor,
+    win: "MainWindow",
+    editor: "DocEditor",
     file_path: Path,
     mime_type: str,
     position_mm: tuple[float, float] | None = None,
@@ -172,10 +170,10 @@ def import_file_at_position(
 def _on_batch_trace_response(
     dialog,
     response_id: str,
-    editor: DocEditor,
+    editor: "DocEditor",
     file_list: list[tuple[Path, str]],
     position_mm: tuple[float, float],
-    win: MainWindow,
+    win: "MainWindow",
 ):
     """
     Handles the user's choice from the batch tracing configuration dialog.
@@ -194,8 +192,8 @@ def _on_batch_trace_response(
 
 
 def import_multiple_files_at_position(
-    win: MainWindow,
-    editor: DocEditor,
+    win: "MainWindow",
+    editor: "DocEditor",
     file_list: list[tuple[Path, str]],
     position_mm: tuple[float, float],
 ):
@@ -270,8 +268,8 @@ def import_multiple_files_at_position(
 
 
 def start_reimport(
-    win: MainWindow,
-    editor: DocEditor,
+    win: "MainWindow",
+    editor: "DocEditor",
     source_asset: SourceAsset,
     position_mm: tuple[float, float] | None = None,
     target_layer: Layer | None = None,

--- a/rayforge/ui_gtk/doceditor/recipes/pages/post_processing.py
+++ b/rayforge/ui_gtk/doceditor/recipes/pages/post_processing.py
@@ -1,7 +1,5 @@
 """Recipe-mode post-processing transformers settings page."""
 
-from __future__ import annotations
-
 from gettext import gettext as _
 from typing import Any
 

--- a/rayforge/ui_gtk/sim3d/gl_utils.py
+++ b/rayforge/ui_gtk/sim3d/gl_utils.py
@@ -3,8 +3,6 @@ A collection of utility classes and functions for simplifying common
 PyOpenGL tasks, such as shader compilation and buffer management.
 """
 
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -68,7 +66,7 @@ class ShaderSet:
     valid during migration.
     """
 
-    main: Shader | None = None
-    text: Shader | None = None
-    texture: Shader | None = None
-    background: Shader | None = None
+    main: "Shader | None" = None
+    text: "Shader | None" = None
+    texture: "Shader | None" = None
+    background: "Shader | None" = None

--- a/rayforge/ui_gtk/sim3d/renderer/axis_renderer_3d.py
+++ b/rayforge/ui_gtk/sim3d/renderer/axis_renderer_3d.py
@@ -6,8 +6,6 @@ creating and drawing a grid on the XY plane, along with labeled X and Y
 axes. It uses a composed PlaneRenderer for the background.
 """
 
-from __future__ import annotations
-
 import logging
 import math
 

--- a/rayforge/ui_gtk/sim3d/renderer/plane_renderer.py
+++ b/rayforge/ui_gtk/sim3d/renderer/plane_renderer.py
@@ -2,8 +2,6 @@
 A simple renderer for a 2D plane in 3D space.
 """
 
-from __future__ import annotations
-
 import logging
 
 import numpy as np

--- a/scripts/mac/mac_build.sh
+++ b/scripts/mac/mac_build.sh
@@ -7,8 +7,6 @@ DO_DMG=0
 DO_RUN_APP=0
 VERSION_OVERRIDE=""
 MACOS_MIN_VERSION="12.0"
-MACOS_NUMPY_VERSION="1.26.4"
-MACOS_SCIPY_VERSION="1.11.4"
 GREEN="\033[0;32m"
 NC="\033[0m"
 
@@ -104,8 +102,8 @@ echo ""
 
 VENV_PATH=${VENV_PATH:-.venv}
 PYTHON_BOOTSTRAP=python3
-if command -v python3.11 >/dev/null 2>&1; then
-    PYTHON_BOOTSTRAP=python3.11
+if command -v python3.13 >/dev/null 2>&1; then
+    PYTHON_BOOTSTRAP=python3.13
 fi
 if [ ! -d "$VENV_PATH" ]; then
     "$PYTHON_BOOTSTRAP" -m venv "$VENV_PATH"
@@ -115,37 +113,9 @@ VENV_PY="$VENV_PATH/bin/python"
 "$VENV_PY" -m pip install --upgrade pip
 "$VENV_PY" -m pip install --upgrade build pyinstaller
 TMP_REQUIREMENTS=$(mktemp)
-trap 'rm -f "$TMP_REQUIREMENTS" "$TMP_REQUIREMENTS.patched"' EXIT
+trap 'rm -f "$TMP_REQUIREMENTS"' EXIT
 grep -Evi '^(PyOpenGL_accelerate|opencv[_-]python)' \
     requirements.txt > "$TMP_REQUIREMENTS"
-
-if [ "$(uname -s)" = "Darwin" ]; then
-    awk \
-        -v numpy_version="$MACOS_NUMPY_VERSION" \
-        -v scipy_version="$MACOS_SCIPY_VERSION" '
-        BEGIN { done_numpy = 0; done_scipy = 0 }
-        /^numpy[=~><!]/ {
-            print "numpy==" numpy_version
-            done_numpy = 1
-            next
-        }
-        /^scipy[=~><!]/ {
-            print "scipy==" scipy_version
-            done_scipy = 1
-            next
-        }
-        { print }
-        END {
-            if (done_numpy == 0) {
-                print "numpy==" numpy_version
-            }
-            if (done_scipy == 0) {
-                print "scipy==" scipy_version
-            }
-        }
-    ' "$TMP_REQUIREMENTS" > "$TMP_REQUIREMENTS.patched"
-    mv "$TMP_REQUIREMENTS.patched" "$TMP_REQUIREMENTS"
-fi
 
 if [ "$(uname -s)" = "Darwin" ]; then
     echo "Installing pinned OpenCV wheel for macOS..."
@@ -154,30 +124,18 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 "$VENV_PY" -m pip install -r "$TMP_REQUIREMENTS"
-if [ "$(uname -s)" = "Darwin" ]; then
-    "$VENV_PY" -m pip install --upgrade --force-reinstall \
-        --only-binary=:all: \
-        "numpy==$MACOS_NUMPY_VERSION" "scipy==$MACOS_SCIPY_VERSION"
-fi
 rm -f "$TMP_REQUIREMENTS"
 trap - EXIT
 "$VENV_PY" -m pip install PyOpenGL_accelerate==3.1.10 || \
     echo "PyOpenGL_accelerate install failed; continuing."
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    "$VENV_PY" - "$MACOS_NUMPY_VERSION" \
-        "$MACOS_SCIPY_VERSION" <<'PY'
-import sys
-
-import numpy
-import scipy
+    "$VENV_PY" - <<'PY'
 from scipy.linalg import null_space
 from scipy.ndimage import binary_dilation
 from scipy.optimize import least_squares
 from scipy.signal import fftconvolve
 
-assert numpy.__version__ == sys.argv[1]
-assert scipy.__version__ == sys.argv[2]
 assert all((null_space, binary_dilation, least_squares, fftconvolve))
 print("Verified SciPy modules used by Rayforge.")
 PY

--- a/scripts/profile_raster.py
+++ b/scripts/profile_raster.py
@@ -111,8 +111,6 @@ Top sources (memray --native, stock raygeo):
   needs float32; do not "compress" it.
 """
 
-from __future__ import annotations
-
 import argparse
 import ctypes
 import gc

--- a/scripts/snapshot_memory.py
+++ b/scripts/snapshot_memory.py
@@ -23,8 +23,6 @@ should be roughly attributable to the reported owners.  Discrepancies
 point to untracked holders.
 """
 
-from __future__ import annotations
-
 import gc
 import logging
 import os
@@ -215,7 +213,7 @@ def _claim_ops(
 
 
 def _measure_encoded_output(
-    r: OwnerReport, label: str, encoded: EncodedOutput | None
+    r: OwnerReport, label: str, encoded: "EncodedOutput | None"
 ) -> None:
     """Record the encoded G-code text and op-map payloads."""
     if encoded is None:
@@ -239,7 +237,7 @@ def _measure_encoded_output(
     r.items.append((label2, lines_sz))
 
 
-def _measure_artifact_store(store: ArtifactStore) -> OwnerReport:
+def _measure_artifact_store(store: "ArtifactStore") -> OwnerReport:
     r = OwnerReport(name="ArtifactStore")
     seen_ops: set[int] = set()
     for key, art in store._artifacts.items():
@@ -271,7 +269,7 @@ def _measure_artifact_store(store: ArtifactStore) -> OwnerReport:
     return r
 
 
-def _measure_view_manager(vm: ViewManager) -> OwnerReport:
+def _measure_view_manager(vm: "ViewManager") -> OwnerReport:
     r = OwnerReport(name="ViewManager")
     for composite_id, entry in vm._view_entries.items():
         label = f"ViewEntry{composite_id}"
@@ -282,7 +280,7 @@ def _measure_view_manager(vm: ViewManager) -> OwnerReport:
     return r
 
 
-def _measure_scene_presenter(presenter: ScenePresenter) -> OwnerReport:
+def _measure_scene_presenter(presenter: "ScenePresenter") -> OwnerReport:
     r = OwnerReport(name="ScenePresenter")
     art = presenter._compiled_artifact
     if art is None:
@@ -312,7 +310,7 @@ def _measure_scene_presenter(presenter: ScenePresenter) -> OwnerReport:
     return r
 
 
-def _measure_pipeline(pipeline: Pipeline) -> OwnerReport:
+def _measure_pipeline(pipeline: "Pipeline") -> OwnerReport:
     r = OwnerReport(name="Pipeline")
     # raygeo cache
     cache_bytes = pipeline._raygeo_pipeline.cache_used_bytes
@@ -330,7 +328,7 @@ def _measure_pipeline(pipeline: Pipeline) -> OwnerReport:
     return r
 
 
-def _measure_source_assets(doc: Doc) -> OwnerReport:
+def _measure_source_assets(doc: "Doc") -> OwnerReport:
     r = OwnerReport(name="SourceAssets")
     for layer in doc.layers:
         for wp in layer.all_workpieces:
@@ -538,12 +536,12 @@ class AppProtocol(Protocol):
     def quit_idle(self) -> None: ...
 
 
-def _find_scene_presenter(win: MainWindow) -> ScenePresenter | None:
+def _find_scene_presenter(win: "MainWindow") -> "ScenePresenter | None":
     """Locate the ScenePresenter on the 3D canvas, if it exists."""
     try:
         from rayforge.ui_gtk.sim3d.canvas3d import Canvas3D
 
-        def search(widget: Gtk.Widget) -> ScenePresenter | None:
+        def search(widget: "Gtk.Widget") -> "ScenePresenter | None":
             if isinstance(widget, Canvas3D):
                 return widget._presenter
             child = widget.get_first_child()
@@ -560,7 +558,7 @@ def _find_scene_presenter(win: MainWindow) -> ScenePresenter | None:
 
 
 def _wait_for_settle(
-    editor: DocEditor, quiet_seconds: float = 2.0, timeout: float = 300.0
+    editor: "DocEditor", quiet_seconds: float = 2.0, timeout: float = 300.0
 ) -> bool:
     """Block until ``editor.is_processing`` has been False for
     *quiet_seconds* consecutive seconds, or *timeout* elapses."""
@@ -588,7 +586,7 @@ def _wait_for_settle(
     return False
 
 
-def _switch_to_3d_view(win: MainWindow) -> None:
+def _switch_to_3d_view(win: "MainWindow") -> None:
     """Switch the view stack to the 3D page so the GLArea realizes."""
     try:
         win.view_stack.set_visible_child_name("3d")
@@ -597,7 +595,7 @@ def _switch_to_3d_view(win: MainWindow) -> None:
         logger.warning("snapshot_memory: failed to switch to 3D: %s", e)
 
 
-def _wait_for_gl(win: MainWindow, timeout: float = 30.0) -> None:
+def _wait_for_gl(win: "MainWindow", timeout: float = 30.0) -> None:
     """Wait for the 3D canvas GL to initialize and scene to compile."""
     canvas = win.canvas3d
     if canvas is None:
@@ -614,7 +612,9 @@ def _wait_for_gl(win: MainWindow, timeout: float = 30.0) -> None:
     )
 
 
-def _wait_for_scene_compiled(win: MainWindow, timeout: float = 120.0) -> None:
+def _wait_for_scene_compiled(
+    win: "MainWindow", timeout: float = 120.0
+) -> None:
     """Wait for the ScenePresenter to have a compiled artifact."""
     canvas = win.canvas3d
     if canvas is None:
@@ -631,7 +631,7 @@ def _wait_for_scene_compiled(win: MainWindow, timeout: float = 120.0) -> None:
     )
 
 
-def run_snapshot(app: AppProtocol, win: MainWindow) -> None:
+def run_snapshot(app: AppProtocol, win: "MainWindow") -> None:
     """Entry point — called from the UI script thread."""
     logger.info("snapshot_memory: waiting for document to settle...")
     editor = win.doc_editor
@@ -693,7 +693,7 @@ def run_snapshot(app: AppProtocol, win: MainWindow) -> None:
 # When run via --uiscript, the globals `app` and `win` are injected
 # by rayforge.uiscript._set_context().
 _app: AppProtocol | None = None
-_win: MainWindow | None = None
+_win: "MainWindow | None" = None
 try:
     from rayforge import uiscript as _ui
 

--- a/tests/tasker/test_task.py
+++ b/tests/tasker/test_task.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from unittest.mock import AsyncMock, Mock
 


### PR DESCRIPTION
Closes the TODO item: remove `from __future__ import annotations` everywhere.

## Why

Python 3.14 (PEP 649) makes annotations lazy by default, so the future import is redundant on the dev environment. It was only needed for Python <=3.13, where annotations are evaluated eagerly.

## Changes

- Removed the import from all 171 files
- Quoted annotations that reference names not bound at runtime (forward references, `TYPE_CHECKING`-only imports, self-references in `from_dict`/`create` classmethods) so they keep working on eager-evaluating Pythons
- Fixed `DictProxy[str, ...]` annotations in `shared/tasker/{pool,manager}.py`, which raise `TypeError` when evaluated
- ci(macos): bump the macOS build from Python 3.11 to 3.13 and drop the numpy 1.26.4/scipy 1.11.4 overrides in `mac_build.sh` (requirements.txt pins numpy 2.5.2/scipy 1.18.0, which require >=3.12 and ship macOS x86_64/arm64 wheels for 3.13)

## Verification

- `pixi run lint` clean (ruff, flake8, pyflakes, pyright)
- 5906 backend tests pass on Python 3.14 (pixi) and on Python 3.11 (local env, to prove the quoted annotations work with eager evaluation)
- All UI modules, `rayforge.app`, and every builtin/private addon module import cleanly on 3.11