### PR TITLE
Add mirror tools to sketcher

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
@@ -23,6 +23,7 @@ from .grid import GridCommand
 from .items import AddItemsCommand
 from .line import LineCommand, LinePreviewState
 from .live_text_edit import LiveTextEditCommand
+from .mirror import MirrorAxis, MirrorCommand, MirrorDirection
 from .point import (
     MoveControlPointCommand,
     MovePointCommand,
@@ -68,6 +69,9 @@ __all__ = [
     "LineCommand",
     "LinePreviewState",
     "LiveTextEditCommand",
+    "MirrorAxis",
+    "MirrorCommand",
+    "MirrorDirection",
     "ModifyConstraintCommand",
     "ModifyTextPropertyCommand",
     "MoveControlPointCommand",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/mirror.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/mirror.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum, auto
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..entities import Ellipse, TextBoxEntity
+from ..types import EntityID
+from .base import SketchChangeCommand
+
+if TYPE_CHECKING:
+    from ..constraints import Constraint
+    from ..selection import SketchSelection
+    from ..sketch import Sketch
+
+logger = logging.getLogger(__name__)
+
+
+class MirrorDirection(Enum):
+    """
+    Direction of a mirror reflection.
+
+    VERTICAL: flip in the vertical direction (top↔bottom) → flips Y
+    coordinates, mirror axis is horizontal.
+    HORIZONTAL: flip in the horizontal direction (left↔right) → flips X
+    coordinates, mirror axis is vertical.
+    """
+
+    VERTICAL = auto()
+    HORIZONTAL = auto()
+
+
+@dataclass(frozen=True)
+class MirrorAxis:
+    """
+    Defines a mirror reflection axis.
+
+    - VERTICAL: horizontal axis at y=position → flips Y coords.
+    - HORIZONTAL: vertical axis at x=position → flips X coords.
+    """
+
+    direction: MirrorDirection
+    position: float
+
+    def apply(self, x: float, y: float) -> tuple[float, float]:
+        """Mirrors a point (x, y) across this axis."""
+        if self.direction == MirrorDirection.VERTICAL:
+            return (x, 2.0 * self.position - y)
+        return (2.0 * self.position - x, y)
+
+    def flip_offset(self, offset: tuple[float, float]) -> tuple[float, float]:
+        """Mirrors a (dx, dy) offset vector across this axis."""
+        if self.direction == MirrorDirection.VERTICAL:
+            return (offset[0], -offset[1])
+        return (-offset[0], offset[1])
+
+
+class MirrorCommand(SketchChangeCommand):
+    """
+    Mirrors the current selection in-place across an axis through the
+    bounding-box center of the selected points.
+
+    Points are mirrored centrally (shared points are de-duplicated).
+    Entity-specific state (bezier control-point deltas, arc chirality) is
+    handled polymorphically via ``Entity.mirror()``. Constraints that
+    reference geometry outside the selection are dropped. Internal
+    constraints are preserved; chirality-sensitive constraints (e.g.
+    AngleConstraint) are updated via ``Constraint.mirror()`` or dropped if
+    incompatible (expression-based angle).
+    """
+
+    def __init__(
+        self,
+        sketch: Sketch,
+        selection: SketchSelection,
+        direction: MirrorDirection,
+    ):
+        super().__init__(sketch, _("Mirror Selection"))
+        self._selection = selection
+        self._direction: MirrorDirection = direction
+        self._axis: MirrorAxis | None = None
+        self._dropped_constraints: list[Constraint] = []
+        # Save state of internal constraints that were mutated by mirror()
+        # so undo can restore them (e.g. AngleConstraint.value negation).
+        self._mirrored_constraint_states: dict[int, dict] = {}
+
+    @staticmethod
+    def prepare(
+        sketch: Sketch,
+        selection: SketchSelection,
+        direction: MirrorDirection,
+    ) -> (
+        tuple[
+            list[EntityID],
+            set[EntityID],
+            list[Constraint],
+            MirrorAxis,
+        ]
+        | None
+    ):
+        """
+        Pure function that resolves the mirror operation parameters.
+
+        Returns:
+            A tuple of (entity_ids_to_mirror, point_ids_to_mirror,
+            constraints_to_drop, mirror_axis), or None if the selection
+            is empty or contains no mirrorable geometry.
+        """
+        registry = sketch.registry
+
+        # 1. Resolve entity set (including compound helpers)
+        entity_id_set: set[EntityID] = set(selection.entity_ids)
+        point_id_set: set[EntityID] = set(selection.point_ids)
+
+        # Pull in helper lines for compound entities (same unity logic
+        # as RemoveItemsCommand.calculate_dependencies).
+        changed = True
+        while changed:
+            changed = False
+            for e in registry.entities:
+                helper_ids = None
+                if isinstance(e, TextBoxEntity):
+                    helper_ids = e.construction_line_ids
+                elif isinstance(e, Ellipse):
+                    helper_ids = e.helper_line_ids
+
+                if helper_ids and (
+                    e.id in entity_id_set
+                    or not entity_id_set.isdisjoint(helper_ids)
+                ):
+                    for hid in helper_ids:
+                        if hid not in entity_id_set:
+                            entity_id_set.add(hid)
+                            changed = True
+
+        # 2. Resolve point set from entities
+        for eid in entity_id_set:
+            e = registry.get_entity(eid)
+            if e:
+                point_id_set.update(e.get_point_ids())
+
+        if not point_id_set and not entity_id_set:
+            return None
+
+        if not point_id_set:
+            return None
+
+        # 3. Compute mirror axis = bbox center of selected points
+        xs = []
+        ys = []
+        for pid in point_id_set:
+            p = registry.get_point(pid)
+            if p:
+                xs.append(p.x)
+                ys.append(p.y)
+
+        if not xs:
+            return None
+
+        if direction == MirrorDirection.VERTICAL:
+            axis_pos = (min(ys) + max(ys)) / 2.0
+        else:
+            axis_pos = (min(xs) + max(xs)) / 2.0
+
+        axis = MirrorAxis(direction=direction, position=axis_pos)
+
+        # 4. Find constraints to drop:
+        #    - Constraints with at least one ref inside AND at least one
+        #      ref outside the selection.
+        #    - Constraints that are not mirror-compatible (e.g. expression-
+        #      based AngleConstraint) with all refs inside.
+        constraints_to_drop: list[Constraint] = []
+        for constr in sketch.constraints:
+            ref_points = constr.get_referenced_point_ids()
+            ref_entities = constr.get_referenced_entity_ids()
+
+            has_internal = bool(ref_points & point_id_set) or bool(
+                ref_entities & entity_id_set
+            )
+            has_external = bool(ref_points - point_id_set) or bool(
+                ref_entities - entity_id_set
+            )
+
+            if (
+                has_internal
+                and has_external
+                or (
+                    has_internal
+                    and not has_external
+                    and (not constr.is_mirror_compatible())
+                )
+            ):
+                constraints_to_drop.append(constr)
+
+        entity_ids = sorted(entity_id_set)
+        return entity_ids, point_id_set, constraints_to_drop, axis
+
+    def _do_execute(self) -> None:
+        result = self.prepare(self.sketch, self._selection, self._direction)
+        if result is None:
+            return
+
+        entity_ids, point_ids, dropped, axis = result
+        self._axis = axis
+        self._dropped_constraints = list(dropped)
+
+        registry = self.sketch.registry
+
+        # Mirror points
+        for pid in point_ids:
+            p = registry.get_point(pid)
+            if p and not p.fixed:
+                p.x, p.y = axis.apply(p.x, p.y)
+
+        # Mirror entity-specific state
+        for eid in entity_ids:
+            e = registry.get_entity(eid)
+            if e:
+                e.mirror(axis)
+
+        # Mirror internal constraints (e.g. negate angle values)
+        # Constraints that were dropped are skipped.
+        dropped_set = {id(c) for c in self._dropped_constraints}
+        for constr in self.sketch.constraints:
+            if id(constr) in dropped_set:
+                continue
+            ref_points = constr.get_referenced_point_ids()
+            ref_entities = constr.get_referenced_entity_ids()
+            has_internal = bool(ref_points & point_ids) or bool(
+                ref_entities & set(entity_ids)
+            )
+            has_external = bool(ref_points - point_ids) or bool(
+                ref_entities - set(entity_ids)
+            )
+            if has_internal and not has_external:
+                # Save value before mirroring so undo can restore it
+                # (e.g. AngleConstraint.mirror negates self.value)
+                if hasattr(constr, "value"):
+                    self._mirrored_constraint_states[id(constr)] = {
+                        "value": constr.value
+                    }
+                constr.mirror(axis)
+
+        # Drop incompatible constraints
+        for c in self._dropped_constraints:
+            if c in self.sketch.constraints:
+                self.sketch.constraints.remove(c)
+
+    def _do_undo(self) -> None:
+        # Restore constraint values that were mutated by mirror()
+        # (e.g. AngleConstraint.value negation).
+        for constr in self.sketch.constraints:
+            state = self._mirrored_constraint_states.get(id(constr))
+            if state and hasattr(constr, "value"):
+                constr.value = state["value"]
+
+        # Re-add dropped constraints.
+        for c in self._dropped_constraints:
+            if c not in self.sketch.constraints:
+                self.sketch.constraints.append(c)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/angle.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/angle.py
@@ -78,6 +78,30 @@ class AngleConstraint(Constraint):
     def get_type_key(cls) -> str:
         return "angle"
 
+    def get_referenced_entity_ids(self) -> set[EntityID]:
+        return {self.e1_id, self.e2_id}
+
+    def get_referenced_point_ids(self) -> set[EntityID]:
+        ids: set[EntityID] = set()
+        if self.e1_far_idx is not None:
+            ids.add(self.e1_far_idx)
+        if self.e2_far_idx is not None:
+            ids.add(self.e2_far_idx)
+        return ids
+
+    def is_mirror_compatible(self) -> bool:
+        # An expression-based angle encodes a user intent (e.g. "width/2")
+        # that does not auto-flip under reflection, so it cannot be
+        # preserved. A plain numeric angle can be negated — see mirror().
+        return self.expression is None
+
+    def mirror(self, axis) -> None:
+        # Reflection reverses the signed (CW) angle. Negate the numeric
+        # value so the constraint stays satisfied with the mirrored lines.
+        if self.expression is not None:
+            return  # should have been dropped via is_mirror_compatible
+        self.value = -self.value
+
     @classmethod
     def can_apply_to(
         cls, selection: SketchSelection, sketch: Sketch | None = None

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/base.py
@@ -17,6 +17,7 @@ from ..types import EntityID
 if TYPE_CHECKING:
     import cairo
 
+    from ..commands.mirror import MirrorAxis
     from ..params import ParameterContext
     from ..registry import EntityRegistry
     from ..selection import SketchSelection
@@ -212,16 +213,37 @@ class Constraint:
 
     def depends_on_points(self, point_ids: set[EntityID]) -> bool:
         """Checks if the constraint references any of the given point IDs."""
-        for attr in ["p1", "p2", "p3", "p4", "center", "point_id"]:
-            if hasattr(self, attr):
-                pid = getattr(self, attr)
-                if pid is not None and pid in point_ids:
-                    return True
-        return False
+        return not self.get_referenced_point_ids().isdisjoint(point_ids)
 
     def depends_on_entities(self, entity_ids: set[EntityID]) -> bool:
         """Checks if the constraint references any of the given entity IDs."""
-        for attr in [
+        return not self.get_referenced_entity_ids().isdisjoint(entity_ids)
+
+    def get_referenced_point_ids(self) -> set[EntityID]:
+        """
+        Returns the set of point IDs this constraint references.
+
+        Subclasses that reference points via attributes not covered by the
+        default ``p1``..``p4``, ``center``, ``point_id`` names must override
+        this.
+        """
+        ids: set[EntityID] = set()
+        for attr in ("p1", "p2", "p3", "p4", "center", "point_id"):
+            if hasattr(self, attr):
+                pid = getattr(self, attr)
+                if pid is not None:
+                    ids.add(pid)
+        return ids
+
+    def get_referenced_entity_ids(self) -> set[EntityID]:
+        """
+        Returns the set of entity IDs this constraint references.
+
+        Subclasses that reference entities via attributes not covered by the
+        default names must override this.
+        """
+        ids: set[EntityID] = set()
+        for attr in (
             "e1_id",
             "e2_id",
             "line_id",
@@ -229,18 +251,36 @@ class Constraint:
             "entity_id",
             "circle_id",
             "axis",
-        ]:
+        ):
             if hasattr(self, attr):
                 eid = getattr(self, attr)
-                if eid is not None and eid in entity_ids:
-                    return True
-        # Special case for lists of entities
-        for attr in ["entity_ids"]:
-            if hasattr(self, attr):
-                eids = getattr(self, attr)
-                if eids and not entity_ids.isdisjoint(eids):
-                    return True
-        return False
+                if eid is not None:
+                    ids.add(eid)
+        entity_ids_attr = getattr(self, "entity_ids", None)
+        if entity_ids_attr:
+            ids.update(entity_ids_attr)
+        return ids
+
+    def is_mirror_compatible(self) -> bool:
+        """
+        Returns True if this constraint can be preserved when *all* its
+        referenced entities/points are mirrored together.
+
+        The default is True: most geometric constraints are invariant under
+        reflection. Subclasses that encode chirality or a signed value
+        (e.g. AngleConstraint with an expression) should override this.
+        """
+        return True
+
+    def mirror(self, axis: MirrorAxis) -> None:
+        """
+        Updates internal state for a mirror transform applied to all
+        referenced geometry. The default is a no-op: most constraints are
+        mirror-invariant when their references move together.
+
+        Subclasses that encode chirality or a signed value should override
+        this (see AngleConstraint).
+        """
 
     def get_draggable_point(self) -> EntityID | None:
         """

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/parallelogram.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/parallelogram.py
@@ -32,6 +32,9 @@ class ParallelogramConstraint(Constraint):
         self.p_height: EntityID = p_height
         self.p4: EntityID = p4
 
+    def get_referenced_point_ids(self) -> set[EntityID]:
+        return {self.p_origin, self.p_width, self.p_height, self.p4}
+
     @classmethod
     def can_apply_to(
         cls, selection: SketchSelection, sketch: Sketch | None = None

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/arc.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/arc.py
@@ -16,6 +16,7 @@ from ..types import EntityID
 from .entity import Entity
 
 if TYPE_CHECKING:
+    from ..commands.mirror import MirrorAxis
     from ..constraints import Constraint
     from ..registry import EntityRegistry
 
@@ -46,6 +47,11 @@ class Arc(Entity):
         super().set_state(state)
         if "clockwise" in state:
             self.clockwise = state["clockwise"]
+
+    def mirror(self, axis: "MirrorAxis") -> None:
+        # Reflection reverses chirality: a clockwise arc becomes CCW and
+        # vice versa. Point positions are mirrored by the command.
+        self.clockwise = not self.clockwise
 
     def get_point_ids(self) -> list[EntityID]:
         return [self.start_idx, self.end_idx, self.center_idx]

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/bezier.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/bezier.py
@@ -14,6 +14,7 @@ from ..types import EntityID
 from .entity import Entity
 
 if TYPE_CHECKING:
+    from ..commands.mirror import MirrorAxis
     from ..constraints import Constraint
     from ..registry import EntityRegistry
 
@@ -34,6 +35,28 @@ class Bezier(Entity):
         self.type = "bezier"
         self.cp1 = cp1
         self.cp2 = cp2
+
+    def get_state(self) -> dict[str, Any] | None:
+        state = super().get_state() or {}
+        state["cp1"] = self.cp1
+        state["cp2"] = self.cp2
+        return state
+
+    def set_state(self, state: dict[str, Any]) -> None:
+        super().set_state(state)
+        if "cp1" in state:
+            self.cp1 = state["cp1"]
+        if "cp2" in state:
+            self.cp2 = state["cp2"]
+
+    def mirror(self, axis: "MirrorAxis") -> None:
+        # Control points are stored as (dx, dy) offsets relative to the
+        # start/end points. Since the endpoints are mirrored by the command,
+        # we must mirror the deltas too so the curve bulges correctly.
+        if self.cp1 is not None:
+            self.cp1 = axis.flip_offset(self.cp1)
+        if self.cp2 is not None:
+            self.cp2 = axis.flip_offset(self.cp2)
 
     def get_control_points(
         self, registry: "EntityRegistry"

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/entity.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/entity.py
@@ -7,6 +7,7 @@ from raygeo.geo.types import Polygon, Rect
 from ..types import EntityID
 
 if TYPE_CHECKING:
+    from ..commands.mirror import MirrorAxis
     from ..constraints import Constraint
     from ..registry import EntityRegistry
 
@@ -96,6 +97,17 @@ class Entity:
         should drag all points together).
         """
         return []
+
+    def mirror(self, axis: "MirrorAxis") -> None:
+        """
+        Updates entity-specific non-point state for a mirror transform.
+
+        Point positions are mirrored centrally by the command (since points
+        are shared resources in the registry). This method handles only
+        entity-internal state such as bezier control-point deltas or arc
+        chirality. The default is a no-op: entities whose geometry is fully
+        defined by their control points need no special handling.
+        """
 
     def is_contained_by(
         self,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/menu.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/menu.py
@@ -47,6 +47,12 @@ class SketchMenu(Gio.Menu):
             _("Toggle Construction"), "sketch.toggle_construction"
         )
         constr_group.append(_("Chamfer Corner"), "sketch.chamfer_corner")
+        constr_group.append(
+            _("Mirror Vertically"), "sketch.tool_mirror_vertical"
+        )
+        constr_group.append(
+            _("Mirror Horizontally"), "sketch.tool_mirror_horizontal"
+        )
         tools_menu.append_section(_("Modify"), constr_group)
 
         self.append_submenu(_("_Sketch"), tools_menu)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/piemenu.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/piemenu.py
@@ -72,6 +72,9 @@ class SketchPieMenu(PieMenu):
             if tool.ICON is None or tool.LABEL is None:
                 continue
 
+            if not tool.SHOW_IN_PIE:
+                continue
+
             if not tool.is_available(self.target, self.target_type):
                 continue
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/studio.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/studio.py
@@ -117,6 +117,31 @@ class SketchStudio(Gtk.Box):
         color_box.append(self.fill_color_button)
         toolbar.append(color_box)
 
+        mirror_sep = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+        toolbar.append(mirror_sep)
+
+        self.mirror_vertical_button = Gtk.Button()
+        self.mirror_vertical_button.set_child(
+            get_icon("flip-vertical-symbolic")
+        )
+        self.mirror_vertical_button.set_tooltip_text(_("Mirror Vertically"))
+        self.mirror_vertical_button.set_action_name(
+            "sketch.tool_mirror_vertical"
+        )
+        toolbar.append(self.mirror_vertical_button)
+
+        self.mirror_horizontal_button = Gtk.Button()
+        self.mirror_horizontal_button.set_child(
+            get_icon("flip-horizontal-symbolic")
+        )
+        self.mirror_horizontal_button.set_tooltip_text(
+            _("Mirror Horizontally")
+        )
+        self.mirror_horizontal_button.set_action_name(
+            "sketch.tool_mirror_horizontal"
+        )
+        toolbar.append(self.mirror_horizontal_button)
+
         spacer = Gtk.Box()
         spacer.set_hexpand(True)
         toolbar.append(spacer)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/__init__.py
@@ -14,6 +14,7 @@ from .fill_tool import FillTool
 from .fillet_tool import FilletTool
 from .grid_tool import GridTool
 from .horizontal_constraint_tool import HorizontalConstraintTool
+from .mirror_tool import MirrorHorizontalTool, MirrorVerticalTool
 from .path_tool import PathTool
 from .perpendicular_constraint_tool import PerpendicularConstraintTool
 from .radius_constraint_tool import RadiusConstraintTool
@@ -46,6 +47,8 @@ TOOL_REGISTRY = {
     "fillet": FilletTool,
     "grid": GridTool,
     "horizontal": HorizontalConstraintTool,
+    "mirror_vertical": MirrorVerticalTool,
+    "mirror_horizontal": MirrorHorizontalTool,
     "path": PathTool,
     "perpendicular": PerpendicularConstraintTool,
     "radius": RadiusConstraintTool,
@@ -103,6 +106,8 @@ __all__ = [
     "FilletTool",
     "GridTool",
     "HorizontalConstraintTool",
+    "MirrorHorizontalTool",
+    "MirrorVerticalTool",
     "PathTool",
     "PerpendicularConstraintTool",
     "RadiusConstraintTool",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
@@ -41,6 +41,7 @@ class SketchTool(ABC):
     LABEL: str | None = None
     SHORTCUTS: ClassVar[list[str]] = []
     CURSOR_ICON: str | None = None
+    SHOW_IN_PIE: bool = True
 
     def __init__(self, element: SketchElement):
         self.element = element

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/mirror_tool.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/mirror_tool.py
@@ -1,0 +1,71 @@
+from gettext import gettext as _
+from typing import TYPE_CHECKING, ClassVar, Union
+
+from ...core.commands import MirrorCommand, MirrorDirection
+from ...core.entities import Entity, Point
+from .base import SketchTool
+
+if TYPE_CHECKING:
+    from ...core.constraints import Constraint
+
+
+class MirrorVerticalTool(SketchTool):
+    ICON = "flip-vertical-symbolic"
+    LABEL = _("Mirror Vertically")
+    SHORTCUTS: ClassVar[list[str]] = ["mv"]
+    SHOW_IN_PIE = False
+
+    def is_available(
+        self,
+        target: Union[Point, Entity, "Constraint"] | None,
+        target_type: str | None,
+    ) -> bool:
+        sel = self.element.selection
+        return bool(sel.entity_ids or sel.point_ids)
+
+    def on_press(self, world_x: float, world_y: float, n_press: int) -> bool:
+        return True
+
+    def on_drag(self, world_dx: float, world_dy: float):
+        pass
+
+    def on_release(self, world_x: float, world_y: float):
+        pass
+
+    def on_activate(self):
+        sel = self.element.selection
+        cmd = MirrorCommand(self.element.sketch, sel, MirrorDirection.VERTICAL)
+        self.element.execute_command(cmd)
+        self.element.set_tool("select")
+
+
+class MirrorHorizontalTool(SketchTool):
+    ICON = "flip-horizontal-symbolic"
+    LABEL = _("Mirror Horizontally")
+    SHORTCUTS: ClassVar[list[str]] = ["mh"]
+    SHOW_IN_PIE = False
+
+    def is_available(
+        self,
+        target: Union[Point, Entity, "Constraint"] | None,
+        target_type: str | None,
+    ) -> bool:
+        sel = self.element.selection
+        return bool(sel.entity_ids or sel.point_ids)
+
+    def on_press(self, world_x: float, world_y: float, n_press: int) -> bool:
+        return True
+
+    def on_drag(self, world_dx: float, world_dy: float):
+        pass
+
+    def on_release(self, world_x: float, world_y: float):
+        pass
+
+    def on_activate(self):
+        sel = self.element.selection
+        cmd = MirrorCommand(
+            self.element.sketch, sel, MirrorDirection.HORIZONTAL
+        )
+        self.element.execute_command(cmd)
+        self.element.set_tool("select")

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_mirror_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_mirror_cmd.py
@@ -1,0 +1,434 @@
+import pytest
+from sketcher.core import Sketch
+from sketcher.core.commands import MirrorAxis, MirrorCommand, MirrorDirection
+from sketcher.core.constraints import (
+    AngleConstraint,
+    DistanceConstraint,
+    TangentConstraint,
+)
+from sketcher.core.entities import Arc, Bezier
+from sketcher.core.selection import SketchSelection
+
+
+@pytest.fixture
+def sketch_with_l():
+    """Two lines forming an L at (0,0)."""
+    s = Sketch()
+    p1 = s.add_point(-100, 0)  # left of corner
+    corner = s.add_point(0, 0)
+    p3 = s.add_point(0, 100)  # above corner
+    line1 = s.add_line(p1, corner)
+    line2 = s.add_line(corner, p3)
+    return s, [line1, line2], [p1, corner, p3]
+
+
+class TestMirrorPrepare:
+    def test_empty_selection_returns_none(self):
+        s = Sketch()
+
+        sel = SketchSelection()
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is None
+
+    def test_line_mirror_vertical(self, sketch_with_l):
+        s, entity_ids, point_ids = sketch_with_l
+
+        sel = SketchSelection()
+        sel.entity_ids = entity_ids
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is not None
+
+        ent_ids, pt_ids, dropped, axis = result
+        # bbox of points: x in [-100, 0], y in [0, 100]
+        # VERTICAL flips Y, axis at y = (0 + 100) / 2 = 50
+        assert axis.direction == MirrorDirection.VERTICAL
+        assert axis.position == pytest.approx(50.0)
+        assert set(ent_ids) == set(entity_ids)
+        assert set(pt_ids) == set(point_ids)
+        assert dropped == []
+
+    def test_line_mirror_horizontal(self, sketch_with_l):
+        s, entity_ids, _point_ids = sketch_with_l
+
+        sel = SketchSelection()
+        sel.entity_ids = entity_ids
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.HORIZONTAL)
+        assert result is not None
+
+        _, _, _, axis = result
+        # HORIZONTAL flips X, axis at x = (-100 + 0) / 2 = -50
+        assert axis.direction == MirrorDirection.HORIZONTAL
+        assert axis.position == pytest.approx(-50.0)
+
+    def test_external_constraint_dropped(self):
+        """TangentConstraint with unselected shape is dropped."""
+        s = Sketch()
+        # Line (selected) tangent to circle (not selected)
+        lp1 = s.add_point(0, 50)
+        lp2 = s.add_point(100, 50)
+        line_id = s.add_line(lp1, lp2)
+
+        cc = s.add_point(50, 0)
+        cr = s.add_point(50, 40)
+        circle_id = s.add_circle(cc, cr)
+
+        s.constraints.append(TangentConstraint(line_id, circle_id))
+
+        sel = SketchSelection()
+        sel.entity_ids = [line_id]
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is not None
+        _, _, dropped, _ = result
+        assert len(dropped) == 1
+        assert isinstance(dropped[0], TangentConstraint)
+
+    def test_internal_constraint_kept(self):
+        """DistanceConstraint between two selected points is kept."""
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        line_id = s.add_line(p1, p2)
+
+        s.constraints.append(DistanceConstraint(p1, p2, 100.0))
+
+        sel = SketchSelection()
+        sel.entity_ids = [line_id]
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is not None
+        _, _, dropped, _ = result
+        assert dropped == []
+
+    def test_expression_angle_constraint_dropped(self):
+        """Expression-based AngleConstraint is not mirror-compatible."""
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        p3 = s.add_point(100, 100)
+        # Two lines forming an angle at p2
+        l1 = s.add_line(p1, p2)
+        l2 = s.add_line(p2, p3)
+
+        s.constraints.append(
+            AngleConstraint(l1, l2, value=45.0, expression="45")
+        )
+
+        sel = SketchSelection()
+        sel.entity_ids = [l1, l2]
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is not None
+        _, _, dropped, _ = result
+        assert len(dropped) == 1
+        assert isinstance(dropped[0], AngleConstraint)
+
+    def test_numeric_angle_constraint_kept(self):
+        """Plain numeric AngleConstraint is mirror-compatible."""
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        p3 = s.add_point(100, 100)
+        l1 = s.add_line(p1, p2)
+        l2 = s.add_line(p2, p3)
+
+        s.constraints.append(AngleConstraint(l1, l2, value=45.0))
+
+        sel = SketchSelection()
+        sel.entity_ids = [l1, l2]
+        result = MirrorCommand.prepare(s, sel, MirrorDirection.VERTICAL)
+        assert result is not None
+        _, _, dropped, _ = result
+        assert dropped == []
+
+
+class TestMirrorAxis:
+    def test_vertical_flips_y(self):
+        axis = MirrorAxis(MirrorDirection.VERTICAL, 50.0)
+        assert axis.apply(10, 0) == (10, 100)
+        assert axis.apply(10, 100) == (10, 0)
+        assert axis.apply(10, 50) == (10, 50)
+
+    def test_horizontal_flips_x(self):
+        axis = MirrorAxis(MirrorDirection.HORIZONTAL, 50.0)
+        assert axis.apply(0, 10) == (100, 10)
+        assert axis.apply(100, 10) == (0, 10)
+        assert axis.apply(50, 10) == (50, 10)
+
+    def test_flip_offset_vertical(self):
+        axis = MirrorAxis(MirrorDirection.VERTICAL, 0.0)
+        assert axis.flip_offset((30, 40)) == (30, -40)
+
+    def test_flip_offset_horizontal(self):
+        axis = MirrorAxis(MirrorDirection.HORIZONTAL, 0.0)
+        assert axis.flip_offset((30, 40)) == (-30, 40)
+
+
+class TestMirrorExecute:
+    def test_line_points_mirrored_in_place(self, sketch_with_l):
+        s, entity_ids, point_ids = sketch_with_l
+
+        sel = SketchSelection()
+        sel.entity_ids = entity_ids
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        s.notify_update = lambda: None  # avoid solver for unit test
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        p1 = s.registry.get_point(point_ids[0])
+        corner = s.registry.get_point(point_ids[1])
+        p3 = s.registry.get_point(point_ids[2])
+
+        # Original: p1=(-100,0), corner=(0,0), p3=(0,100)
+        # VERTICAL flips Y, axis at y=50. Mirrored:
+        # p1: x=-100, y=2*50-0=100 -> (-100, 100)
+        # corner: x=0, y=2*50-0=100 -> (0, 100)
+        # p3: x=0, y=2*50-100=0 -> (0, 0)
+        assert p1.x == pytest.approx(-100)
+        assert p1.y == pytest.approx(100)
+        assert corner.x == pytest.approx(0)
+        assert corner.y == pytest.approx(100)
+        assert p3.x == pytest.approx(0)
+        assert p3.y == pytest.approx(0)
+
+    def test_no_new_points_created(self, sketch_with_l):
+        s, entity_ids, _point_ids = sketch_with_l
+        original_point_count = len(s.registry.points)
+
+        sel = SketchSelection()
+        sel.entity_ids = entity_ids
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        assert len(s.registry.points) == original_point_count
+
+    def test_arc_clockwise_toggled(self):
+        s = Sketch()
+        start = s.add_point(100, 0)
+        end = s.add_point(0, 100)
+        center = s.add_point(0, 0)
+        arc_id = s.add_arc(start, end, center, clockwise=True)
+
+        sel = SketchSelection()
+        sel.entity_ids = [arc_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        arc = s.registry.get_entity(arc_id)
+        assert isinstance(arc, Arc)
+        assert arc.clockwise is False
+
+    def test_bezier_cp_deltas_flipped(self):
+        s = Sketch()
+        start = s.add_point(0, 0)
+        end = s.add_point(100, 0)
+        bezier_id = s.add_bezier(start, end, cp1=(30, 40), cp2=(-20, -10))
+
+        sel = SketchSelection()
+        sel.entity_ids = [bezier_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        bezier = s.registry.get_entity(bezier_id)
+        assert isinstance(bezier, Bezier)
+        # Vertical mirror flips dy component of cp deltas
+        assert bezier.cp1 == (30, -40)
+        assert bezier.cp2 == (-20, 10)
+
+    def test_external_constraint_removed(self):
+        """TangentConstraint to unselected circle is removed on execute."""
+        s = Sketch()
+        lp1 = s.add_point(0, 50)
+        lp2 = s.add_point(100, 50)
+        line_id = s.add_line(lp1, lp2)
+        cc = s.add_point(50, 0)
+        cr = s.add_point(50, 40)
+        circle_id = s.add_circle(cc, cr)
+        s.constraints.append(TangentConstraint(line_id, circle_id))
+
+        sel = SketchSelection()
+        sel.entity_ids = [line_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        assert len(s.constraints) == 0
+
+    def test_internal_distance_constraint_kept(self):
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        line_id = s.add_line(p1, p2)
+        s.constraints.append(DistanceConstraint(p1, p2, 100.0))
+
+        sel = SketchSelection()
+        sel.entity_ids = [line_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        assert len(s.constraints) == 1
+        assert isinstance(s.constraints[0], DistanceConstraint)
+
+    def test_numeric_angle_value_negated(self):
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        p3 = s.add_point(100, 100)
+        l1 = s.add_line(p1, p2)
+        l2 = s.add_line(p2, p3)
+        s.constraints.append(AngleConstraint(l1, l2, value=45.0))
+
+        sel = SketchSelection()
+        sel.entity_ids = [l1, l2]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        assert len(s.constraints) == 1
+        assert s.constraints[0].value == pytest.approx(-45.0)
+
+
+class TestMirrorUndo:
+    def test_undo_restores_points(self, sketch_with_l):
+        s, entity_ids, point_ids = sketch_with_l
+
+        sel = SketchSelection()
+        sel.entity_ids = entity_ids
+
+        # Save original positions
+        originals = {}
+        for pid in point_ids:
+            p = s.registry.get_point(pid)
+            originals[pid] = (p.x, p.y)
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.execute()
+
+        # Verify points moved (VERTICAL flips Y)
+        moved = any(
+            s.registry.get_point(pid).y != originals[pid][1]
+            for pid in point_ids
+        )
+        assert moved
+
+        cmd.undo()
+
+        for pid in point_ids:
+            p = s.registry.get_point(pid)
+            assert p.x == pytest.approx(originals[pid][0])
+            assert p.y == pytest.approx(originals[pid][1])
+
+    def test_undo_restores_arc_clockwise(self):
+        s = Sketch()
+        start = s.add_point(100, 0)
+        end = s.add_point(0, 100)
+        center = s.add_point(0, 0)
+        arc_id = s.add_arc(start, end, center, clockwise=True)
+
+        sel = SketchSelection()
+        sel.entity_ids = [arc_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.execute()
+
+        arc = s.registry.get_entity(arc_id)
+        assert isinstance(arc, Arc)
+        assert arc.clockwise is False
+
+        cmd.undo()
+
+        arc = s.registry.get_entity(arc_id)
+        assert isinstance(arc, Arc)
+        assert arc.clockwise is True
+
+    def test_undo_restores_bezier_cps(self):
+        s = Sketch()
+        start = s.add_point(0, 0)
+        end = s.add_point(100, 0)
+        bezier_id = s.add_bezier(start, end, cp1=(30, 40), cp2=(-20, -10))
+
+        sel = SketchSelection()
+        sel.entity_ids = [bezier_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.execute()
+
+        bezier = s.registry.get_entity(bezier_id)
+        assert isinstance(bezier, Bezier)
+        assert bezier.cp1 == (30, -40)
+
+        cmd.undo()
+
+        bezier = s.registry.get_entity(bezier_id)
+        assert isinstance(bezier, Bezier)
+        assert bezier.cp1 == (30, 40)
+        assert bezier.cp2 == (-20, -10)
+
+    def test_undo_re_adds_dropped_constraints(self):
+        s = Sketch()
+        lp1 = s.add_point(0, 50)
+        lp2 = s.add_point(100, 50)
+        line_id = s.add_line(lp1, lp2)
+        cc = s.add_point(50, 0)
+        cr = s.add_point(50, 40)
+        circle_id = s.add_circle(cc, cr)
+        s.constraints.append(TangentConstraint(line_id, circle_id))
+
+        sel = SketchSelection()
+        sel.entity_ids = [line_id]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.execute()
+        assert len(s.constraints) == 0
+
+        cmd.undo()
+        assert len(s.constraints) == 1
+        assert isinstance(s.constraints[0], TangentConstraint)
+
+    def test_undo_restores_angle_value(self):
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        p3 = s.add_point(100, 100)
+        l1 = s.add_line(p1, p2)
+        l2 = s.add_line(p2, p3)
+        s.constraints.append(AngleConstraint(l1, l2, value=45.0))
+
+        sel = SketchSelection()
+        sel.entity_ids = [l1, l2]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.execute()
+        assert s.constraints[0].value == pytest.approx(-45.0)
+
+        cmd.undo()
+        assert s.constraints[0].value == pytest.approx(45.0)
+
+
+class TestMirrorBarePoints:
+    def test_bare_point_selection_mirrors_points(self):
+        s = Sketch()
+        p1 = s.add_point(0, 0)
+        p2 = s.add_point(100, 0)
+        p3 = s.add_point(50, 100)
+
+        sel = SketchSelection()
+        sel.point_ids = [p1, p2, p3]
+
+        cmd = MirrorCommand(s, sel, MirrorDirection.VERTICAL)
+        cmd.capture_snapshot()
+        cmd._do_execute()
+
+        # bbox y: [0, 100], VERTICAL flips Y, axis at y=50
+        # p1: y=2*50-0=100, p2: y=2*50-0=100, p3: y=2*50-100=0
+        assert s.registry.get_point(p1).y == pytest.approx(100)
+        assert s.registry.get_point(p2).y == pytest.approx(100)
+        assert s.registry.get_point(p3).y == pytest.approx(0)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/entities/test_bezier_entity.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/entities/test_bezier_entity.py
@@ -172,7 +172,11 @@ def test_bezier_get_set_state(registry):
     bezier = registry.get_entity(bid)
 
     state = bezier.get_state()
-    assert state == {"construction": False}
+    assert state == {
+        "construction": False,
+        "cp1": None,
+        "cp2": None,
+    }
 
     bezier.construction = True
 


### PR DESCRIPTION
Add Mirror Vertically and Mirror Horizontally toolbar buttons that mirror the current selection in-place across the bounding-box center.

## Behavior

- Select entities and/or points, click a mirror button — selection is reflected in-place (no duplicates created)
- Mirror axis passes through the bounding-box center of selected points
- Mirror Vertically: flips Y coordinates (top↔bottom)
- Mirror Horizontally: flips X coordinates (left↔right)
- Constraints spanning the selection boundary are dropped
- Internal constraints are preserved; chirality-sensitive constraints (AngleConstraint) are negated or dropped if expression-based
- Full undo support

## Architecture

Polymorphic design mirroring the existing entity/constraint OOP pattern:

- `Entity.mirror(axis)` — no-op default; Bezier flips cp deltas, Arc toggles clockwise
- `Constraint.mirror(axis)` + `is_mirror_compatible()` — no-op default; AngleConstraint negates signed value
- `MirrorCommand` orchestrates: resolves entity/point set, mirrors points centrally, delegates entity-specific state to `mirror()`, drops incompatible constraints
- `MirrorDirection` enum, `MirrorAxis` dataclass with `apply()` and `flip_offset()`

## Additional changes

- `Constraint.get_referenced_point_ids()` / `get_referenced_entity_ids()` refactored from `depends_on_*` for reuse (overrides in AngleConstraint and ParallelogramConstraint)
- `Bezier.get_state()`/`set_state()` extended to include cp1/cp2 for snapshot-based undo
- `SHOW_IN_PIE` flag on `SketchTool` to exclude mirror tools from the pie menu (toolbar-only)
- Toolbar buttons placed after the fill color selector with a separator
- Also accessible via Sketch → Modify menu

Refs #358