### PR TITLE
Sketcher: saved-state tracking, history fixes, undo/redo toolbar

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
@@ -25,6 +25,7 @@ from .line import LineCommand, LinePreviewState
 from .live_text_edit import LiveTextEditCommand
 from .point import (
     MoveControlPointCommand,
+    MoveEntitiesCommand,
     MovePointCommand,
     UnstickJunctionCommand,
 )
@@ -71,6 +72,7 @@ __all__ = [
     "ModifyConstraintCommand",
     "ModifyTextPropertyCommand",
     "MoveControlPointCommand",
+    "MoveEntitiesCommand",
     "MovePointCommand",
     "PreviewState",
     "RectangleCommand",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint.py
@@ -4,6 +4,8 @@ import logging
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
+from rayforge.core.undo.command import Command
+
 from .base import SketchChangeCommand
 
 if TYPE_CHECKING:
@@ -41,3 +43,18 @@ class ModifyConstraintCommand(SketchChangeCommand):
     def _do_undo(self) -> None:
         self.constraint.value = self.old_value
         self.constraint.expression = self.old_expression
+
+    def can_coalesce_with(self, next_command: Command) -> bool:
+        return (
+            isinstance(next_command, ModifyConstraintCommand)
+            and self.constraint is next_command.constraint
+        )
+
+    def coalesce_with(self, next_command: Command) -> bool:
+        if not self.can_coalesce_with(next_command):
+            return False
+        assert isinstance(next_command, ModifyConstraintCommand)
+        self.new_value = next_command.new_value
+        self.new_expression = next_command.new_expression
+        self.timestamp = next_command.timestamp
+        return True

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint_create.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/constraint_create.py
@@ -4,6 +4,8 @@ import math
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
+from rayforge.core.undo.command import Command
+
 from ..constraints import (
     DiameterConstraint,
     DistanceConstraint,
@@ -11,6 +13,7 @@ from ..constraints import (
 )
 from ..entities import Arc, Circle, Entity, Line
 from .base import SketchChangeCommand
+from .constraint import ModifyConstraintCommand
 from .items import AddItemsCommand
 
 if TYPE_CHECKING:
@@ -183,6 +186,27 @@ class CreateOrEditConstraintCommand(SketchChangeCommand):
     def _do_undo(self) -> None:
         if self._add_cmd is not None:
             self._add_cmd._do_undo()
+
+    def should_skip_undo(self) -> bool:
+        # Skip history for no-op case where an existing constraint was
+        # found and no new one was created.
+        return self._add_cmd is None and self._created_constraint is None
+
+    def can_coalesce_with(self, next_command: Command) -> bool:
+        return (
+            isinstance(next_command, ModifyConstraintCommand)
+            and self._created_constraint is not None
+            and next_command.constraint is self._created_constraint
+        )
+
+    def coalesce_with(self, next_command: Command) -> bool:
+        if not self.can_coalesce_with(next_command):
+            return False
+        # Adopt the new value from the modify command so that undo
+        # correctly removes the constraint entirely (via _add_cmd._do_undo)
+        # rather than reverting to the initial default value.
+        self.timestamp = next_command.timestamp
+        return True
 
     def _get_command_label(self, constraint: Constraint) -> str:
         return _("Add {}").format(constraint.get_type_name())

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/point.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/point.py
@@ -230,3 +230,53 @@ class UnstickJunctionCommand(SketchChangeCommand):
             registry.points = [
                 p for p in registry.points if p.id != self.new_point.id
             ]
+
+
+class MoveEntitiesCommand(SketchChangeCommand):
+    """An undoable command for moving one or more entities as a group."""
+
+    def __init__(
+        self,
+        sketch: Sketch,
+        entity_ids: list[EntityID],
+        start_positions: dict[EntityID, GeoPoint],
+        end_positions: dict[EntityID, GeoPoint],
+        snapshot: tuple[dict[EntityID, GeoPoint], dict[EntityID, Any]]
+        | None = None,
+    ):
+        super().__init__(sketch, _("Move Entities"))
+        self.entity_ids = list(entity_ids)
+        self.start_positions = dict(start_positions)
+        self.end_positions = dict(end_positions)
+        if snapshot:
+            self._snapshot = snapshot
+
+    def _apply_positions(self, positions: dict[EntityID, GeoPoint]):
+        registry = self.sketch.registry
+        for pid, (x, y) in positions.items():
+            try:
+                p = registry.get_point(pid)
+                p.x = x
+                p.y = y
+            except IndexError:
+                pass
+
+    def _do_execute(self) -> None:
+        self._apply_positions(self.end_positions)
+
+    def _do_undo(self) -> None:
+        self._apply_positions(self.start_positions)
+
+    def can_coalesce_with(self, next_command: Command) -> bool:
+        return (
+            isinstance(next_command, MoveEntitiesCommand)
+            and self.entity_ids == next_command.entity_ids
+        )
+
+    def coalesce_with(self, next_command: Command) -> bool:
+        if not self.can_coalesce_with(next_command):
+            return False
+        assert isinstance(next_command, MoveEntitiesCommand)
+        self.end_positions = next_command.end_positions
+        self.timestamp = next_command.timestamp
+        return True

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketch_mode_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketch_mode_cmd.py
@@ -37,6 +37,58 @@ class SketchModeCmd:
         self._editor = editor
         self.active_sketch_workpiece: WorkPiece | None = None
         self._is_editing_new_sketch = False
+        self._sketch_history_connected = False
+        self._doc_was_saved_on_entry: bool = True
+
+    def _on_sketch_history_changed(self, sender, **kwargs):
+        """Updates the document's saved state based on the sketch history.
+
+        If the sketch has been modified away from its entry state, the
+        document is marked as unsaved. If the sketch is undone back to its
+        entry state, the document's saved state is restored to what it was
+        before entering the sketcher.
+        """
+        sketch_editor = self._get_active_sketch_editor()
+        if not sketch_editor:
+            return
+        if sketch_editor.history_manager.is_at_checkpoint():
+            if self._doc_was_saved_on_entry:
+                self._editor.mark_as_saved()
+            else:
+                self._editor.mark_as_unsaved()
+        else:
+            self._editor.mark_as_unsaved()
+
+    def _get_active_sketch_editor(self):
+        sketch_studio = _get_sketch_studio()
+        if not sketch_studio:
+            return None
+        return sketch_studio.canvas.sketch_editor
+
+    def _connect_sketch_history(self, sketch_studio: "SketchStudio"):
+        """Connects the sketch editor's history to the document's
+        saved-state tracking so edits mark the project as changed."""
+        if self._sketch_history_connected:
+            return
+        sketch_editor = sketch_studio.canvas.sketch_editor
+        if sketch_editor:
+            self._doc_was_saved_on_entry = self._editor.is_saved
+            sketch_editor.history_manager.set_checkpoint()
+            sketch_editor.history_manager.changed.connect(
+                self._on_sketch_history_changed
+            )
+            self._sketch_history_connected = True
+
+    def _disconnect_sketch_history(self, sketch_studio: "SketchStudio"):
+        """Disconnects the sketch history handler."""
+        if not self._sketch_history_connected:
+            return
+        sketch_editor = sketch_studio.canvas.sketch_editor
+        if sketch_editor:
+            sketch_editor.history_manager.changed.disconnect(
+                self._on_sketch_history_changed
+            )
+        self._sketch_history_connected = False
 
     def enter_sketch_mode(
         self, workpiece: WorkPiece, is_new_sketch: bool = False
@@ -70,6 +122,7 @@ class SketchModeCmd:
             self._win.menubar.set_menu_model(sketch_studio.menu_model)
             self._win.insert_action_group("sketch", sketch_studio.action_group)
             self._win.add_controller(sketch_studio.shortcut_controller)
+            self._connect_sketch_history(sketch_studio)
         except Exception:
             logger.exception("Failed to load sketch for editing")
 
@@ -80,6 +133,7 @@ class SketchModeCmd:
         self._win.insert_action_group("sketch", None)
         if sketch_studio:
             self._win.remove_controller(sketch_studio.shortcut_controller)
+            self._disconnect_sketch_history(sketch_studio)
 
         self._win.close_modal_page()
         self.active_sketch_workpiece = None
@@ -102,6 +156,7 @@ class SketchModeCmd:
             self._win.menubar.set_menu_model(sketch_studio.menu_model)
             self._win.insert_action_group("sketch", sketch_studio.action_group)
             self._win.add_controller(sketch_studio.shortcut_controller)
+            self._connect_sketch_history(sketch_studio)
         except Exception:
             logger.exception("Failed to load sketch definition for editing")
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchcanvas.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchcanvas.py
@@ -397,7 +397,7 @@ class SketchCanvas(WorldSurface):
                     new_value=new_value,
                     new_expression=new_expr,
                 )
-                self.sketch_editor.history_manager.execute(cmd)
+                self.sketch_editor.history_manager.coalesce(cmd)
 
             # Explicitly close the dialog
             dialog.close()

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/studio.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/studio.py
@@ -9,6 +9,7 @@ from rayforge.core.varset import FloatVar, IntVar, SliderFloatVar, Var
 from rayforge.ui_gtk.icons import get_icon
 from rayforge.ui_gtk.shared.keyboard import PRIMARY_ACCEL
 from rayforge.ui_gtk.shared.status_bar import StatusBar
+from rayforge.ui_gtk.shared.undo_button import RedoButton, UndoButton
 from rayforge.ui_gtk.varset.varset_editor import VarSetEditorWidget
 
 from ..core.entities.text_box import TextBoxEntity
@@ -46,6 +47,10 @@ class SketchStudio(Gtk.Box):
         self.finished = Signal()
         self.cancelled = Signal()
 
+        # Flag to suppress spurious commands while programmatically
+        # populating UI fields (e.g. the name row) during set_sketch.
+        self._suppress_name_changed = False
+
         self._build_ui()
 
     def set_world_size(self, width_mm: float, height_mm: float):
@@ -65,6 +70,19 @@ class SketchStudio(Gtk.Box):
         toolbar.set_margin_start(12)
         toolbar.set_margin_end(12)
         self.append(toolbar)
+
+        self.undo_button = UndoButton()
+        self.undo_button.set_tooltip_text(_("Undo"))
+        self.undo_button.set_action_name("sketch.undo")
+        toolbar.append(self.undo_button)
+
+        self.redo_button = RedoButton()
+        self.redo_button.set_tooltip_text(_("Redo"))
+        self.redo_button.set_action_name("sketch.redo")
+        toolbar.append(self.redo_button)
+
+        sep = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+        toolbar.append(sep)
 
         self.constraints_button = Gtk.ToggleButton()
         self.constraints_button.set_child(
@@ -340,7 +358,9 @@ class SketchStudio(Gtk.Box):
         self.canvas.set_sketch(sketch)
 
         # Populate side panel with sketch data
+        self._suppress_name_changed = True
         self.name_row.set_text(sketch.name)
+        self._suppress_name_changed = False
         self.varset_editor.populate(sketch.input_parameters)
 
         # Connect to selection changes to show/hide font properties
@@ -371,6 +391,15 @@ class SketchStudio(Gtk.Box):
             self.conflicts_widget.set_sketch_element(
                 self.canvas.sketch_element
             )
+
+            # Connect undo/redo buttons to the sketch editor's history
+            if self.canvas.sketch_editor:
+                self.undo_button.set_history_manager(
+                    self.canvas.sketch_editor.history_manager
+                )
+                self.redo_button.set_history_manager(
+                    self.canvas.sketch_editor.history_manager
+                )
 
             # Connect to text editing signals to show font properties
             text_tool = self.canvas.sketch_element.tools.get("text_box")
@@ -404,6 +433,8 @@ class SketchStudio(Gtk.Box):
 
     def _on_name_changed(self, entry_row: Adw.EntryRow):
         """Updates the sketch's name with undo support."""
+        if self._suppress_name_changed:
+            return
         if not self.canvas or not self.canvas.sketch_element:
             return
         sketch = self.canvas.sketch_element.sketch

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/select_tool.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/select_tool.py
@@ -15,6 +15,7 @@ from raygeo.geo.types import Point as GeoPoint
 from ...core.commands import (
     CreateOrEditConstraintCommand,
     MoveControlPointCommand,
+    MoveEntitiesCommand,
     MovePointCommand,
 )
 from ...core.constraints import (
@@ -390,6 +391,30 @@ class SelectTool(SnapMixin, SketchTool):
                     self.element.execute_command(cmd)
 
                 self.current_snap_result = None
+
+        # If an entity (or group) was dragged, create an undoable command
+        if self.dragged_entity is not None and self.drag_initial_positions:
+            end_positions = {}
+            moved = False
+            for pid, (sx, sy) in self.drag_initial_positions.items():
+                p = self._safe_get_point(pid)
+                if p:
+                    end_positions[pid] = (p.x, p.y)
+                    if abs(p.x - sx) > 1e-6 or abs(p.y - sy) > 1e-6:
+                        moved = True
+            if moved:
+                snapshot = (
+                    self.drag_initial_positions.copy(),
+                    self.drag_initial_entity_states.copy(),
+                )
+                cmd = MoveEntitiesCommand(
+                    self.element.sketch,
+                    list(self.element.selection.entity_ids),
+                    self.drag_initial_positions,
+                    end_positions,
+                    snapshot=snapshot,
+                )
+                self.element.execute_command(cmd)
 
         # Clear all drag-related state
         self.dragged_point_id = None

--- a/rayforge/core/undo/history.py
+++ b/rayforge/core/undo/history.py
@@ -80,6 +80,25 @@ class HistoryManager:
             return
         self._add_to_history(command)
 
+    def coalesce(self, command: Command):
+        """
+        Executes a command and forces it to coalesce with the previous
+        command on the undo stack, bypassing the time threshold.
+
+        This is used for actions that are logically a single user operation
+        but are split across multiple commands with arbitrary delays
+        between them (e.g., creating a constraint and then editing its
+        value via a dialog).
+        """
+        command.execute()
+        if self.in_transaction:
+            self.transaction_commands.append(command)
+            return
+        if self.undo_stack and self.undo_stack[-1].coalesce_with(command):
+            self.changed.send(self, command=self.undo_stack[-1])
+            return
+        self._add_to_history(command)
+
     def _add_to_history(self, command: Command):
         """
         Adds a command to the undo stack, handling the coalescing logic.

--- a/rayforge/ui_gtk/canvas/canvas.py
+++ b/rayforge/ui_gtk/canvas/canvas.py
@@ -734,6 +734,16 @@ class Canvas(Gtk.DrawingArea):
             ok, start_x, start_y = self._drag_gesture.get_start_point()
             if not ok:
                 return
+            if not self._edit_dragging:
+                # Apply a threshold to distinguish clicks from real
+                # drags. This prevents sub-pixel jitter (e.g. between
+                # the two clicks of a double-click) from triggering
+                # tool drag logic.
+                dist_sq = offset_x**2 + offset_y**2
+                if dist_sq < (DRAG_THRESHOLD**2):
+                    return
+                self._edit_dragging = True
+                self.edit_drag_begin.send(self)
             current_x, current_y = start_x + offset_x, start_y + offset_y
             start_world_x, start_world_y = self._get_world_coords(
                 start_x, start_y
@@ -743,9 +753,6 @@ class Canvas(Gtk.DrawingArea):
             )
             world_dx = current_world_x - start_world_x
             world_dy = current_world_y - start_world_y
-            if not self._edit_dragging:
-                self._edit_dragging = True
-                self.edit_drag_begin.send(self)
             logger.debug(
                 f"on_mouse_drag: calling handle_edit_drag with "
                 f"dx={world_dx}, dy={world_dy}"


### PR DESCRIPTION
## Summary

A set of fixes for the sketcher around document saved-state tracking and undo/redo history:

- **Ctrl+S now works in the sketcher**: unhandled Ctrl-based key presses propagate to the application-level shortcut controller instead of being swallowed by the tool shortcut sequence handler.
- **Document is marked as changed while editing the sketch**: the sketcher's own HistoryManager is now connected to the document's saved-state tracking. Undoing back to the state at sketch entry restores the previous saved state.
- **Dragging an entity creates an undoable command**: added `MoveEntitiesCommand`; previously moving a complete line bypassed the history entirely (not undoable, did not mark doc as changed).
- **Constraint add + edit dialog coalesce into one history entry**: new `HistoryManager.coalesce()` forces coalescing with the previous command, bypassing the 0.5s time threshold. The no-op `CreateOrEditConstraintCommand` (when an existing constraint is found) is skipped from history.
- **Drag threshold in edit mode**: prevents sub-pixel mouse jitter between double-clicks from registering a spurious "Move Entities" history entry.
- **No more spurious "Rename Sketch" history entry** when opening a sketch (caused by programmatically setting the name row text).
- **Undo/redo buttons with dropdown history** added to the sketcher toolbar.

## Testing

- `pixi run lint` passes
- Sketcher UI tests: 152 passed
- Core undo tests: 78 passed