### PR TITLE
Sketcher: nudge selected entities with arrow keys

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/editor.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/editor.py
@@ -409,6 +409,26 @@ class SketchEditor:
             self._reset_key_sequence()
             return True
 
+        # Priority 1.5: Nudge selected entities with arrow keys
+        if preview_state is None:
+            move_amount = 1.0
+            if is_shift:
+                move_amount *= 10.0
+            elif is_primary:
+                move_amount *= 0.1
+
+            nudge_deltas = {
+                Gdk.KEY_Up: (0.0, move_amount),
+                Gdk.KEY_Down: (0.0, -move_amount),
+                Gdk.KEY_Left: (-move_amount, 0.0),
+                Gdk.KEY_Right: (move_amount, 0.0),
+            }
+            if keyval in nudge_deltas:
+                self._reset_key_sequence()
+                dx, dy = nudge_deltas[keyval]
+                self.sketch_element.nudge_selection(dx, dy)
+                return True
+
         # Priority 2: Escape key logic
         if keyval == Gdk.KEY_Escape:
             self._reset_key_sequence()

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchelement.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchelement.py
@@ -7,8 +7,8 @@ from raygeo.geo import Matrix
 
 from rayforge.ui_gtk.canvas import CanvasElement
 
-from ..core.commands import DuplicateCommand
-from ..core.entities import Line
+from ..core.commands import DuplicateCommand, MoveEntitiesCommand
+from ..core.entities import Line, Point
 from ..core.selection import SketchSelection
 from ..core.sketch import Sketch
 from ..core.snap import SnapEngine
@@ -357,6 +357,57 @@ class SketchElement(CanvasElement):
         sel.point_ids = list(cmd.new_point_ids)
         sel.changed.send(sel)
         self.mark_dirty()
+        return True
+
+    def nudge_selection(self, dx_world: float, dy_world: float) -> bool:
+        """
+        Moves the current selection by a delta given in world coordinates,
+        creating a single undoable command.
+
+        Returns True if any geometry was moved.
+        """
+        registry = self.sketch.registry
+        point_ids = set(self.selection.point_ids)
+        if self.selection.junction_pid is not None:
+            point_ids.add(self.selection.junction_pid)
+        for eid in self.selection.entity_ids:
+            try:
+                entity = registry.get_entity(eid)
+            except IndexError:
+                continue
+            if entity:
+                point_ids.update(entity.get_point_ids())
+
+        movable: dict[EntityID, Point] = {}
+        for pid in point_ids:
+            try:
+                p = registry.get_point(pid)
+            except IndexError:
+                continue
+            if not p.fixed:
+                movable[pid] = p
+        if not movable:
+            return False
+
+        # Arrow keys express the visual (WORLD) direction. Apply the
+        # delta in model space, so un-rotate the presented vector.
+        wt_vec = self.get_world_transform().invert().without_translation()
+        ct_vec = self.content_transform.invert().without_translation()
+        ldx, ldy = wt_vec.transform_vector((dx_world, dy_world))
+        mdx, mdy = ct_vec.transform_vector((ldx, ldy))
+
+        start_positions = {pid: (p.x, p.y) for pid, p in movable.items()}
+        end_positions = {
+            pid: (p.x + mdx, p.y + mdy) for pid, p in movable.items()
+        }
+
+        cmd = MoveEntitiesCommand(
+            self.sketch,
+            list(self.selection.entity_ids),
+            start_positions,
+            end_positions,
+        )
+        self.execute_command(cmd)
         return True
 
     def toggle_construction_on_selection(self):

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/ui_gtk/test_sketcher_nudge.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/ui_gtk/test_sketcher_nudge.py
@@ -1,0 +1,110 @@
+# flake8: noqa: E402
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+if sys.platform.startswith("linux"):
+    os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+    if not os.environ.get("DISPLAY"):
+        pytest.skip(
+            "DISPLAY not set on Linux, skipping UI tests. Run with xvfb-run.",
+            allow_module_level=True,
+        )
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from sketcher.core import Sketch
+from sketcher.core.commands import MoveEntitiesCommand
+from sketcher.ui_gtk.sketchelement import SketchElement
+
+from rayforge.core.undo import HistoryManager
+
+
+@pytest.fixture
+def element_with_line():
+    s = Sketch()
+    p1 = s.add_point(0, 0)
+    p2 = s.add_point(10, 0)
+    line_id = s.add_line(p1, p2)
+
+    element = SketchElement(sketch=s)
+    element.editor = MagicMock()
+    history = HistoryManager()
+    element.execute_command = history.execute
+    return element, s, p1, p2, line_id, history
+
+
+def _get_executed_command(history: HistoryManager):
+    return history.undo_stack[-1] if history.undo_stack else None
+
+
+@pytest.mark.ui
+def test_nudge_moves_selected_entity(element_with_line):
+    element, sketch, p1, p2, _, _ = element_with_line
+    registry = sketch.registry
+    entity_id = registry.entities[0].id
+    element.selection.select_entity(
+        registry.get_entity(entity_id), is_multi=False
+    )
+
+    assert element.nudge_selection(1.0, -2.0) is True
+    assert (registry.get_point(p1).x, registry.get_point(p1).y) == (
+        1.0,
+        -2.0,
+    )
+    assert (registry.get_point(p2).x, registry.get_point(p2).y) == (
+        11.0,
+        -2.0,
+    )
+
+
+@pytest.mark.ui
+def test_nudge_creates_undoable_command(element_with_line):
+    element, sketch, p1, p2, _, history = element_with_line
+    registry = sketch.registry
+    entity = registry.entities[0]
+    element.selection.select_entity(entity, is_multi=False)
+
+    element.nudge_selection(5.0, 0.0)
+
+    cmd = _get_executed_command(history)
+    assert isinstance(cmd, MoveEntitiesCommand)
+
+    history.undo()
+    assert (registry.get_point(p1).x, registry.get_point(p1).y) == (
+        0.0,
+        0.0,
+    )
+    assert (registry.get_point(p2).x, registry.get_point(p2).y) == (
+        10.0,
+        0.0,
+    )
+
+
+@pytest.mark.ui
+def test_nudge_without_selection_returns_false(element_with_line):
+    element, _, _, _, _, _ = element_with_line
+    assert element.nudge_selection(1.0, 1.0) is False
+
+
+@pytest.mark.ui
+def test_nudge_skips_fixed_points(element_with_line):
+    element, sketch, p1, p2, _, _ = element_with_line
+    registry = sketch.registry
+    registry.get_point(p1).fixed = True
+    element.selection.point_ids.extend([p1, p2])
+
+    assert element.nudge_selection(1.0, 1.0) is True
+    assert (registry.get_point(p1).x, registry.get_point(p1).y) == (
+        0.0,
+        0.0,
+    )
+    assert (registry.get_point(p2).x, registry.get_point(p2).y) == (
+        11.0,
+        1.0,
+    )


### PR DESCRIPTION
## Description

Arrow keys now move (nudge) the selected sketch entities, mirroring the existing workpiece nudging on the main canvas.

- **Modifier key behavior matches the main canvas:** no modifier moves by 1.0 mm, Shift moves by 10 mm, Ctrl/Cmd moves by 0.1 mm.
- Works for selected entities (all their points), explicitly selected points, and junctions.
- Fixed points are not moved.
- The world-space arrow direction is converted into sketch/model space via the inverse transforms, so nudging stays visually correct even when the sketch is rotated or transformed.
- The move is applied as a single undoable `MoveEntitiesCommand` (with coalescing), so repeated presses collapse into one undo step.
- Nudging is suppressed during text editing and while a drawing tool has an active dimension preview.

## ⚠️ Dependency: merge #367 first

**This PR is based on the `sketcher-saved-state-and-history-fixes` branch and must be merged to main only after #367 ("Sketcher: saved-state tracking, history fixes, undo/redo toolbar") is merged.** Until then, this PR will show #367's commits as part of its diff.

## Testing

- New tests in `rayforge/builtin_addons/rayforge-addon-sketcher/tests/ui_gtk/test_sketcher_nudge.py` cover movement of selected entities, undoability, no-selection behavior, and fixed-point handling.
- Full sketcher test suite and lint pass.
