### PR TITLE
ci: bump pinned pixi to 0.76.2 to fix broken upgrade

### DIFF
--- a/.github/workflows/pixi-dependabot.yml
+++ b/.github/workflows/pixi-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.10.1
         with:
-          pixi-version: v0.68.1
+          pixi-version: v0.76.2
           run-install: false
 
       - name: Generate dependency diff


### PR DESCRIPTION
## Problem

The weekly **Update Pixi Dependencies** workflow fails in the `Upgrade dependencies` step ([run #7](https://github.com/barebaric/rayforge/actions/runs/32002355735/job/95304979261), exit code 1 after ~7s), so no dependency-update PR is created anymore.

## Root cause

The workflow pins `pixi-version: v0.68.1`. pixi 0.68.x ships a bug ([prefix-dev/pixi#6093](https://github.com/prefix-dev/pixi/issues/6093): "pixi upgrade broken since 0.68.0") where `pixi upgrade` aborts with:

```
No Python interpreter found in the dependencies
```

on workspaces that have a **local editable pypi dependency**. We have exactly that precondition in `pixi.toml`:

```toml
[feature.app.pypi-dependencies]
rayforge = { editable = true, path = "." }
```

It was fixed in pixi **0.69.0** via [prefix-dev/pixi#6095](https://github.com/prefix-dev/pixi/pull/6095) ("Don't misclassify missing python as pypi-only during upgrade"). Whether the bug fires depends on the lock-file state, which is why earlier runs passed and this Monday's run (after the `raygeo==1.41.1` lock rewrite in c72ba379) started failing. The fast ~7s failure in `pixi upgrade` while `pixi update` (diff step) succeeds matches the bug's signature.

## Fix

Bump the pinned CI pixi version `v0.68.1` → `v0.76.2` (current latest). All commands used by the workflow (`pixi clean cache -y`, `pixi upgrade --pinning-strategy exact-version`, `pixi update`, `pixi exec`) are unchanged in current pixi.