### PR TITLE
ci: constrain conda pygobject to the stubs pypi floor

### DIFF
--- a/.github/workflows/pixi-dependabot.yml
+++ b/.github/workflows/pixi-dependabot.yml
@@ -31,11 +31,7 @@ jobs:
         run: |
           : > requirements.txt
           pixi clean cache -y
-          # PyGObject must stay pinned: the loosened conda solve can
-          # backtrack it below the pygobject>=3.55.0 floor required by
-          # the pygobject-stubs pypi dependency, making the two-stage
-          # solve unsatisfiable.
-          pixi upgrade --pinning-strategy exact-version --exclude PyGObject
+          pixi upgrade --pinning-strategy exact-version
           git restore requirements.txt
           python3 scripts/sync_requirements.py
           pixi clean cache -y

--- a/pixi.toml
+++ b/pixi.toml
@@ -176,6 +176,12 @@ depends-on = ["compile-translations"]
 [dependencies]
 libadwaita = "==1.9.3"
 
+# Keep the conda solve from backtracking pygobject below the
+# pygobject>=3.55.0 floor required by the pygobject-stubs pypi
+# dependency ("pixi upgrade" otherwise becomes unsatisfiable).
+[constraints]
+pygobject = ">=3.55.0"
+
 [target.linux-64.dependencies]
 libglvnd = "==1.7.0"
 


### PR DESCRIPTION
## Problem

The weekly **Update Pixi Dependencies** job still failed in `Upgrade dependencies` after #353 ([run](https://github.com/barebaric/rayforge/actions/runs/32031947501)) with the same error:

```
× failed to solve the pypi requirements of environment 'default'
╰─▶ Because pygobject-stubs==2.17.0 depends on pygobject>=3.55.0 and pygobject==3.50.0,
    we can conclude ... your requirements are unsatisfiable.
help: The following PyPI packages have been pinned by the conda solve: pygobject==3.50.0
```

## Why #353 didn't work

`--exclude PyGObject` was a no-op: pixi compares the exclude argument against the **normalized** package name (`pygobject`, lowercase; see `parse_specs` in `pixi_cli/src/upgrade.rs`), so the camel-case spelling never matched and the `==3.56.3` pin was loosened anyway.

## Fix (verified in CI)

Use pixi's documented remedy for [pinned package conflicts](https://pixi.sh/latest/concepts/conda_pypi/#pinned-package-conflicts): mirror the pypi-side floor into the conda solve via a workspace constraint:

```toml
[constraints]
pygobject = ">=3.55.0"
```

and revert the ineffective `--exclude` from the workflow. Unlike a pin-freeze, PyGObject stays auto-upgradable.

I verified the full production step sequence on a scratch branch before opening this ([run 32033633749](https://github.com/barebaric/rayforge/actions/runs/32033633749), PR-creation step disabled for the test): `Upgrade dependencies` now solves cleanly and produces the expected weekly bumps (platformdirs 4.11.3, pypdf 6.16.1, ruff 0.16.3, pre-commit 4.6.2, pycairo 1.29.1, ffmpeg 9.0.1, ...) with pygobject staying at 3.56.3.

The scratch branch `ci/pixi-upgrade-probe` was deleted again.