### PR TITLE
feat(ui): add right panel display mode setting

### DIFF
--- a/rayforge/core/config.py
+++ b/rayforge/core/config.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass, fields
 from datetime import datetime, timezone
 from enum import Enum
+from gettext import gettext as _
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,25 @@ class StartupBehavior(Enum):
     NONE = "none"
     LAST_PROJECT = "last_project"
     SPECIFIC_PROJECT = "specific_project"
+
+
+class RightPanelMode(Enum):
+    """Enum for right panel display modes."""
+
+    HIDDEN = "hidden"
+    ACTIVE_LAYER = "active_layer"
+    NON_EMPTY_LAYERS = "non_empty_layers"
+    ALL_LAYERS = "all_layers"
+
+    def label(self) -> str:
+        """Return a translatable label for this panel mode."""
+        labels = {
+            self.HIDDEN: _("Hidden"),
+            self.ACTIVE_LAYER: _("Active Layer Workflow"),
+            self.NON_EMPTY_LAYERS: _("All Non-Empty Layers"),
+            self.ALL_LAYERS: _("All Layers"),
+        }
+        return labels[self]
 
 
 @dataclass
@@ -75,6 +95,7 @@ class Config:
         # UI visibility states
         self.bottom_panel: dict[str, Any] | None = None
         self.right_panel_visible: bool = True
+        self.right_panel_mode: RightPanelMode = RightPanelMode.NON_EMPTY_LAYERS
         self.canvas_view: CanvasViewState = CanvasViewState()
         self.auto_pipeline: bool = True
         self.ops_color_mode: OpsColorMode = OpsColorMode.LASER
@@ -147,6 +168,13 @@ class Config:
         if self.right_panel_visible == visible:
             return
         self.right_panel_visible = visible
+        self.changed.send(self)
+
+    def set_right_panel_mode(self, mode: RightPanelMode):
+        """Sets the right panel display mode."""
+        if self.right_panel_mode == mode:
+            return
+        self.right_panel_mode = mode
         self.changed.send(self)
 
     def set_import_dpi(self, dpi: float):
@@ -241,6 +269,7 @@ class Config:
             ),
             "bottom_panel": self.bottom_panel,
             "right_panel_visible": self.right_panel_visible,
+            "right_panel_mode": self.right_panel_mode.value,
             "canvas_view": self.canvas_view.to_dict(),
             "auto_pipeline": self.auto_pipeline,
             "check_for_app_updates": self.check_for_app_updates,
@@ -293,6 +322,12 @@ class Config:
         # Load UI visibility states
         config.bottom_panel = data.get("bottom_panel", None)
         config.right_panel_visible = data.get("right_panel_visible", True)
+        default_panel_mode = RightPanelMode.NON_EMPTY_LAYERS.value
+        panel_mode_str = data.get("right_panel_mode", default_panel_mode)
+        try:
+            config.right_panel_mode = RightPanelMode(panel_mode_str)
+        except ValueError:
+            config.right_panel_mode = RightPanelMode.NON_EMPTY_LAYERS
         config.canvas_view = CanvasViewState.from_dict(
             data.get("canvas_view", {})
         )

--- a/rayforge/core/layer.py
+++ b/rayforge/core/layer.py
@@ -177,6 +177,11 @@ class Layer(DocItem):
         return self.get_content_items()
 
     @property
+    def is_empty(self) -> bool:
+        """Returns True if the layer holds no user-facing items."""
+        return not self.get_content_items()
+
+    @property
     def workflow(self) -> Workflow | None:
         """Returns the layer's workflow. A layer must have one workflow."""
         for child in self.children:

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -12,6 +12,7 @@ from .. import __version__, const
 from ..addon_mgr.update_cmd import UpdateCommand
 from ..context import get_context
 from ..core.asset_registry import asset_type_registry
+from ..core.config import RightPanelMode
 from ..core.group import Group
 from ..core.item import DocItem
 from ..core.registration import call_registration_hooks
@@ -73,6 +74,10 @@ from .toolbar import MainToolbar
 from .view_mode_cmd import ViewModeCmd
 
 logger = logging.getLogger(__name__)
+
+# Horizontal space reserved for the right panel when it is shown
+RIGHT_PANEL_OVERLAY_MARGIN = 454
+DEFAULT_OVERLAY_MARGIN = 6
 
 
 css = """
@@ -143,6 +148,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._saved_bottom_panel_visible = False
         self._old_doc = None  # Track previous document for signal reconnection
         self.canvas3d: Canvas3D | None = None
+        self._canvas3d_vis_overlay: VisibilityOverlay | None = None
         self._canvas3d_time_overlay: TimeEstimateOverlay | None = None
         self._is_syncing_3d = False
 
@@ -352,7 +358,9 @@ class MainWindow(Adw.ApplicationWindow):
             show_nogo_zones=bool(config.machine and config.machine.nogo_zones),
             shortcuts=SHORTCUTS,
         )
-        self._surface_vis_overlay.set_margin_end(454)
+        self._surface_vis_overlay.set_margin_end(
+            self._get_vis_overlay_margin_end()
+        )
         self.surface_overlay.add_overlay(self._surface_vis_overlay)
         self._time_estimate_overlay = TimeEstimateOverlay()
         self.surface_overlay.add_overlay(self._time_estimate_overlay)
@@ -400,16 +408,14 @@ class MainWindow(Adw.ApplicationWindow):
         right_pane_box.set_size_request(430, -1)
         self._right_pane.set_child(right_pane_box)
 
-        # The WorkflowView will be updated when a layer is activated.
-        initial_workflow = self.doc_editor.doc.active_layer.workflow
-        assert initial_workflow, "Initial active layer must have a workflow"
-        self.workflowview = WorkflowView(
-            self.doc_editor,
-            initial_workflow,
-        )
-        self.workflowview.set_margin_top(6)
-        self.workflowview.set_margin_end(12)
-        right_pane_box.append(self.workflowview)
+        # The workflow views are updated when the document or the
+        # active layer changes, according to the right panel mode.
+        self._workflow_views: list[WorkflowView] = []
+        self._workflow_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self._workflow_box.set_margin_top(6)
+        self._workflow_box.set_margin_end(12)
+        right_pane_box.append(self._workflow_box)
+        self._update_workflow_views()
 
         # Register built-in property providers before creating the widget
         register_builtin_providers()
@@ -676,6 +682,8 @@ class MainWindow(Adw.ApplicationWindow):
             and config.bottom_panel.get("visible")
         ):
             bottom_panel_action.change_state(GLib.Variant.new_boolean(True))
+
+        self._apply_right_panel_visibility()
 
     def add_stack_page(self, name: str, widget: Gtk.Widget):
         """Add a page to the main stack.
@@ -1274,9 +1282,7 @@ class MainWindow(Adw.ApplicationWindow):
     def on_doc_changed(self, sender, **kwargs):
         # Synchronize UI elements that depend on the document model
         self.surface.update_from_doc()
-        doc = self.doc_editor.doc
-        if doc.active_layer and doc.active_layer.workflow:
-            self.workflowview.set_workflow(doc.active_layer.workflow)
+        self._update_workflow_views()
 
         # Sync the selectability of stock items based on active layer
         self._sync_element_selectability()
@@ -1303,17 +1309,84 @@ class MainWindow(Adw.ApplicationWindow):
         # Reset the paste counter to ensure the next paste is in-place.
         self.doc_editor.edit.reset_paste_counter()
 
-        # Get the newly activated layer from the document
-        activated_layer = self.doc_editor.doc.active_layer
-        has_workflow = activated_layer.workflow is not None
+        self._update_workflow_views()
 
-        # Show/hide the workflow view based on the layer type
-        self.workflowview.set_visible(has_workflow)
+    def _get_visible_workflows(self):
+        """
+        Returns the workflows that should be displayed in the right
+        panel, based on the configured right panel mode.
+        """
+        doc = self.doc_editor.doc
+        if not doc:
+            return []
+        mode = get_context().config.right_panel_mode
+        if mode == RightPanelMode.HIDDEN:
+            return []
+        if mode == RightPanelMode.NON_EMPTY_LAYERS:
+            return [
+                layer.workflow
+                for layer in doc.layers
+                if not layer.is_empty and layer.workflow
+            ]
+        if mode == RightPanelMode.ALL_LAYERS:
+            return [layer.workflow for layer in doc.layers if layer.workflow]
+        active = doc.active_layer
+        if active and active.workflow:
+            return [active.workflow]
+        return []
 
-        if has_workflow:
-            # For regular layers, update the workflow view with the
-            # new workflow
-            self.workflowview.set_workflow(activated_layer.workflow)
+    def _update_workflow_views(self):
+        """
+        Reconciles the workflow views in the right panel with the
+        workflows that should currently be displayed. Rebuilds the views
+        only if the set of workflows has changed.
+        """
+        desired = self._get_visible_workflows()
+        current = [view.workflow for view in self._workflow_views]
+        if current == desired:
+            return
+        for view in self._workflow_views:
+            self._workflow_box.remove(view)
+        self._workflow_views.clear()
+        for workflow in desired:
+            view = WorkflowView(self.doc_editor, workflow)
+            view.set_margin_bottom(6)
+            self._workflow_box.append(view)
+            self._workflow_views.append(view)
+
+    def _is_right_panel_effectively_visible(self) -> bool:
+        """
+        Returns True if the right panel should be on screen, combining
+        the user's visibility toggle with the configured panel mode.
+        """
+        config = get_context().config
+        return (
+            config.right_panel_visible
+            and config.right_panel_mode != RightPanelMode.HIDDEN
+        )
+
+    def _get_vis_overlay_margin_end(self) -> int:
+        """
+        Returns the end margin for the canvas visibility overlays. When
+        the right panel is shown, they shift left to avoid overlapping
+        it; otherwise they align with the canvas edge.
+        """
+        if self._is_right_panel_effectively_visible():
+            return RIGHT_PANEL_OVERLAY_MARGIN
+        return DEFAULT_OVERLAY_MARGIN
+
+    def _apply_right_panel_visibility(self):
+        """
+        Shows or hides the right panel and repositions the canvas
+        visibility overlays accordingly.
+        """
+        self._right_pane.set_visible(
+            self._is_right_panel_effectively_visible()
+        )
+        margin_end = self._get_vis_overlay_margin_end()
+        self._surface_vis_overlay.set_margin_end(margin_end)
+        if self._canvas3d_vis_overlay is not None:
+            self._canvas3d_vis_overlay.set_margin_end(margin_end)
 
     def _on_document_changed(self, sender):
         """
@@ -1527,7 +1600,9 @@ class MainWindow(Adw.ApplicationWindow):
             show_nogo_zones=bool(machine and machine.nogo_zones),
             shortcuts=SHORTCUTS,
         )
-        self._canvas3d_vis_overlay.set_margin_end(454)
+        self._canvas3d_vis_overlay.set_margin_end(
+            self._get_vis_overlay_margin_end()
+        )
         self._canvas3d_overlay.add_overlay(self._canvas3d_vis_overlay)
         self._canvas3d_playback = PlaybackOverlay()
         self.canvas3d.set_playback_overlay(self._canvas3d_playback)
@@ -1607,10 +1682,12 @@ class MainWindow(Adw.ApplicationWindow):
         # Show/hide no-go zone toggle based on whether the machine has any
         has_nogo_zones = bool(config.machine and config.machine.nogo_zones)
         self._surface_vis_overlay.set_nogo_visible(has_nogo_zones)
-        if self.canvas3d is not None:
+        if self.canvas3d is not None and self._canvas3d_vis_overlay:
             self._canvas3d_vis_overlay.set_nogo_visible(has_nogo_zones)
 
         self.surface.update_from_doc()
+        self._update_workflow_views()
+        self._apply_right_panel_visibility()
         self._update_macros_menu()
 
         # Check for any pending notifications from the new machine immediately
@@ -2002,8 +2079,8 @@ class MainWindow(Adw.ApplicationWindow):
     ):
         is_visible = value.get_boolean()
         action.set_state(value)
-        self._right_pane.set_visible(is_visible)
         get_context().config.set_right_panel_visible(is_visible)
+        self._apply_right_panel_visibility()
 
     def _on_dialog_notification(self, sender, message: str = ""):
         """Shows a toast when requested by a child dialog."""

--- a/rayforge/ui_gtk/settings/general_preferences_page.py
+++ b/rayforge/ui_gtk/settings/general_preferences_page.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 from gi.repository import Adw, GLib, Gtk
 
 from ...context import get_context
-from ...core.config import OpsColorMode, StartupBehavior
+from ...core.config import OpsColorMode, RightPanelMode, StartupBehavior
 from ...shared.units.definitions import (
     get_base_unit_for_quantity,
     get_units_for_quantity,
@@ -66,6 +66,14 @@ class GeneralPreferencesPage(TrackedPreferencesPage):
     OPS_COLOR_MODE_LABELS: ClassVar[list[str]] = [
         _("Laser Color"),
         _("Layer Color"),
+    ]
+
+    # Ordered right panel display modes shown in the combo row
+    RIGHT_PANEL_MODES: ClassVar[list[RightPanelMode]] = [
+        RightPanelMode.HIDDEN,
+        RightPanelMode.ACTIVE_LAYER,
+        RightPanelMode.NON_EMPTY_LAYERS,
+        RightPanelMode.ALL_LAYERS,
     ]
 
     # Language options: None (system default) + supported languages
@@ -139,6 +147,29 @@ class GeneralPreferencesPage(TrackedPreferencesPage):
             "notify::selected", self.on_ops_color_mode_changed
         )
         app_settings_group.add(self.ops_color_mode_row)
+
+        self.right_panel_mode_row = Adw.ComboRow(
+            model=Gtk.StringList.new(
+                [mode.label() for mode in self.RIGHT_PANEL_MODES]
+            )
+        )
+        self.right_panel_mode_row.set_title(_("Right Panel"))
+        self.right_panel_mode_row.set_subtitle(
+            _("Choose what the right panel displays")
+        )
+        try:
+            selected_index = self.RIGHT_PANEL_MODES.index(
+                config.right_panel_mode
+            )
+        except ValueError:
+            selected_index = self.RIGHT_PANEL_MODES.index(
+                RightPanelMode.NON_EMPTY_LAYERS
+            )
+        self.right_panel_mode_row.set_selected(selected_index)
+        self.right_panel_mode_row.connect(
+            "notify::selected", self.on_right_panel_mode_changed
+        )
+        app_settings_group.add(self.right_panel_mode_row)
 
         # Units Preferences
         units_group = Adw.PreferencesGroup()
@@ -440,6 +471,12 @@ class GeneralPreferencesPage(TrackedPreferencesPage):
         selected_index = combo_row.get_selected()
         mode_string = self.OPS_COLOR_MODE_MAP[selected_index]
         get_context().config.set_ops_color_mode(OpsColorMode(mode_string))
+
+    def on_right_panel_mode_changed(self, combo_row, _):
+        """Called when the user selects a new right panel mode."""
+        selected_index = combo_row.get_selected()
+        mode = self.RIGHT_PANEL_MODES[selected_index]
+        get_context().config.set_right_panel_mode(mode)
 
     def on_length_unit_changed(self, combo_row, _):
         """Called when the user selects a new length unit."""


### PR DESCRIPTION
## Summary
- Adds a new "Right Panel" combo row to Settings → General → Appearance with four modes: Hidden, Active Layer Workflow, All Non-Empty Layers (new default), and All Layers
- The right panel now builds one workflow view per displayed workflow instead of always showing only the active layer's; views are rebuilt only when the set of workflows changes and update in-place otherwise
- New `Layer.is_empty` property treats a layer with no user-facing items as empty; in "All Non-Empty Layers" mode, workflow views appear/disappear automatically as layers gain or lose content
- The 2D/3D canvas visibility toggle overlays shift dynamically: they leave room for the panel when it is shown and align flush right when it is hidden

## Testing
- `pixi run lint` (ruff, flake8, pyright): clean
- `pixi run test`: 6136 passed
- `pixi run uitest`: 735 passed