### PR TITLE
ci: exclude PyGObject from pixi upgrade to avoid stubs conflict

### DIFF
--- a/.github/workflows/pixi-dependabot.yml
+++ b/.github/workflows/pixi-dependabot.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           : > requirements.txt
           pixi clean cache -y
-          pixi upgrade --pinning-strategy exact-version
+          # PyGObject must stay pinned: the loosened conda solve can
+          # backtrack it below the pygobject>=3.55.0 floor required by
+          # the pygobject-stubs pypi dependency, making the two-stage
+          # solve unsatisfiable.
+          pixi upgrade --pinning-strategy exact-version --exclude PyGObject
           git restore requirements.txt
           python3 scripts/sync_requirements.py
           pixi clean cache -y


### PR DESCRIPTION
## Problem

The weekly **Update Pixi Dependencies** job still fails in `Upgrade dependencies` after #352 ([run log](https://github.com/barebaric/rayforge/actions/runs/32022104860/job/95363762738)):

```
Error: × failed to solve the pypi requirements of environment 'default' for platform 'linux-64'
  ├─▶ failed to resolve pypi dependencies
  ╰─▶ Because pygobject-stubs==2.17.0 depends on pygobject>=3.55.0 and pygobject==3.50.0,
      we can conclude that pygobject-stubs==2.17.0 cannot be used.
      And because you require pygobject-stubs==2.17.0, we can conclude that your
      requirements are unsatisfiable.
  help: The following PyPI packages have been pinned by the conda solve, and this
        version may be causing a conflict: pygobject==3.50.0
```

(The run before the pixi bump failed identically on `osx-arm64`, so the pixi version was never the issue — apologies for the wrong diagnosis in #352.)

## Root cause

`pixi upgrade` **loosens every spec** in `pixi.toml` before re-solving. In the loosened conda solve the solver backtracks `PyGObject` down to **3.50.0** (available and still on `main` in conda-forge). The second, pypi solve stage then has to reconcile that conda-pinned `pygobject==3.50.0` with `pygobject-stubs==2.17.0` (test feature), which requires `pygobject>=3.55.0` → unsatisfiable → the whole step aborts. This is pixi's documented [pinned-package-conflict](https://pixi.sh/latest/concepts/conda_pypi/#pinned-package-conflicts) class: the conda solve cannot see pypi requirements.

Notably the *pinned* solve is fine: the `Generate dependency diff` step (`pixi update`) resolves `PyGObject ==3.56.3` on both platforms without trouble. Only the loosened upgrade solve backtracks.

## Fix

Exclude `PyGObject` from the upgrade:

```
pixi upgrade --pinning-strategy exact-version --exclude PyGObject
```

Its `==3.56.3` pin then stays in force during the loosened solve, which we know is satisfiable. `PyGObject` will no longer be auto-bumped by the weekly bot and needs manual bumps together with the GTK stack — same trade-off as the earlier "keep pluggy pinned" fix (a47347e4) for the same class of failure.