### PR TITLE
fix(tests): use generous wait_until_settled timeouts on CI

### DIFF
--- a/tests/tasker/test_manager.py
+++ b/tests/tasker/test_manager.py
@@ -661,12 +661,14 @@ class TestWaitUntilSettled:
 
         # wait_until_settled should wait and return True
         start_time = time.time()
-        result = manager.wait_until_settled(1000)  # 1 second timeout
+        # Slow CI runners (especially Windows) can stall coroutine
+        # scheduling for over a second, so use a generous timeout.
+        result = manager.wait_until_settled(5000)  # 5 second timeout
         elapsed = time.time() - start_time
 
         assert result is True
         assert elapsed >= 0.3  # Should have waited at least the task duration
-        assert elapsed < 1.0  # But less than the timeout
+        assert elapsed < 5.0  # But less than the timeout
 
         # Task should be completed
         assert completion_event.is_set()
@@ -724,14 +726,16 @@ class TestWaitUntilSettled:
             )
 
         # wait_until_settled should wait for the longest task
-        result = manager.wait_until_settled(3000)  # 3 second timeout
+        # Slow CI runners (especially Windows) can stall coroutine
+        # scheduling for over a second, so use a generous timeout.
+        result = manager.wait_until_settled(8000)  # 8 second timeout
         elapsed = time.time() - start_time
 
         assert result is True
         assert (
             elapsed >= 1.2
         )  # Should have waited at least the longest task duration
-        assert elapsed < 3.0  # But less than the timeout
+        assert elapsed < 8.0  # But less than the timeout
 
         # All tasks should be completed
         for event in completion_events:


### PR DESCRIPTION
## Problem

The Windows CI run failed on `tests/tasker/test_manager.py::TestWaitUntilSettled::test_wait_until_settled_with_running_tasks` ([run 31994363662](https://github.com/barebaric/rayforge/actions/runs/31994363662)):

```
assert result is True
E       assert False is True
tests/tasker/test_manager.py:667: AssertionError
```

## Root cause

The CI log shows the 0.3s test coroutine actually took **~1.2s** to complete on the runner (task added at 04:45:46.94, `Coro completed successfully` at 04:45:48.14). Other coroutines in the same run only had ~0.1s of scheduling overhead, so this was a transient scheduler stall on the loaded Windows runner.

Since 8bf83214 (`fix(tasker): enforce wait_until_settled timeout against wall clock`), `wait_until_settled` correctly stops at its deadline instead of stretching the wait when `Event.wait()` oversleeps. With a 0.3s task and a 1s timeout there was only 0.7s of slack, so the stall made it return `False` and the test failed.

## Solution

Follow the established precedent from c52fcbc1 ("use generous timeouts for process task tests on CI") and raise the margins in the `TestWaitUntilSettled` tests:

- `test_wait_until_settled_with_running_tasks`: timeout 1000ms → 5000ms (upper-bound assertion scaled accordingly)
- `test_wait_until_settled_multiple_tasks`: timeout 3000ms → 8000ms (only 1.5s of slack for a 1.5s task; same flakiness class)

The lower-bound assertions (`elapsed >= 0.3`, `elapsed >= 1.2`) are unchanged, so the tests still verify that `wait_until_settled` actually waits for running tasks.

## Verification

- `pytest tests/tasker/test_manager.py` — 24 passed