### PR TITLE
Show USB serial ports first with two-line port selector

### DIFF
--- a/rayforge/machine/transport/serial.py
+++ b/rayforge/machine/transport/serial.py
@@ -2,8 +2,11 @@ import asyncio
 import glob
 import logging
 import os
+import re
 import threading
 import time
+from collections.abc import Iterable
+from dataclasses import dataclass
 from gettext import gettext as _
 
 import serial
@@ -13,6 +16,8 @@ from .transport import Transport, TransportStatus
 
 logger = logging.getLogger(__name__)
 
+USB_PORT_MARKERS = ("ttyUSB", "ttyACM")
+
 
 class SerialPort(str):
     """A string subclass for identifying serial ports, for UI generation."""
@@ -20,6 +25,85 @@ class SerialPort(str):
 
 class SerialPortPermissionError(Exception):
     """Custom exception for systemic serial port permission issues."""
+
+
+@dataclass(frozen=True)
+class SerialPortInfo:
+    """A serial port path together with an optional human-readable
+    description."""
+
+    device: str
+    description: str | None = None
+
+
+def is_usb_serial_port(port: str) -> bool:
+    """
+    Heuristically determines if a port path refers to a USB serial
+    device. On non-POSIX systems (e.g. Windows), every port is treated
+    as potentially USB.
+    """
+    if os.name != "posix":
+        return True
+    return any(marker in port for marker in USB_PORT_MARKERS)
+
+
+def natural_key(s: str) -> list[int | str]:
+    return [
+        int(t) if t.isdigit() else t.lower() for t in re.split("([0-9]+)", s)
+    ]
+
+
+def _port_sort_key(port: str) -> tuple[int, list[int | str]]:
+    return (not is_usb_serial_port(port), natural_key(port))
+
+
+def sort_ports(ports: Iterable[str]) -> list[str]:
+    """
+    Sorts ports so USB serial adapters come first, followed by all
+    other ports. Each group is ordered naturally, e.g.
+    ttyUSB2 before ttyUSB10.
+    """
+    return sorted(ports, key=_port_sort_key)
+
+
+_BY_ID_SUFFIX_RE = re.compile(r"-if\d+(-port\d+)?$")
+
+
+def _describe_by_id_link(path: str) -> str | None:
+    """
+    Extracts a device description from a /dev/serial/by-id symlink
+    name, which embeds vendor and product strings, e.g.
+    'usb-FTDI_FT232R_USB_UART_AH03K1A0-if00-port0'.
+    """
+    name = os.path.basename(path)
+    if not name.startswith("usb-"):
+        return None
+    name = name[len("usb-") :]
+    name = _BY_ID_SUFFIX_RE.sub("", name)
+    name = name.replace("_", " ").strip()
+    return name or None
+
+
+def _collect_by_id_descriptions(paths: list[str]) -> dict[str, str]:
+    """
+    Maps port paths to descriptions derived from /dev/serial/by-id
+    symlinks. Both the link path itself and the resolved device path
+    are mapped, so ttyUSB devices get described too.
+    """
+    descriptions: dict[str, str] = {}
+    for path in paths:
+        if "/by-id/" not in path:
+            continue
+        desc = _describe_by_id_link(path)
+        if not desc:
+            continue
+        try:
+            resolved = os.path.realpath(path)
+        except OSError:
+            continue
+        descriptions.setdefault(path, desc)
+        descriptions.setdefault(resolved, desc)
+    return descriptions
 
 
 def safe_list_ports_linux() -> list[str]:
@@ -57,17 +141,46 @@ class SerialTransport(Transport):
 
     @staticmethod
     def list_ports() -> list[str]:
-        """Lists available serial ports."""
+        """Lists available serial ports, USB adapters first."""
         # If we're on Linux (posix) and running in a Snap, use our
         # safe scanner, as list_ports.comports() fails with permission errors.
         if os.name == "posix" and "SNAP" in os.environ:
-            return safe_list_ports_linux()
+            return sort_ports(safe_list_ports_linux())
 
         # On other systems or outside a Snap, the default is fine.
         try:
-            return sorted([p.device for p in list_ports.comports()])
+            return sort_ports([p.device for p in list_ports.comports()])
         except (OSError, serial.SerialException, TypeError) as e:
             # Fallback for any other unexpected errors
+            logger.error(f"Failed to list serial ports with pyserial: {e}")
+            return []
+
+    @staticmethod
+    def list_port_info() -> list[SerialPortInfo]:
+        """
+        Lists available serial ports together with a human-readable
+        description when the platform provides one. USB adapters are
+        listed first.
+        """
+        if os.name == "posix" and "SNAP" in os.environ:
+            paths = safe_list_ports_linux()
+            descriptions = _collect_by_id_descriptions(paths)
+            infos = [
+                SerialPortInfo(path, descriptions.get(path)) for path in paths
+            ]
+            infos.sort(key=lambda info: _port_sort_key(info.device))
+            return infos
+
+        try:
+            infos = []
+            for port in list_ports.comports():
+                desc = port.description
+                if not desc or desc == "n/a":
+                    desc = None
+                infos.append(SerialPortInfo(port.device, desc))
+            infos.sort(key=lambda info: _port_sort_key(info.device))
+            return infos
+        except (OSError, serial.SerialException, TypeError) as e:
             logger.error(f"Failed to list serial ports with pyserial: {e}")
             return []
 
@@ -80,7 +193,7 @@ class SerialTransport(Transport):
             # On non-POSIX systems, we can't reliably filter, so return all.
             return all_ports
 
-        return [p for p in all_ports if "ttyUSB" in p or "ttyACM" in p]
+        return [p for p in all_ports if is_usb_serial_port(p)]
 
     @staticmethod
     def check_serial_permissions_globally() -> None:

--- a/rayforge/ui_gtk/varset/adapter/combo.py
+++ b/rayforge/ui_gtk/varset/adapter/combo.py
@@ -8,13 +8,17 @@ from ....core.varset import (
     SerialPortVar,
     Var,
 )
-from ....machine.transport.serial import SerialTransport
+from ....machine.transport.serial import (
+    SerialPortInfo,
+    SerialTransport,
+    is_usb_serial_port,
+    natural_key,
+)
 from ...shared.adwfix import ensure_row_min_width
 from .base import (
     NULL_CHOICE_LABEL,
     RowAdapter,
     escape_title,
-    natural_sort_key,
     register_adapter,
 )
 
@@ -124,43 +128,108 @@ class BaudRateAdapter(ComboAdapter):
 
 @register_adapter(SerialPortVar)
 class SerialPortAdapter(ComboAdapter):
+    """
+    A two-line port selector, mirroring the WCS selector: the device
+    path on the first line and the USB description (if known) as a
+    dimmed second line. The model holds raw device paths, so value
+    mapping is handled by ComboAdapter directly.
+    """
+
+    def __init__(self, row: Adw.ComboRow, var: Var) -> None:
+        super().__init__(row, var)
+        self._descriptions: dict[str, str] = {}
+
     @classmethod
     def create(
         cls, var: Var, target_property: str
     ) -> tuple[Adw.PreferencesRow, "SerialPortAdapter"]:
         initial_val = getattr(var, target_property)
-        port_set = set(SerialTransport.list_ports())
-        if initial_val:
-            port_set.add(initial_val)
-        sorted_ports = sorted(port_set, key=natural_sort_key)
-        choices = [NULL_CHOICE_LABEL] + sorted_ports
-        store = Gtk.StringList.new(choices)
-        row = Adw.ComboRow(model=store, title=escape_title(var.label))
+        row = Adw.ComboRow(title=escape_title(var.label))
         if var.description:
             row.set_subtitle(var.description)
-        if initial_val and initial_val in choices:
-            row.set_selected(choices.index(initial_val))
+        adapter = cls(row, var)
 
-        def on_open(gesture, n_press, x, y):
-            selected_obj = row.get_selected_item()
-            current_sel = None
-            if selected_obj:
-                current_sel = selected_obj.get_string()  # type: ignore
+        factory = Gtk.SignalListItemFactory()
+        factory.connect("setup", adapter._on_factory_setup)
+        factory.connect("bind", adapter._on_factory_bind)
+        row.set_factory(factory)
 
-            new_ports = SerialTransport.list_ports()
-            port_set = set(new_ports)
-            if current_sel and current_sel != NULL_CHOICE_LABEL:
-                port_set.add(current_sel)
-            new_sorted = sorted(port_set, key=natural_sort_key)
-            new_choices = [NULL_CHOICE_LABEL] + new_sorted
+        adapter._refresh(initial_val)
 
-            model = row.get_model()
-            if isinstance(model, Gtk.StringList):
-                model.splice(0, model.get_n_items(), new_choices)
-                if current_sel in new_choices:
-                    row.set_selected(new_choices.index(current_sel))
+        def on_open(
+            gesture: Gtk.GestureClick, n_press: int, x: float, y: float
+        ) -> None:
+            adapter._refresh(adapter.get_value())
 
         click_controller = Gtk.GestureClick.new()
         click_controller.connect("pressed", on_open)
         row.add_controller(click_controller)
-        return row, cls(row, var)
+        return row, adapter
+
+    def _on_factory_setup(
+        self, factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem
+    ) -> None:
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        name_label = Gtk.Label(xalign=0)
+        subtitle_label = Gtk.Label(xalign=0)
+        subtitle_label.add_css_class("dim-label")
+        box.append(name_label)
+        box.append(subtitle_label)
+        list_item.set_child(box)
+
+    def _on_factory_bind(
+        self, factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem
+    ) -> None:
+        item = list_item.get_item()
+        assert isinstance(item, Gtk.StringObject)
+        path = item.get_string()
+        box = list_item.get_child()
+        assert box is not None
+        name_label = box.get_first_child()
+        assert isinstance(name_label, Gtk.Label)
+        sibling = name_label.get_next_sibling()
+        assert isinstance(sibling, Gtk.Label)
+        name_label.set_label(path)
+        description = self._descriptions.get(path)
+        sibling.set_visible(bool(description))
+        if description:
+            sibling.set_label(description)
+
+    @staticmethod
+    def _scan_ports(extra_value: str | None) -> list[SerialPortInfo]:
+        """
+        Returns the available ports. USB adapters come first; a
+        configured port that is not currently plugged in is pinned
+        to the top so it stays immediately visible.
+        """
+        ports: list[SerialPortInfo] = []
+        seen: set[str] = set()
+        for info in SerialTransport.list_port_info():
+            if info.device in seen:
+                continue
+            seen.add(info.device)
+            ports.append(info)
+        ports.sort(
+            key=lambda i: (
+                not is_usb_serial_port(i.device),
+                natural_key(i.device),
+            )
+        )
+        if extra_value and extra_value not in seen:
+            ports.insert(0, SerialPortInfo(extra_value))
+        return ports
+
+    def _refresh(self, current_value: Any | None) -> None:
+        """Re-scans ports and rebuilds the dropdown contents."""
+        value_str = str(current_value) if current_value else None
+        ports = self._scan_ports(value_str)
+        self._descriptions = {
+            p.device: p.description for p in ports if p.description
+        }
+        devices = [p.device for p in ports]
+        model = Gtk.StringList.new([NULL_CHOICE_LABEL] + devices)
+        self._row.set_model(model)
+        selected = 0
+        if value_str and value_str in devices:
+            selected = devices.index(value_str) + 1
+        self._row.set_selected(selected)

--- a/tests/machine/transport/test_serial_transport.py
+++ b/tests/machine/transport/test_serial_transport.py
@@ -1,5 +1,6 @@
 import asyncio
 import queue
+from types import SimpleNamespace
 
 import pytest
 
@@ -8,7 +9,9 @@ from rayforge.machine.transport.serial import (
     SerialPort,
     SerialPortPermissionError,
     SerialTransport,
+    is_usb_serial_port,
     safe_list_ports_linux,
+    sort_ports,
 )
 
 
@@ -367,3 +370,109 @@ class TestSerialTransportIntegration:
 
         # Should not raise any errors
         await transport.purge()
+
+
+def test_is_usb_serial_port(mocker):
+    """Test the USB port detection heuristic."""
+    mocker.patch("os.name", "posix")
+    assert is_usb_serial_port("/dev/ttyUSB0")
+    assert is_usb_serial_port("/dev/ttyACM0")
+    assert not is_usb_serial_port("/dev/ttyS0")
+
+    mocker.patch("os.name", "nt")
+    assert is_usb_serial_port("/dev/ttyS0")
+
+
+def test_sort_ports_usb_first():
+    """
+    USB adapters must come first; each group ordered naturally,
+    so ttyUSB2 sorts before ttyUSB10.
+    """
+    ports = [
+        "/dev/ttyS3",
+        "/dev/ttyUSB10",
+        "/dev/ttyACM0",
+        "/dev/ttyUSB2",
+        "/dev/ttyS0",
+    ]
+    assert sort_ports(ports) == [
+        "/dev/ttyACM0",
+        "/dev/ttyUSB2",
+        "/dev/ttyUSB10",
+        "/dev/ttyS0",
+        "/dev/ttyS3",
+    ]
+
+
+def test_list_port_info_with_descriptions(monkeypatch):
+    """
+    Outside a Snap, pyserial's descriptions are used. Placeholder
+    descriptions ('n/a') are discarded.
+    """
+    monkeypatch.delenv("SNAP", raising=False)
+    devices = [
+        SimpleNamespace(device="/dev/ttyS0", description="ttyS0"),
+        SimpleNamespace(device="/dev/ttyUSB10", description="CH340"),
+        SimpleNamespace(device="/dev/ttyACM0", description="n/a"),
+        SimpleNamespace(device="/dev/ttyUSB2", description=None),
+    ]
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial.list_ports.comports",
+        lambda: devices,
+    )
+    infos = SerialTransport.list_port_info()
+    assert [i.device for i in infos] == [
+        "/dev/ttyACM0",
+        "/dev/ttyUSB2",
+        "/dev/ttyUSB10",
+        "/dev/ttyS0",
+    ]
+    by_device = {i.device: i for i in infos}
+    assert by_device["/dev/ttyUSB10"].description == "CH340"
+    assert by_device["/dev/ttyACM0"].description is None
+    assert by_device["/dev/ttyUSB2"].description is None
+    assert by_device["/dev/ttyS0"].description == "ttyS0"
+
+
+def test_list_port_info_snap_by_id_descriptions(monkeypatch):
+    """
+    In a Snap, descriptions are derived from /dev/serial/by-id symlink
+    names and also applied to the resolved device paths.
+    """
+    monkeypatch.setattr("os.name", "posix")
+    monkeypatch.setenv("SNAP", "/snap/rayforge/123")
+    by_id = "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AH03K1A0-if00-port0"
+
+    def mock_glob(pattern):
+        if pattern == "/dev/serial/by-id/*":
+            return [by_id]
+        if pattern in ["/dev/ttyUSB*", "/dev/ttyACM*"]:
+            return ["/dev/ttyUSB0"]
+        return []
+
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial.glob.glob", mock_glob
+    )
+    monkeypatch.setattr(
+        "os.path.realpath",
+        lambda p: "/dev/ttyUSB0" if p == by_id else p,
+    )
+    infos = SerialTransport.list_port_info()
+    descriptions = {i.device: i.description for i in infos}
+    desc = "FTDI FT232R USB UART AH03K1A0"
+    assert descriptions["/dev/ttyUSB0"] == desc
+    assert descriptions[by_id] == desc
+
+
+def test_list_port_info_pyserial_error(monkeypatch):
+    """If pyserial fails, an empty list is returned instead of raising."""
+    monkeypatch.delenv("SNAP", raising=False)
+
+    def raise_error():
+        raise OSError("boom")
+
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial.list_ports.comports",
+        raise_error,
+    )
+    assert SerialTransport.list_port_info() == []

--- a/tests/machine/transport/test_serial_transport.py
+++ b/tests/machine/transport/test_serial_transport.py
@@ -383,11 +383,12 @@ def test_is_usb_serial_port(mocker):
     assert is_usb_serial_port("/dev/ttyS0")
 
 
-def test_sort_ports_usb_first():
+def test_sort_ports_usb_first(mocker):
     """
     USB adapters must come first; each group ordered naturally,
     so ttyUSB2 sorts before ttyUSB10.
     """
+    mocker.patch("os.name", "posix")
     ports = [
         "/dev/ttyS3",
         "/dev/ttyUSB10",
@@ -404,11 +405,12 @@ def test_sort_ports_usb_first():
     ]
 
 
-def test_list_port_info_with_descriptions(monkeypatch):
+def test_list_port_info_with_descriptions(monkeypatch, mocker):
     """
     Outside a Snap, pyserial's descriptions are used. Placeholder
     descriptions ('n/a') are discarded.
     """
+    mocker.patch("os.name", "posix")
     monkeypatch.delenv("SNAP", raising=False)
     devices = [
         SimpleNamespace(device="/dev/ttyS0", description="ttyS0"),

--- a/tests/ui_gtk/varset/test_serial_port_adapter.py
+++ b/tests/ui_gtk/varset/test_serial_port_adapter.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from contextlib import ExitStack
 from typing import cast
 from unittest.mock import patch
 
@@ -54,12 +55,24 @@ def _make_infos() -> list:
     ]
 
 
+def _scan_patches(infos: list):
+    """
+    Returns context managers patching the port scan on a POSIX system.
+    USB detection behaves differently on non-POSIX platforms, where
+    every port is treated as USB.
+    """
+    return [
+        patch.object(SerialTransport, "list_port_info", return_value=infos),
+        patch("os.name", "posix"),
+    ]
+
+
 def test_usb_ports_come_first(ui_context_initializer):
     """USB adapters are listed before hardware ports."""
     var = SerialPortVar(key="port", label="Port")
-    with patch.object(
-        SerialTransport, "list_port_info", return_value=_make_infos()
-    ):
+    with ExitStack() as stack:
+        for p in _scan_patches(_make_infos()):
+            stack.enter_context(p)
         row, _adapter = _create_row(var)
         assert _model_strings(row) == [
             NULL_LABEL,
@@ -73,9 +86,9 @@ def test_usb_ports_come_first(ui_context_initializer):
 def test_descriptions_collected_for_factory(ui_context_initializer):
     """Known descriptions are stored for the two-line factory."""
     var = SerialPortVar(key="port", label="Port")
-    with patch.object(
-        SerialTransport, "list_port_info", return_value=_make_infos()
-    ):
+    with ExitStack() as stack:
+        for p in _scan_patches(_make_infos()):
+            stack.enter_context(p)
         _row, adapter = _create_row(var)
         assert adapter._descriptions == {
             "/dev/ttyS0": "ttyS0",
@@ -88,9 +101,9 @@ def test_descriptions_collected_for_factory(ui_context_initializer):
 def test_device_paths_round_trip(ui_context_initializer):
     """Selecting an entry yields the raw device path and back."""
     var = SerialPortVar(key="port", label="Port")
-    with patch.object(
-        SerialTransport, "list_port_info", return_value=_make_infos()
-    ):
+    with ExitStack() as stack:
+        for p in _scan_patches(_make_infos()):
+            stack.enter_context(p)
         _row, adapter = _create_row(var)
         adapter.set_value("/dev/ttyUSB0")
         assert adapter.get_value() == "/dev/ttyUSB0"
@@ -104,7 +117,9 @@ def test_configured_port_pinned_when_not_plugged_in(ui_context_initializer):
     relegated to the end of the list; it stays on top.
     """
     var = SerialPortVar(key="port", label="Port", value="/dev/ttyUSB0")
-    with patch.object(SerialTransport, "list_port_info", return_value=[]):
+    with ExitStack() as stack:
+        for p in _scan_patches([]):
+            stack.enter_context(p)
         row, adapter = _create_row(var)
         strings = _model_strings(row)
         assert strings == [NULL_LABEL, "/dev/ttyUSB0"]
@@ -118,16 +133,18 @@ def test_rescan_preserves_configured_value(ui_context_initializer):
     port reappears in the live scan.
     """
     var = SerialPortVar(key="port", label="Port", value="/dev/ttyUSB0")
-    with patch.object(SerialTransport, "list_port_info", return_value=[]):
+    with ExitStack() as stack:
+        for p in _scan_patches([]):
+            stack.enter_context(p)
         _row, adapter = _create_row(var)
 
-    with patch.object(
-        SerialTransport,
-        "list_port_info",
-        return_value=[
-            SerialPortInfo("/dev/ttyUSB0", "CH340"),
-            SerialPortInfo("/dev/ttyS0", "ttyS0"),
-        ],
-    ):
+    with ExitStack() as stack:
+        for p in _scan_patches(
+            [
+                SerialPortInfo("/dev/ttyUSB0", "CH340"),
+                SerialPortInfo("/dev/ttyS0", "ttyS0"),
+            ]
+        ):
+            stack.enter_context(p)
         adapter._refresh(adapter.get_value())
         assert adapter.get_value() == "/dev/ttyUSB0"

--- a/tests/ui_gtk/varset/test_serial_port_adapter.py
+++ b/tests/ui_gtk/varset/test_serial_port_adapter.py
@@ -1,0 +1,133 @@
+# flake8: noqa: E402
+"""UI tests for the SerialPortAdapter (USB-first ordering, port pinning)."""
+
+import os
+import sys
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+if sys.platform.startswith("linux"):
+    os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+    if not os.environ.get("DISPLAY"):
+        pytest.skip(
+            "DISPLAY not set on Linux, skipping UI tests.",
+            allow_module_level=True,
+        )
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gtk
+
+from rayforge.core.varset import SerialPortVar
+from rayforge.machine.transport.serial import SerialPortInfo, SerialTransport
+from rayforge.ui_gtk.varset.adapter import create_row_for_var
+from rayforge.ui_gtk.varset.adapter.combo import SerialPortAdapter
+
+pytestmark = pytest.mark.ui
+
+NULL_LABEL = "None Selected"
+
+
+def _create_row(var: SerialPortVar) -> tuple[Adw.ComboRow, SerialPortAdapter]:
+    row, adapter = create_row_for_var(var, "value")
+    assert adapter is not None
+    return cast(Adw.ComboRow, row), cast(SerialPortAdapter, adapter)
+
+
+def _model_strings(row: Adw.ComboRow) -> list:
+    model = row.get_model()
+    assert isinstance(model, Gtk.StringList)
+    return [model.get_string(i) for i in range(model.get_n_items())]
+
+
+def _make_infos() -> list:
+    return [
+        SerialPortInfo("/dev/ttyS0", "ttyS0"),
+        SerialPortInfo("/dev/ttyS3", "ttyS3"),
+        SerialPortInfo("/dev/ttyACM0", "ttyACM0"),
+        SerialPortInfo("/dev/ttyUSB0", "CH340"),
+    ]
+
+
+def test_usb_ports_come_first(ui_context_initializer):
+    """USB adapters are listed before hardware ports."""
+    var = SerialPortVar(key="port", label="Port")
+    with patch.object(
+        SerialTransport, "list_port_info", return_value=_make_infos()
+    ):
+        row, _adapter = _create_row(var)
+        assert _model_strings(row) == [
+            NULL_LABEL,
+            "/dev/ttyACM0",
+            "/dev/ttyUSB0",
+            "/dev/ttyS0",
+            "/dev/ttyS3",
+        ]
+
+
+def test_descriptions_collected_for_factory(ui_context_initializer):
+    """Known descriptions are stored for the two-line factory."""
+    var = SerialPortVar(key="port", label="Port")
+    with patch.object(
+        SerialTransport, "list_port_info", return_value=_make_infos()
+    ):
+        _row, adapter = _create_row(var)
+        assert adapter._descriptions == {
+            "/dev/ttyS0": "ttyS0",
+            "/dev/ttyS3": "ttyS3",
+            "/dev/ttyACM0": "ttyACM0",
+            "/dev/ttyUSB0": "CH340",
+        }
+
+
+def test_device_paths_round_trip(ui_context_initializer):
+    """Selecting an entry yields the raw device path and back."""
+    var = SerialPortVar(key="port", label="Port")
+    with patch.object(
+        SerialTransport, "list_port_info", return_value=_make_infos()
+    ):
+        _row, adapter = _create_row(var)
+        adapter.set_value("/dev/ttyUSB0")
+        assert adapter.get_value() == "/dev/ttyUSB0"
+        adapter.set_value(None)
+        assert adapter.get_value() is None
+
+
+def test_configured_port_pinned_when_not_plugged_in(ui_context_initializer):
+    """
+    A configured port that is absent from the live scan must not be
+    relegated to the end of the list; it stays on top.
+    """
+    var = SerialPortVar(key="port", label="Port", value="/dev/ttyUSB0")
+    with patch.object(SerialTransport, "list_port_info", return_value=[]):
+        row, adapter = _create_row(var)
+        strings = _model_strings(row)
+        assert strings == [NULL_LABEL, "/dev/ttyUSB0"]
+        assert row.get_selected() == 1
+        assert adapter.get_value() == "/dev/ttyUSB0"
+
+
+def test_rescan_preserves_configured_value(ui_context_initializer):
+    """
+    Re-scanning (dropdown open) keeps the selection when the configured
+    port reappears in the live scan.
+    """
+    var = SerialPortVar(key="port", label="Port", value="/dev/ttyUSB0")
+    with patch.object(SerialTransport, "list_port_info", return_value=[]):
+        _row, adapter = _create_row(var)
+
+    with patch.object(
+        SerialTransport,
+        "list_port_info",
+        return_value=[
+            SerialPortInfo("/dev/ttyUSB0", "CH340"),
+            SerialPortInfo("/dev/ttyS0", "ttyS0"),
+        ],
+    ):
+        adapter._refresh(adapter.get_value())
+        assert adapter.get_value() == "/dev/ttyUSB0"


### PR DESCRIPTION
## Summary
- Sort serial ports so USB adapters (ttyUSB/ttyACM) come before hardware ports (ttyS*), both in `SerialTransport.list_ports()` and in the port dropdown, with natural ordering within each group (ttyUSB2 before ttyUSB10)
- Add `SerialTransport.list_port_info()`, which provides device descriptions from pyserial metadata on regular systems, or from `/dev/serial/by-id` symlink names when running sandboxed (Snap), where pyserial cannot enumerate safely
- Rework `SerialPortAdapter` into a two-line combo row mirroring the WCS selector: device path on the first line, dimmed USB description (e.g. CH340) on the second. The model holds raw device paths, so no label/value mapping is needed
- A configured port that is not currently plugged in is pinned to the top of the list instead of being appended at the end

## Test plan
- [x] New unit tests for USB detection, USB-first sorting, port info/descriptions (incl. Snap by-id parsing) — 21 transport tests pass
- [x] New UI tests for the adapter: ordering, value round-trip, pinning of unplugged configured ports, rescan behavior — 5 tests pass
- [x] `pixi run lint` clean (ruff, flake8, pyflakes, pyright)