### PR TITLE
fix(sim3d): keep playhead, slider, and gcode viewer in sync

### DIFF
--- a/rayforge/shared/gcodeedit/viewer.py
+++ b/rayforge/shared/gcodeedit/viewer.py
@@ -143,8 +143,11 @@ class GcodeViewer(Gtk.Box):
 
         start_line, line_count = self.op_map.span_for_op(op_index)
         if line_count:
-            # Highlight the first line associated with this op
-            self.editor.highlight_line(start_line)
+            # An op's span can bundle state lines that the encoder
+            # deferred into it (e.g. a lazily emitted "M4" before the
+            # first cutting move).  The op's own action line is the
+            # last one, so highlight that.
+            self.editor.highlight_line(start_line + line_count - 1)
         else:
             # Op produced no g-code, so clear any existing highlight
             self.clear_highlight()

--- a/rayforge/simulator/op_player.py
+++ b/rayforge/simulator/op_player.py
@@ -141,17 +141,91 @@ class OpPlayer:
         """Cumulative simulated time (seconds) up to command *idx*."""
         return self._time_ops.get_cumulative_time_at(idx, *self._play_params)
 
+    @property
+    def sim_time(self) -> float:
+        """The current simulated playback time (seconds)."""
+        return self._sim_time
+
     def set_sim_time(self, t: float) -> None:
         """Set the simulated playback time and cache the playhead progress.
 
         The playhead is described as the command currently being
         executed plus the fraction of its duration that has elapsed.
         Once playback has run to completion the laser is turned off.
+
+        Note that time alone cannot distinguish positions inside a
+        cluster of zero-duration commands; use :meth:`set_playhead`
+        when the desired position is known as a command index.
         """
         self._sim_time = float(t)
         self._playback = self._compute_playback_progress(self._sim_time)
         if self.is_finished:
             self.state.laser_on = False
+
+    def set_playhead(self, index: int) -> None:
+        """Place the playhead on command *index* (that command executed).
+
+        Seeks the machine state to *index*, sets the simulated clock to
+        its completion time, and anchors the cached playback progress
+        to the *following* command. Anchoring by index keeps stepping
+        and external syncing exact even when many commands share the
+        same cumulative time (zero-duration state changes).
+        """
+        n = self.ops.len()
+        index = max(0, min(index, n - 1))
+        t = self.get_cumulative_time(index)
+        self._anchor_progress(index, t, index + 1)
+
+    def set_progress_anchor(self, completed: int, t: float) -> None:
+        """Anchor the playhead between *completed* and the next command.
+
+        Seeks the machine state so commands up to *completed* are
+        applied, sets the simulated clock to *t*, and caches playback
+        progress as command ``completed + 1`` in progress. Used when a
+        position is known both as an index boundary and a time (for
+        example scrubbing the time-based slider while paused).
+        """
+        n = self.ops.len()
+        completed = max(-1, min(completed, n - 1))
+        k = completed + 1
+        if completed < 0:
+            self.state = self._create_home_state()
+            self._current_index = -1
+            self._source_axis = Axis.Y
+            self._rotary_axis = None
+            self._rotary_dpm = 0.0
+            self._prev_layer_uid = None
+        elif k >= n:
+            self.seek(n - 1)
+            self._sim_time = self.get_cumulative_time(n - 1)
+            self._playback = (n - 1, 1.0)
+            return
+        else:
+            self.seek(completed)
+        self._sim_time = float(t)
+        self._playback = self._progress_at_index(float(t), k)
+        if self.is_finished:
+            self.state.laser_on = False
+
+    def _anchor_progress(self, completed: int, t: float, k: int) -> None:
+        self.seek(completed)
+        self._sim_time = float(t)
+        n = self.ops.len()
+        if k >= n:
+            self._playback = (n - 1, 1.0)
+        else:
+            self._playback = self._progress_at_index(float(t), k)
+        if self.is_finished:
+            self.state.laser_on = False
+
+    def _progress_at_index(self, t: float, k: int) -> tuple[int, float]:
+        """Playback progress anchored at command *k* for time *t*."""
+        start = self.get_cumulative_time(k - 1) if k > 0 else 0.0
+        span = self.get_cumulative_time(k) - start
+        if span <= 0.0:
+            return (k, 0.0)
+        frac = max(0.0, min(1.0, (t - start) / span))
+        return (k, frac)
 
     @property
     def is_finished(self) -> bool:
@@ -188,6 +262,80 @@ class OpPlayer:
         frac = max(0.0, min(1.0, (t - t_end) / span))
         return (idx + 1, frac)
 
+    def _interpolate_rotary_arc(
+        self,
+        p: int,
+        frac: float,
+        start_axes: dict,
+        end: tuple,
+        axes: dict,
+    ) -> bool:
+        """Interpolate along a rotary-mode arc, or fall back to linear.
+
+        Rotary mapping rewrites endpoint Y while the arc's stored
+        radius (from I/J) still describes the unwrapped surface
+        geometry, so the Cartesian angle math cannot use the mapped
+        endpoints directly. Instead the planar arc is reconstructed in
+        (X, surface) space: the Y travel comes from the rotary axis
+        itself (``delta_angle / degrees_per_mm``), which is
+        authoritative, and the circle is solved through BOTH
+        reconstructed endpoints with the stored radius - so the
+        interpolation always lands exactly on the command's target.
+
+        Returns True when the reconstruction succeeded and ``axes``
+        holds the interpolated position; False when the caller must
+        fall back to linear interpolation.
+        """
+        i, j, cw = self.ops.arc_params(p)
+        radius = math.hypot(i, j)
+        if radius <= 1e-9:
+            return False
+        ea = self.ops.extra_axes(p) or {}
+        a_end = ea.get(self._rotary_axis)
+        if a_end is None:
+            return False
+        dpm = self._rotary_dpm
+        a_start = start_axes.get(self._rotary_axis, 0.0)
+        sx = start_axes.get(Axis.X, 0.0)
+        su = a_start / dpm
+        ex = end[0]
+        eu = su + (a_end - a_start) / dpm
+
+        # Solve the circle through (sx, su) and (ex, eu) with the
+        # stored radius. The center lies on the chord's perpendicular
+        # bisector; pick the side that agrees with the stored I/J.
+        dx, dy = ex - sx, eu - su
+        chord = math.hypot(dx, dy)
+        if chord > 2.0 * radius:
+            return False
+        cx0, cu0 = sx + i, su + j
+        if chord <= 1e-9:
+            # Full turn: the stored center defines the circle.
+            cx, cu = cx0, cu0
+        else:
+            h = math.sqrt(max(radius * radius - (chord * 0.5) ** 2, 0.0))
+            mx, mu = sx + dx * 0.5, su + dy * 0.5
+            px, pu = -dy / chord, dx / chord
+            if (cx0 - mx) * px + (cu0 - mu) * pu >= 0.0:
+                cx, cu = mx + px * h, mu + pu * h
+            else:
+                cx, cu = mx - px * h, mu - pu * h
+
+        angle_start = math.atan2(su - cu, sx - cx)
+        angle_end = math.atan2(eu - cu, ex - cx)
+        sweep_ccw = (angle_end - angle_start) % (2.0 * math.pi)
+        sweep = sweep_ccw - 2.0 * math.pi if cw else sweep_ccw
+        angle = angle_start + frac * sweep
+
+        axes[Axis.X] = cx + radius * math.cos(angle)
+        u = cu + radius * math.sin(angle)
+        axes[self._rotary_axis] = a_start + (u - su) * dpm
+        if Axis.Z in axes:
+            axes[Axis.Z] = start_axes.get(Axis.Z, 0.0) + frac * (
+                end[2] - start_axes.get(Axis.Z, 0.0)
+            )
+        return True
+
     def render_state(self) -> MachineState:
         """State for rendering, with axes interpolated within the
         in-progress command during playback.
@@ -214,10 +362,21 @@ class OpPlayer:
 
         axes = dict(start_axes)
         is_arc = self.ops.command_type(p) == CommandType.ARC_TO
-
+        rotary_done = False
+        spatial_done = False
         if is_arc:
-            self._interpolate_arc(p, frac, start_axes, end, axes)
-        else:
+            if self._rotary_axis is not None and self._rotary_dpm != 0.0:
+                # Rotary arcs are reconstructed from the rotary axis
+                # travel; mapping may have detached the stored circle
+                # from the mapped endpoints.
+                rotary_done = self._interpolate_rotary_arc(
+                    p, frac, start_axes, end, axes
+                )
+                spatial_done = rotary_done
+            else:
+                self._interpolate_arc(p, frac, start_axes, end, axes)
+                spatial_done = True
+        if not spatial_done:
             for axis, value in (
                 (Axis.X, end[0]),
                 (Axis.Y, end[1]),
@@ -232,8 +391,10 @@ class OpPlayer:
         ea = self.ops.extra_axes(p)
         if ea:
             for axis, value in ea.items():
-                # The rotary axis is already handled by _interpolate_arc.
-                if is_arc and axis == self._rotary_axis:
+                # The rotary axis is already interpolated by
+                # _interpolate_rotary_arc when that path succeeded;
+                # otherwise it blends linearly like the other extras.
+                if rotary_done and axis == self._rotary_axis:
                     continue
                 axes[axis] = start_axes.get(axis, 0.0) + frac * (
                     value - start_axes.get(axis, 0.0)
@@ -408,6 +569,25 @@ class OpPlayer:
                 self._update_rotary_config(self.ops.layer_uid(i))
             self.state.apply_command(self.ops, i)
         self._current_index = index
+
+    def sync_state_to_playhead(self) -> None:
+        """Move the machine state to the command before the playhead.
+
+        Used during time-based playback, where the playhead is defined
+        by the simulated clock instead of explicit seeks. Forward
+        movement is incremental, so steady playback only pays for the
+        commands crossed since the previous tick; scrubbing backwards
+        falls back to :meth:`seek` (snapshot-accelerated).
+        """
+        p, _frac = self._playback
+        target = min(p - 1, self.ops.len() - 1)
+        if target < 0 or target == self._current_index:
+            return
+        if target > self._current_index:
+            self.advance_to(target)
+        else:
+            self.seek(target)
+        self._emit_layer_change()
 
     def seek_last_movement(self) -> int | None:
         last = None

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -1020,9 +1020,11 @@ class MainWindow(Adw.ApplicationWindow):
         """Updates the G-code preview panel from a pre-generated string."""
         if gcode_string is None:
             self.bottom_panel.gcode_viewer.clear()
+            self._canvas3d_playback.set_op_map(None)
             return
 
         self.bottom_panel.gcode_viewer.set_gcode(gcode_string)
+        self._canvas3d_playback.set_op_map(op_map)
         if op_map:
             self.bottom_panel.gcode_viewer.set_op_map(op_map)
 

--- a/rayforge/ui_gtk/sim3d/playback_overlay.py
+++ b/rayforge/ui_gtk/sim3d/playback_overlay.py
@@ -1,9 +1,10 @@
 import logging
 from gettext import gettext as _
-from typing import Any, Protocol
+from typing import Protocol
 
 from blinker import Signal
 from gi.repository import GLib, Gtk
+from raygeo.ops import Ops
 
 from ..icons import get_icon
 from ..shared.gtk import apply_css
@@ -11,13 +12,38 @@ from ..shared.gtk import apply_css
 logger = logging.getLogger(__name__)
 
 
+class OpMapLike(Protocol):
+    """Surface of :class:`MachineCodeOpMap` used by the overlay.
+
+    Implemented by ``MachineCodeOpMap``; backed by compact numpy
+    arrays that already exist per job, so holding a reference here
+    adds no per-job memory.
+    """
+
+    @property
+    def op_count(self) -> int: ...
+
+    @property
+    def line_count(self) -> int: ...
+
+    def span_for_op(self, op_index: int) -> tuple[int, int]: ...
+
+    def op_for_line(self, line_idx: int) -> int | None: ...
+
+
 class PlaybackPlayer(Protocol):
     """Minimal OpPlayer surface required by the playback overlay."""
 
-    ops: Any
+    ops: Ops
 
     @property
     def current_index(self) -> int: ...
+
+    @property
+    def is_finished(self) -> bool: ...
+
+    @property
+    def sim_time(self) -> float: ...
 
     def seek(self, index: int) -> None: ...
 
@@ -29,6 +55,12 @@ class PlaybackPlayer(Protocol):
 
     def set_sim_time(self, t: float) -> None: ...
 
+    def set_playhead(self, index: int) -> None: ...
+
+    def set_progress_anchor(self, completed: int, t: float) -> None: ...
+
+    def sync_state_to_playhead(self) -> None: ...
+
     def playback_progress(self) -> tuple[int, float]: ...
 
 
@@ -38,7 +70,7 @@ SPEED_OPTIONS = [1, 2, 4, 8, 16, 32, 64]
 # display frame rate). The simulated clock advances by this amount per
 # tick, scaled by the speed multiplier. Every tick queues a render so
 # the interpolated playhead is redrawn continuously, not only when the
-# slider value (command index) changes.
+# slider value changes.
 TICK_SECONDS = 1.0 / 60.0
 
 # Wall-clock span of the step-button animation (~0.2 s). Each manual
@@ -68,9 +100,10 @@ css = """
 class PlaybackOverlay(Gtk.Box):
     """
     Playback controls (play/pause button + slider + speed button)
-    shown as a bar below the 3D canvas. Slider drives OpPlayer.seek();
-    play button starts a ~24 fps timer that advances the playhead by
-    simulated machine time (speed multiplier scales real machine speed).
+    shown as a bar below the 3D canvas. The slider spans the command
+    indices, matching the G-code viewer; the underlying animation
+    advances by simulated machine time so motion follows feed rates.
+    Play starts a ~60 fps timer that drives the playhead.
     """
 
     step_changed = Signal()
@@ -138,10 +171,11 @@ class PlaybackOverlay(Gtk.Box):
         self._timer_id: int | None = None
         self._canvas = None
         self._player: PlaybackPlayer | None = None
+        self._op_map: OpMapLike | None = None
         self._is_syncing = False
-        self._suppress_seek = False
         self._tick_driving_slider = False
         self._sim_time: float = 0.0
+        self._emitted_index: int = -1
         self._step_timer_id: int | None = None
         self._step_animating = False
         self._step_ticks_remaining = 0
@@ -161,6 +195,122 @@ class PlaybackOverlay(Gtk.Box):
         """Connect this overlay to a Canvas3D instance."""
         self._canvas = canvas
 
+    def set_op_map(self, op_map: OpMapLike | None):
+        """Provide the ops-to-gcode-line map used while stepping.
+
+        When set, stepping skips commands that produced no G-code
+        output (markers, redundant state changes) so every step lands
+        on a line that is visible in the G-code viewer.  The slider
+        then spans G-code line numbers, keeping its position in sync
+        with the highlighted viewer line.
+
+        The map is the encoder-produced ``MachineCodeOpMap``; this only
+        holds a reference to its compact numpy arrays (4 bytes per line
+        plus 8 bytes per op, already allocated for the job), so no
+        additional per-job memory is created here.
+        """
+        self._op_map = op_map
+        self._refresh_slider_range()
+
+    def _gcode_line_count(self, index: int) -> int:
+        """G-code lines produced by command *index* (1 if unknown)."""
+        if self._op_map is None:
+            return 1
+        try:
+            _, count = self._op_map.span_for_op(index)
+            return count
+        except (IndexError, AttributeError):
+            return 1
+
+    def _slider_extent(self) -> int:
+        """Largest slider value: last G-code line (or command)."""
+        if self._op_map is not None:
+            return max(self._op_map.line_count - 1, 0)
+        return max(self.command_count - 1, 0)
+
+    def _slider_value_for_op(self, op_index: int) -> int | None:
+        """Slider value displaying command *op_index*, or ``None``.
+
+        With an op map this is the op's action line - the same line the
+        G-code viewer highlights for it - so the slider always matches
+        the selection.  Commands without G-code output keep the slider
+        where it is.
+        """
+        if self._op_map is None:
+            if not 0 <= op_index <= max(self.command_count - 1, 0):
+                return None
+            return max(0, op_index)
+        try:
+            start, count = self._op_map.span_for_op(op_index)
+        except (IndexError, AttributeError):
+            return None
+        if count <= 0:
+            return None
+        return start + count - 1
+
+    def _line_to_op(self, line: int) -> int | None:
+        """Command owning *line*, or the nearest owner after/before it.
+
+        Every encoded G-code line is owned by exactly one command, so
+        the forward scan resolves on the first iteration; the loops are
+        effectively O(1) and only walk further if an encoder ever left
+        a run of unowned lines.  Called once per user scrub event,
+        never per playback tick.
+        """
+        if self._op_map is None:
+            return line
+        n = self._op_map.line_count
+        line = max(0, min(line, n - 1))
+        for k in range(line, n):
+            op = self._op_map.op_for_line(k)
+            if op is not None and op >= 0:
+                return op
+        for k in range(line, -1, -1):
+            op = self._op_map.op_for_line(k)
+            if op is not None and op >= 0:
+                return op
+        return None
+
+    def _set_slider_for_op(self, op_index: int):
+        """Move the slider to *op_index*'s position (guarded)."""
+        value = self._slider_value_for_op(op_index)
+        if value is None:
+            return
+        self._tick_driving_slider = True
+        self._slider.set_value(value)
+        self._tick_driving_slider = False
+
+    def _refresh_slider_range(self):
+        """Recompute the slider range after the op map changed."""
+        extent = self._slider_extent()
+        self._tick_driving_slider = True
+        self._slider.set_range(0, max(extent, 1))
+        self._tick_driving_slider = False
+        # A pristine playhead (-1) keeps the slider at the beginning;
+        # an established playhead follows to its action line.
+        if self.current_index >= 0:
+            self._set_slider_for_op(self.current_index)
+
+    def _resolve_step_target(self, base: int, steps: int) -> int:
+        """Resolve a step of *steps* commands from *base*.
+
+        Skips commands without G-code output so the playhead always
+        lands on something visible in the G-code viewer.
+
+        Complexity is bounded by ``abs(steps)`` (the number of queued
+        clicks, a handful at most) times the longest run of commands
+        without G-code output - linear, never exponential.
+        """
+        max_idx = self.command_count - 1
+        delta = 1 if steps > 0 else -1
+        k = base
+        for _step in range(abs(steps)):
+            k += delta
+            if 0 <= k <= max_idx:
+                while 0 <= k <= max_idx and self._gcode_line_count(k) == 0:
+                    k += delta
+        return max(0, min(k, max_idx))
+
     def set_player(
         self,
         player: PlaybackPlayer | None,
@@ -168,9 +318,9 @@ class PlaybackOverlay(Gtk.Box):
     ):
         """Set the OpPlayer backing this overlay's slider and seek calls.
 
-        ``initial_index`` positions the slider for a freshly built player
-        (typically 0). The player itself may already be seeked to the
-        first layer for rendering.
+        ``initial_index`` positions the slider for a freshly built
+        player (typically 0). The player itself may already be seeked
+        to the first layer for rendering.
         """
         self._cancel_step_animation()
         self._player = player
@@ -199,36 +349,56 @@ class PlaybackOverlay(Gtk.Box):
             return self._player.current_index
         return -1
 
-    def seek(self, index: int):
-        """Seek the OpPlayer to the given command index.
+    def _total_time(self) -> float:
+        """Total simulated job time in seconds (never zero)."""
+        if self._player and self.command_count > 0:
+            total = self._player.get_cumulative_time(self.command_count - 1)
+            return max(total, 1e-9)
+        return 1e-9
 
-        While paused, the simulated clock is resynced to the new
-        position so that resuming play continues from there.
+    def _set_slider_index(self, index: int):
+        """Move the slider to a command index (guarded, no op map)."""
+        value = self._slider_value_for_op(index)
+        if value is None:
+            return
+        self._tick_driving_slider = True
+        self._slider.set_value(value)
+        self._tick_driving_slider = False
+
+    def _emit_step_changed(self, ops_index: int):
+        """Notify listeners when the command under the playhead changes."""
+        if ops_index != self._emitted_index and not self._is_syncing:
+            self._emitted_index = ops_index
+            self.step_changed.send(self, ops_index=ops_index)
+
+    def seek(self, index: int):
+        """Jump the playhead to the given command index.
+
+        Works while playing and while paused; the simulated clock is
+        resynced to the new position either way. Anchoring by index
+        (via ``set_playhead``) keeps the position exact across
+        clusters of zero-duration commands.
         """
+        if not self._player or self.command_count == 0:
+            return
         self._cancel_step_animation()
-        if self._player:
-            self._player.seek(index)
-            if not self._playing:
-                self._sim_time = self._player.get_cumulative_time(index)
-                self._player.set_sim_time(self._sim_time)
-            if self._canvas:
-                self._canvas.queue_render()
+        index = max(0, min(index, self.command_count - 1))
+        self._player.set_playhead(index)
+        self._sim_time = self._player.sim_time
+        self._set_slider_index(index)
+        if self._canvas:
+            self._canvas.queue_render()
+        self._emit_step_changed(index)
 
     def seek_to_fraction(self, fraction: float):
-        """Seek the OpPlayer by fraction (0.0 to 1.0) and sync the slider."""
-        if self._player:
-            self._player.seek_to_fraction(fraction)
-            self.update_ops_range(
-                len(self._player.ops),
-                self._player.current_index,
-            )
-            if not self._playing:
-                self._sim_time = self._player.get_cumulative_time(
-                    self._player.current_index
-                )
-                self._player.set_sim_time(self._sim_time)
-            if self._canvas:
-                self._canvas.queue_render()
+        """Seek to *fraction* (0.0-1.0) of the slider range."""
+        if not self._player or self.command_count == 0:
+            return
+        fraction = max(0.0, min(1.0, fraction))
+        target = round(fraction * self._slider_extent())
+        op = self._line_to_op(target)
+        if op is not None:
+            self.seek(op)
 
     def handle_space(self):
         """Toggle playback when the space key is pressed."""
@@ -238,54 +408,46 @@ class PlaybackOverlay(Gtk.Box):
     def update_ops_range(self, command_count: int, initial_index: int = 0):
         """Update slider range for the given number of commands.
 
-        initial_index sets the slider to the first layer's position
-        so the canvas displays the correct surface from the start.
+        initial_index positions the slider at the first layer's
+        position so the canvas displays the correct surface from the
+        start.  With an op map the slider spans G-code line numbers;
+        otherwise it spans raw command indices.
         """
         if command_count > 0:
-            self._slider.set_range(0, command_count - 1)
-            self._slider.set_value(initial_index)
+            self._refresh_slider_range()
+            if initial_index > 0:
+                # Restored playhead: show its action line.
+                self._set_slider_for_op(initial_index)
+            else:
+                # Pristine playhead: nothing has executed yet, so the
+                # slider starts at the very beginning of the job.
+                self._tick_driving_slider = True
+                self._slider.set_value(0)
+                self._tick_driving_slider = False
             self._slider.set_sensitive(True)
             self._play_button.set_sensitive(True)
             self._step_back_button.set_sensitive(True)
             self._step_fwd_button.set_sensitive(True)
         else:
             self._slider.set_range(0, 1)
-            self._slider.set_value(0)
+            self._set_slider_for_op(0)
             self._slider.set_sensitive(False)
             self._play_button.set_sensitive(False)
             self._step_back_button.set_sensitive(False)
             self._step_fwd_button.set_sensitive(False)
 
-    def get_slider_index(self) -> int:
-        return int(self._slider.get_value())
-
-    def _on_slider_changed(self, slider):
-        if self._canvas:
-            index = int(slider.get_value())
-            if self.current_index != index:
-                self.seek(index)
-        # A user-initiated scrub while playing resyncs the simulated
-        # clock to the new position so the next tick continues from
-        # there instead of snapping back to the pre-drag playhead.
-        # Tick-driven slider moves set ``_tick_driving_slider`` so they
-        # are not mistaken for user scrubs.
-        if self._playing and self._player and not self._tick_driving_slider:
-            self._sim_time = self._player.get_cumulative_time(
-                int(slider.get_value())
-            )
-            self._player.set_sim_time(self._sim_time)
-        if not self._is_syncing:
-            self.step_changed.send(self, ops_index=int(slider.get_value()))
-
     def set_playback_position(self, ops_index: int):
         """
-        Set the slider position from an external source (e.g. a G-code
+        Set the playhead from an external source (e.g. a G-code
         viewer click) without triggering a feedback loop.
         """
-        self._cancel_step_animation()
+        if not self._player or self.command_count == 0:
+            return
         self._is_syncing = True
-        self._slider.set_value(ops_index)
-        self._is_syncing = False
+        try:
+            self.seek(int(ops_index))
+        finally:
+            self._is_syncing = False
 
     def can_play(self) -> bool:
         """Returns True if the play button is currently sensitive."""
@@ -294,6 +456,31 @@ class PlaybackOverlay(Gtk.Box):
     def toggle_playback(self):
         """Toggles play/pause state, as if the play button was clicked."""
         self._on_play_clicked(self._play_button)
+
+    def _on_slider_changed(self, slider):
+        if self._tick_driving_slider:
+            return
+        if not self._player or self.command_count == 0:
+            return
+        self._cancel_step_animation()
+        index = self._line_to_op(int(slider.get_value()))
+        if index is None:
+            return
+        if not self._playing:
+            # Paused: anchor the playhead explicitly so positions stay
+            # exact across zero-duration command clusters.
+            self._player.set_playhead(index)
+            self._sim_time = self._player.sim_time
+        else:
+            # While playing the slider drag resyncs the simulated
+            # clock to the new position so the next tick continues
+            # from there instead of snapping back to the old playhead.
+            self._sim_time = self._player.get_cumulative_time(index)
+            self._player.set_sim_time(self._sim_time)
+            self._player.sync_state_to_playhead()
+        if self._canvas:
+            self._canvas.queue_render()
+        self._emit_step_changed(index)
 
     def _on_play_clicked(self, button):
         if self._playing:
@@ -304,20 +491,13 @@ class PlaybackOverlay(Gtk.Box):
     def _start_playback(self):
         if not self._canvas or self.command_count == 0:
             return
-        max_idx = self.command_count - 1
-        current = int(self._slider.get_value())
-        if max_idx >= 0 and current >= max_idx:
-            self._slider.set_value(0)
-            current = 0
-        # Resync the simulated clock to the current playhead so that
-        # playback continues from wherever the user left the slider.
-        # An in-flight step animation keeps its interpolated time so
-        # that playback continues seamlessly from the gliding playhead.
+        if self._reached_end():
+            self._restart_from_beginning()
+        if self._step_animating:
+            # Keep the interpolated time so playback continues
+            # seamlessly from the gliding playhead.
+            self._cancel_step_animation()
         if self._player:
-            if self._step_animating:
-                self._cancel_step_animation()
-            else:
-                self._sim_time = self._player.get_cumulative_time(current)
             self._player.set_sim_time(self._sim_time)
         else:
             self._sim_time = 0.0
@@ -329,6 +509,21 @@ class PlaybackOverlay(Gtk.Box):
         self._timer_id = GLib.timeout_add(
             int(TICK_SECONDS * 1000), self._on_tick
         )
+
+    def _reached_end(self) -> bool:
+        """True when the playhead sits at (or past) the job end."""
+        if self._player and self._player.is_finished:
+            return True
+        total = self._total_time()
+        return self._sim_time >= total - TICK_SECONDS
+
+    def _restart_from_beginning(self):
+        self._sim_time = 0.0
+        if self._player:
+            self._player.set_progress_anchor(-1, 0.0)
+        self._tick_driving_slider = True
+        self._slider.set_value(0)
+        self._tick_driving_slider = False
 
     def _stop_playback(self):
         self._cancel_step_animation()
@@ -354,21 +549,28 @@ class PlaybackOverlay(Gtk.Box):
         multiplier = SPEED_OPTIONS[self._speed_index]
         self._sim_time += TICK_SECONDS * multiplier
         self._player.set_sim_time(self._sim_time)
+        self._player.sync_state_to_playhead()
         max_idx = self.command_count - 1
         target = self._player.find_index_at_sim_time(self._sim_time)
 
         if target >= max_idx:
+            # Anchor the playhead on the final command so its state
+            # (laser off after the trailing M5s, home position) is
+            # actually applied - identical to stepping forward onto
+            # the last command by hand.
+            self._player.set_playhead(max_idx)
+            self._sim_time = self._player.sim_time
             self._tick_driving_slider = True
-            self._slider.set_value(max_idx)
+            self._slider.set_value(self._slider_extent())
             self._tick_driving_slider = False
+            self._emit_step_changed(max_idx)
             self._stop_playback()
             return False
 
-        self._tick_driving_slider = True
-        self._slider.set_value(target)
-        self._tick_driving_slider = False
-        # The slider value only changes at command boundaries; within a
-        # command the playhead still moves, so always redraw.
+        self._set_slider_for_op(target)
+        self._emit_step_changed(target)
+        # The slider value only changes at command boundaries; within
+        # a command the playhead still moves, so always redraw.
         self._canvas.queue_render()
         return True
 
@@ -377,15 +579,15 @@ class PlaybackOverlay(Gtk.Box):
         button.set_label(f"{SPEED_OPTIONS[self._speed_index]}x")
 
     def _on_step_back(self, button):
-        # The bounds check must look past the playhead (slider + queued
-        # steps): a backward click may cancel a forward glide even
-        # while the slider still sits at 0.
-        if self._pending_steps > 0 or int(self._slider.get_value()) > 0:
+        # The bounds check must look past the playhead: a backward
+        # click may cancel a forward glide even while the playhead
+        # still sits at the first command.
+        if self._pending_steps > 0 or self.current_index > 0:
             self._queue_step(-1)
 
     def _on_step_fwd(self, button):
-        max_idx = self._slider.get_adjustment().get_upper()
-        if self._pending_steps < 0 or int(self._slider.get_value()) < max_idx:
+        max_idx = self.command_count - 1
+        if self._pending_steps < 0 or self.current_index < max_idx:
             self._queue_step(1)
 
     def _queue_step(self, delta: int):
@@ -397,7 +599,12 @@ class PlaybackOverlay(Gtk.Box):
         jump instantly as before.
         """
         if self._playing or not self._player:
-            self._slider.set_value(int(self._slider.get_value()) + delta)
+            if not self._player or self.command_count == 0:
+                return
+            base = self._player.find_index_at_sim_time(self._sim_time)
+            target = self._resolve_step_target(base, delta)
+            if target != self.current_index:
+                self.seek(target)
             return
         self._pending_steps += delta
         self._start_step_glide()
@@ -411,19 +618,17 @@ class PlaybackOverlay(Gtk.Box):
         """
         if self._playing or not self._player:
             return
-        current = int(self._slider.get_value())
-        max_idx = int(self._slider.get_adjustment().get_upper())
-        target = max(0, min(current + self._pending_steps, max_idx))
+        # A fresh player sits at -1 (before the first command), so the
+        # first forward step must land on the first visible command.
+        current = self.current_index
+        target = self._resolve_step_target(current, self._pending_steps)
         consumed = target - current
         if self._step_animating:
             if consumed == 0:
-                # The queued clicks cancel each other out: snap back to
-                # the playhead and drop the batch.
+                # The queued clicks cancel each other out: snap back
+                # to the playhead and drop the batch.
                 self._cancel_step_animation()
-                self._sim_time = self._player.get_cumulative_time(current)
-                self._player.set_sim_time(self._sim_time)
-                if self._canvas:
-                    self._canvas.queue_render()
+                self._jump_to_index(current)
                 return
             self._step_consumed = consumed
             self._step_target = target
@@ -433,18 +638,6 @@ class PlaybackOverlay(Gtk.Box):
             self._pending_steps = 0
             return
         end_time = self._player.get_cumulative_time(target)
-        while end_time == self._sim_time:
-            # Zero-duration commands between the playhead and the
-            # target: move through them instantly, then continue with
-            # the rest of the batch.
-            self._pending_steps -= consumed
-            self._slider.set_value(target)
-            current = target
-            target = max(0, min(current + self._pending_steps, max_idx))
-            consumed = target - current
-            if consumed == 0:
-                return
-            end_time = self._player.get_cumulative_time(target)
         self._step_animating = True
         self._step_ticks_remaining = STEP_ANIMATION_TICKS
         self._step_start_time = self._sim_time
@@ -466,14 +659,32 @@ class PlaybackOverlay(Gtk.Box):
             + (self._step_end_time - self._step_start_time) * progress
         )
         self._player.set_sim_time(self._sim_time)
+        self._player.sync_state_to_playhead()
         if self._canvas:
             self._canvas.queue_render()
         if self._step_ticks_remaining == 0:
             self._pending_steps -= self._step_consumed
             self._cancel_step_animation()
-            self._slider.set_value(self._step_target)
+            self._jump_to_index(self._step_target)
             return False
         return True
+
+    def _jump_to_index(self, index: int):
+        """Instantly place the playhead on a command boundary.
+
+        Anchoring by index (rather than deriving the position from the
+        simulated time) keeps stepping exact across clusters of
+        zero-duration commands that share cumulative times.
+        """
+        if not self._player or self.command_count == 0:
+            return
+        index = max(0, min(index, self.command_count - 1))
+        self._player.set_playhead(index)
+        self._sim_time = self._player.sim_time
+        self._set_slider_index(index)
+        if self._canvas:
+            self._canvas.queue_render()
+        self._emit_step_changed(index)
 
     def _cancel_step_animation(self):
         """Stop any in-flight step glide and drop queued steps."""

--- a/tests/shared/gcodeedit/test_viewer_highlight.py
+++ b/tests/shared/gcodeedit/test_viewer_highlight.py
@@ -1,0 +1,42 @@
+# flake8: noqa: E402
+"""UI tests for GcodeViewer op highlighting."""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+import pytest
+
+from rayforge.pipeline.encoder.base import MachineCodeOpMap
+from rayforge.shared.gcodeedit.viewer import GcodeViewer
+
+
+@pytest.mark.ui
+def test_highlight_op_selects_action_line(ui_context_initializer):
+    """Regression test for issue #370.
+
+    The encoder defers state lines like "M4 S800" into the span of the
+    first cutting move.  Highlighting an op must select the op's own
+    action line (the last of its span), not the deferred state line.
+    """
+    viewer = GcodeViewer()
+    viewer.set_gcode("G21\nG90\nG54\nT0\nG0 X1 Y1\nM4 S800\nG1 X2 Y2 F500\n")
+    # Op spans: preamble 3 lines, T0, travel, then the first cut op
+    # owns both the deferred "M4 S800" and its own move line.
+    viewer.set_op_map(
+        MachineCodeOpMap.from_lists(
+            [(0, 3), (3, 0), (3, 0), (3, 0), (3, 1), (4, 1), (5, 2), (7, 1)],
+            [0, 0, 0, 3, 4, 6, 6, 7],
+        )
+    )
+    # Stepping onto op 6 (the first cutting segment) must highlight
+    # line 6 ("G1 X2 Y2 F500"), not line 5 ("M4 S800").
+    viewer.highlight_op(6)
+    assert viewer.editor.current_highlight_line == 6
+    # A single-line op highlights that line (op 4 -> "T0", line 3).
+    viewer.highlight_op(4)
+    assert viewer.editor.current_highlight_line == 3
+    # An op without output clears the highlight.
+    viewer.highlight_op(1)
+    assert viewer.editor.current_highlight_line == -1

--- a/tests/simulator/test_op_player.py
+++ b/tests/simulator/test_op_player.py
@@ -95,6 +95,34 @@ def test_seek_then_advance():
     assert player.state.axes[Axis.X] == 0.0
 
 
+def test_sync_state_to_playhead_advances_to_playhead():
+    ops = _make_ops()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    player.seek(0)
+    t = player.get_cumulative_time(4)
+    player.set_sim_time(t)
+    player.sync_state_to_playhead()
+    p, _frac = player.playback_progress()
+    reference = OpPlayer(ops, _make_machine(), Doc())
+    reference.seek(max(p - 1, 0))
+    assert player.current_index == reference.current_index
+    assert player.state.axes == reference.state.axes
+
+
+def test_sync_state_to_playhead_scrubs_backwards():
+    ops = _make_ops()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    player.seek(6)
+    t = player.get_cumulative_time(2)
+    player.set_sim_time(t)
+    player.sync_state_to_playhead()
+    p, _frac = player.playback_progress()
+    reference = OpPlayer(ops, _make_machine(), Doc())
+    reference.seek(max(p - 1, 0))
+    assert player.current_index == reference.current_index
+    assert player.state.axes == reference.state.axes
+
+
 def test_advance_backwards_raises():
     ops = _make_ops()
     player = OpPlayer(ops, _make_machine(), Doc())
@@ -108,6 +136,127 @@ def test_seek_out_of_range_raises():
     player = OpPlayer(ops, _make_machine(), Doc())
     with pytest.raises(IndexError):
         player.seek(999)
+
+
+def test_set_playhead_anchors_at_command_boundary():
+    """Regression test for issue #370 stepping sync.
+
+    Commands 0-2 of ``_make_ops`` take zero simulated time, so
+    commands 0, 1 and 2 all share cumulative time 0. Anchoring by
+    index must land exactly on the stepped-to command instead of
+    letting the ambiguous time lookup skip ahead.
+    """
+    ops = _make_ops()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    player.set_playhead(2)
+    assert player.current_index == 2
+    assert player.sim_time == pytest.approx(0.0)
+    # Progress is anchored to command 3 (the first cut) at frac 0:
+    # nothing of it is revealed yet.
+    assert player.playback_progress() == (3, 0.0)
+    assert player.state.axes[Axis.X] == 0.0
+    assert player.state.power == 0.5
+
+    # Stepping onto a zero-duration command right after a move: state
+    # includes it, progress anchors to the next cut with no reveal.
+    player.set_playhead(4)
+    assert player.current_index == 4
+    assert player.playback_progress() == (5, 0.0)
+
+    # Stepping onto the final cut reveals everything up to it.
+    player.set_playhead(5)
+    assert player.current_index == 5
+    assert player.state.axes[Axis.Y] == 10.0
+    p, frac = player.playback_progress()
+    assert (p, frac) == (6, 0.0)
+
+
+def test_set_playhead_backwards_recovers_state():
+    ops = _make_ops()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    player.set_playhead(5)
+    player.set_playhead(2)
+    assert player.current_index == 2
+    assert player.state.axes[Axis.X] == 0.0
+    assert player.state.power == 0.5
+
+
+def test_set_progress_anchor_keeps_fraction():
+    ops = _make_ops()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    t_start = player.get_cumulative_time(2)
+    t_end = player.get_cumulative_time(3)
+    mid = (t_start + t_end) / 2.0
+    player.set_progress_anchor(2, mid)
+    assert player.current_index == 2
+    p, frac = player.playback_progress()
+    assert p == 3
+    assert frac == pytest.approx(0.5)
+    # State reflects completed commands only.
+    assert player.state.axes[Axis.X] == 0.0
+
+
+def _make_step_ops():
+    """Ops mirroring a simple two-pass cut job with state changes.
+
+    Layout: preamble states, a rapid, a laser-on state, a cut, a
+    zero-duration filler, another cut, two laser-off states, and a
+    rapid home - like G-code with M3/M5 commands around moves.
+    """
+    ops = Ops()
+    ops.set_power(0.0)
+    ops.set_feed_rate(500)
+    ops.move_to(83.877, 60.0)
+    ops.set_power(0.8)
+    ops.line_to(36.123, 60.0)
+    ops.set_feed_rate(500)
+    ops.line_to(83.877, 60.0)
+    ops.set_power(0.0)
+    ops.set_power(0.0)
+    ops.move_to(0.0, 0.0)
+    return ops
+
+
+def test_set_playhead_steps_through_zero_duration_commands():
+    """Stepping must land exactly one command at a time.
+
+    Zero-duration state changes share cumulative times with their
+    neighbours; index-anchored playhead placement keeps the reveal and
+    the reported position in sync with the stepped-to command.
+    """
+    ops = _make_step_ops()
+    n = ops.len()
+    player = OpPlayer(ops, _make_machine(), Doc())
+
+    seen = []
+    for index in range(n):
+        player.set_playhead(index)
+        p, frac = player.playback_progress()
+        seen.append((index, player.current_index, p))
+        if index + 1 < n:
+            # Progress anchored to the next command, not yet revealed.
+            assert player.current_index == index
+            assert p == index + 1
+            assert frac == pytest.approx(0.0)
+    assert seen[0] == (0, 0, 1)
+
+    # On the laser-on state: neither cut may be revealed yet.
+    player.set_playhead(3)
+    p, _frac = player.playback_progress()
+    assert p == 4
+
+    # After the first cut: exactly the first cut is done, not both.
+    player.set_playhead(5)
+    p, _frac = player.playback_progress()
+    assert p == 6
+
+    # Stepping backwards lands exactly, restoring earlier state.
+    player.set_playhead(7)
+    assert player.current_index == 7
+    assert player.state.power == 0.0
+    player.set_playhead(4)
+    assert player.current_index == 4
+    assert player.state.power == 0.8
 
 
 def test_advance_out_of_range_raises():
@@ -876,3 +1025,128 @@ def test_render_state_rotary_arc_rotation_oscillates():
 
     # The arc dips to Y=0 at the midpoint, so rotary angle is lower.
     assert rot_mid < rot_start
+
+
+def _make_true4th_broken_frame_player():
+    """Player over TRUE_4TH_AXIS mapped ops whose arcs lost their frame.
+
+    Mirrors a wrapped-cylinder cut with four consecutive arcs (I/J from
+    the unwrapped geometry): mapping collapses endpoint Y onto the
+    cylinder position, detaching each stored circle from its
+    endpoints.
+    """
+    machine = _make_machine()
+    rm = RotaryModule()
+    rm.set_mode(RotaryMode.TRUE_4TH_AXIS)
+    rm.set_axis(Axis.A)
+    rm.default_diameter = 40.0
+    machine.add_rotary_module(rm)
+
+    arcs = [
+        # (x_end, a_end_deg, i, j) like the reported gcode.
+        (29.859, -110.648, 14.165, 15.021),
+        (29.522, -92.459, 75.975, 24.224),
+        (29.438, -53.874, 311.838, 26.596),
+        (29.944, -19.149, 101.253, 1.595),
+    ]
+    circumference = math.pi * 40.0
+    a_start = -128.0
+    y = a_start / 360.0 * circumference
+
+    def build():
+        seq = Ops()
+        seq.set_feed_rate(60)
+        seq.move_to(29.0, y, 0.0)
+        seq.layer_start("test")
+        for x_end, a_end, i, j in arcs:
+            seq.arc_to(x_end, a_end / 360.0 * circumference, i, j, True)
+        seq.layer_end("test")
+        return seq
+
+    # Like the pipeline: playback walks the mapped ops while the time
+    # model uses the raw unwrapped ones.
+    time_ops = build()
+    ops = build()
+    KinematicMapping(rotary_axis=Axis.A, diameter=40.0).apply(ops)
+
+    doc = Doc()
+    doc.active_layer.uid = "test"
+    doc.active_layer.set_rotary_enabled(True)
+    doc.active_layer.set_rotary_diameter(40.0)
+    doc.active_layer.set_rotary_module_uid(rm.uid)
+
+    player = OpPlayer(
+        ops, machine, doc, build_snapshots=False, time_ops=time_ops
+    )
+    player.set_playback_params(500.0, 3000.0, 0.0)
+    return player, arcs
+
+
+def test_rotary_arc_detached_frame_interpolates_linearly():
+    """Regression test for issue #370 (rotary follow-up).
+
+    Rotary mapping collapses endpoint Y, detaching the stored circles
+    from their mapped endpoints. Angle interpolation in that broken
+    frame stalled or wildly swung the rotary axis on some arcs. The
+    playhead must reconstruct each arc from the rotary axis travel:
+    X stays between the endpoints and every arc rotates through its
+    full angular travel without stalling.
+    """
+    player, arcs = _make_true4th_broken_frame_player()
+    player.seek_to_first_layer()
+    assert player._rotary_axis == Axis.A
+
+    total = player.get_cumulative_time(player.ops.len() - 1)
+    t = 0.0
+    tick = 1.0 / 60.0
+    samples = {}
+    prev_a = None
+    while t < total:
+        t = min(t + tick, total)
+        player.set_sim_time(t)
+        player.sync_state_to_playhead()
+        p, _frac = player.playback_progress()
+        if p not in (3, 4, 5, 6):
+            continue
+        st = player.render_state()
+        x = st.axes[Axis.X]
+        assert 28.0 <= x <= 30.5, f"X off path: {x}"
+        a = st.axes[Axis.A]
+        if prev_a is not None:
+            assert a >= prev_a - 1e-6, f"A not monotonic: {prev_a} -> {a}"
+        prev_a = a
+        samples.setdefault(p, []).append(a)
+    # The rotation completes at the last arc's mapped target angle.
+    last_op = 2 + len(arcs)
+    extra = player.ops.extra_axes(last_op) or {}
+    a_target = extra.get(Axis.A)
+    assert a_target is not None
+    assert prev_a == pytest.approx(a_target, abs=0.05)
+    # No stalls: every arc sweeps at least 80% of its angular travel.
+    a_before = {3: -128.0, 4: arcs[0][1], 5: arcs[1][1], 6: arcs[2][1]}
+    for op, (_x_end, a_end, _i, _j) in enumerate(arcs, start=3):
+        values = samples.get(op, [])
+        assert values, f"arc op {op} never rendered"
+        sweep = max(values) - min(values)
+        expected = abs(a_end - a_before[op])
+        assert sweep >= 0.8 * expected, (
+            f"rotary axis stalled during op {op}: swept "
+            f"{sweep:.3f} of {expected:.3f} deg"
+        )
+
+
+def test_flat_arc_still_interpolates_along_circle():
+    """The consistency fallback must not affect healthy flat arcs."""
+    ops = _make_arc_player()
+    player = OpPlayer(ops, _make_machine(), Doc())
+    player.set_playback_params(600.0, 3000.0, 0.0)
+    player.seek(1)  # state at move_to (0,0); arc starts there
+    # Arc duration is ~6.28 s; a quarter second in, frac ~ 0.04.
+    player.set_sim_time(0.25)
+    p, _frac = player.playback_progress()
+    assert p == 2
+    st = player.render_state()
+    # The CW full circle of r=10 is centered at (10, 0): the head must
+    # stay ON the circle, not somewhere inside it.
+    dist = math.hypot(st.axes[Axis.X] - 10.0, st.axes[Axis.Y])
+    assert dist == pytest.approx(10.0, abs=1e-3)

--- a/tests/ui_gtk/sim3d/test_playback_overlay.py
+++ b/tests/ui_gtk/sim3d/test_playback_overlay.py
@@ -6,6 +6,8 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
+from typing import Any
+
 import pytest
 
 from rayforge.ui_gtk.sim3d.playback_overlay import (
@@ -18,12 +20,23 @@ from rayforge.ui_gtk.sim3d.playback_overlay import (
 class FakePlayer:
     """Minimal OpPlayer stand-in exposing the playback surface.
 
-    Each command takes ``cmd_time`` simulated seconds: cumulative time
-    at index *i* is ``cmd_time * (i + 1)`` and the playhead lands on the
+    Each command takes ``cmd_time`` simulated seconds (or the entries
+    of ``cmd_times``): cumulative time at index *i* is the sum of the
+    durations up to and including *i*, and the playhead lands on the
     last command whose cumulative time is <= *t*.
+
+    The ``ops`` attribute is intentionally opaque to the type checker;
+    the overlay only reads its length.
     """
 
-    def __init__(self, n_ops: int = 0, cmd_time: float = 1.0):
+    ops: Any
+
+    def __init__(
+        self,
+        n_ops: int = 0,
+        cmd_time: float = 1.0,
+        cmd_times: list[float] | None = None,
+    ) -> None:
         class FakeOps:
             def __init__(self, n):
                 self._n = n
@@ -36,41 +49,116 @@ class FakePlayer:
 
         self.ops = FakeOps(n_ops)
         self._current_index = -1
-        self._cmd_time = cmd_time
+        if cmd_times is None:
+            cmd_times = [cmd_time] * n_ops
+        self._cmd_times = list(cmd_times)
         self._sim_time = 0.0
+        self.seek_count = 0
 
     @property
     def current_index(self) -> int:
         return self._current_index
 
-    def seek(self, index: int):
+    @property
+    def is_finished(self) -> bool:
+        if not self._cmd_times:
+            return False
+        return self._sim_time >= sum(self._cmd_times) - 1e-9
+
+    @property
+    def sim_time(self) -> float:
+        return self._sim_time
+
+    def set_playhead(self, index: int) -> None:
+        n = len(self._cmd_times)
+        index = max(0, min(index, n - 1))
+        self._current_index = index
+        self._sim_time = self.get_cumulative_time(index)
+
+    def set_progress_anchor(self, completed: int, t: float) -> None:
+        n = len(self._cmd_times)
+        completed = max(-1, min(completed, n - 1))
+        self._current_index = completed
+        self._sim_time = float(t)
+
+    def seek(self, index: int) -> None:
+        self.seek_count += 1
         self._current_index = index
 
-    def seek_to_fraction(self, fraction: float):
+    def seek_to_fraction(self, fraction: float) -> None:
         self._current_index = int(self.ops.len() * fraction)
 
     def find_index_at_sim_time(self, t: float) -> int:
-        n = self.ops.len()
+        n = len(self._cmd_times)
         if n == 0:
             return 0
-        idx = int(t / self._cmd_time) - 1
-        return max(0, min(idx, n - 1))
+        idx = 0
+        acc = 0.0
+        for i, duration in enumerate(self._cmd_times):
+            acc += duration
+            if acc <= t:
+                idx = i
+        return idx
 
     def get_cumulative_time(self, idx: int) -> float:
-        n = self.ops.len()
+        n = len(self._cmd_times)
         if n == 0:
             return 0.0
         idx = max(0, min(idx, n - 1))
-        return self._cmd_time * (idx + 1)
+        return sum(self._cmd_times[: idx + 1])
 
     def set_sim_time(self, t: float):
         self._sim_time = t
 
-    def playback_progress(self):
-        return (self._current_index + 1, 0.0)
+    def sync_state_to_playhead(self) -> None:
+        # Mirrors OpPlayer: state advances only through the commands
+        # COMPLETED before the playhead (p - 1), leaving trailing
+        # commands unapplied until explicitly anchored.
+        p, _frac = self.playback_progress()
+        n = len(self._cmd_times)
+        self._current_index = max(0, min(p - 1, n - 1))
+
+    def playback_progress(self) -> tuple[int, float]:
+        n = len(self._cmd_times)
+        if n == 0:
+            return (0, 0.0)
+        idx = self.find_index_at_sim_time(self._sim_time)
+        t_end = self.get_cumulative_time(idx)
+        if idx + 1 >= n:
+            return (idx, 1.0)
+        span = self.get_cumulative_time(idx + 1) - t_end
+        if span <= 0.0:
+            return (idx + 1, 0.0)
+        frac = (self._sim_time - t_end) / span
+        return (idx + 1, max(0.0, min(1.0, frac)))
 
     def render_state(self):
         return None
+
+
+class FakeOpMap:
+    """Minimal MachineCodeOpMap stand-in: op -> (start_line, lines)."""
+
+    def __init__(self, spans):
+        self._spans = list(spans)
+        self._line_to_op = {}
+        for op, (start, count) in enumerate(self._spans):
+            for ln in range(start, start + count):
+                self._line_to_op[ln] = op
+
+    @property
+    def op_count(self) -> int:
+        return len(self._spans)
+
+    @property
+    def line_count(self) -> int:
+        return max((start + count for start, count in self._spans), default=0)
+
+    def span_for_op(self, op_index):
+        return self._spans[op_index]
+
+    def op_for_line(self, line_idx: int) -> int | None:
+        return self._line_to_op.get(line_idx)
 
 
 class FakeCanvas:
@@ -188,8 +276,10 @@ def test_seek_to_fraction_seeks_and_syncs_slider(ui_context_initializer):
     overlay.set_player(player)
     canvas.render_queued = 0
     overlay.seek_to_fraction(0.5)
-    assert player.current_index == 5
-    assert canvas.render_queued == 1
+    # Half the total simulated time (5 s of 10 s) lands on command 4.
+    assert player.current_index == 4
+    assert int(overlay._slider.get_value()) == 4
+    assert canvas.render_queued >= 1
 
 
 @pytest.mark.ui
@@ -213,6 +303,7 @@ def test_start_playback_resyncs_sim_time_from_playhead(ui_context_initializer):
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=1.0)
     overlay.set_player(player)
+    # Drag the slider to command 3 (4 s cumulative) while paused.
     overlay._slider.set_value(3)
     overlay._start_playback()
     assert overlay._sim_time == pytest.approx(4.0)
@@ -225,10 +316,11 @@ def test_start_playback_wraps_from_end(ui_context_initializer):
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=1.0)
     overlay.set_player(player)
-    overlay._slider.set_value(9)
+    # Run to the very end, then press play again: it restarts from 0.
+    overlay.seek_to_fraction(1.0)
     overlay._start_playback()
     assert int(overlay._slider.get_value()) == 0
-    assert overlay._sim_time == pytest.approx(1.0)
+    assert overlay._sim_time == pytest.approx(0.0)
     assert overlay._playing
 
 
@@ -284,6 +376,7 @@ def test_step_forward_animates_to_next_command(ui_context_initializer):
     overlay = PlaybackOverlay()
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=1.0)
+    player.seek(0)
     overlay.set_player(player)
     overlay._on_step_fwd(None)
     # Stepping is animated, not instant: the slider keeps showing the
@@ -307,6 +400,7 @@ def test_step_back_animates_to_previous_command(ui_context_initializer):
     player = FakePlayer(n_ops=10, cmd_time=1.0)
     overlay.set_player(player)
     overlay._slider.set_value(5)
+    assert player.current_index == 5
     overlay._on_step_back(None)
     assert overlay._step_animating
     while overlay._step_animating:
@@ -322,6 +416,7 @@ def test_step_animation_interpolates_sim_time(ui_context_initializer):
     canvas = FakeCanvas()
     overlay.set_canvas(canvas)
     player = FakePlayer(n_ops=10, cmd_time=10.0)
+    player.seek(0)
     overlay.set_player(player)
     overlay._on_step_fwd(None)
     # Halfway through the animation of a 10 s command the playhead is
@@ -354,6 +449,7 @@ def test_play_during_step_animation_keeps_interpolated_time(
     overlay = PlaybackOverlay()
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=10.0)
+    player.seek(0)
     overlay.set_player(player)
     overlay._on_step_fwd(None)
     for _ in range(int(STEP_ANIMATION_SECONDS / TICK_SECONDS / 2)):
@@ -383,6 +479,7 @@ def test_rapid_step_forward_clicks_coalesce(ui_context_initializer):
     overlay = PlaybackOverlay()
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=1.0)
+    player.seek(0)
     overlay.set_player(player)
     for _ in range(5):
         overlay._on_step_fwd(None)
@@ -454,6 +551,7 @@ def test_clicks_during_glide_merge_into_it(ui_context_initializer):
     overlay = PlaybackOverlay()
     overlay.set_canvas(FakeCanvas())
     player = FakePlayer(n_ops=10, cmd_time=1.0)
+    player.seek(0)
     overlay.set_player(player)
     overlay._on_step_fwd(None)
     # Two more clicks while the first glide is running merge into it.
@@ -559,14 +657,15 @@ def test_scrub_while_playing_resyncs_sim_time(ui_context_initializer):
         overlay._on_tick()
     before = overlay._sim_time
     assert before > 1.0
-    # User drags the slider to command 20 while playback is active.
-    overlay._slider.set_value(20)
-    assert overlay._sim_time == pytest.approx(21.0)
+    # User drags the slider to command 24 (25 s cumulative) while
+    # playback is active.
+    overlay._slider.set_value(24)
+    assert overlay._sim_time == pytest.approx(25.0)
     assert overlay._playing
     # The next tick continues from the dragged position, not the old one.
     overlay._on_tick()
-    assert overlay._sim_time > 21.0
-    assert overlay._sim_time < 21.0 + 2 * TICK_SECONDS
+    assert overlay._sim_time > 25.0
+    assert overlay._sim_time < 25.0 + 2 * TICK_SECONDS
 
 
 @pytest.mark.ui
@@ -578,10 +677,220 @@ def test_scrub_while_playing_does_not_fight_tick(ui_context_initializer):
     overlay._start_playback()
     for _ in range(60):
         overlay._on_tick()
-    overlay._slider.set_value(20)
+    overlay._slider.set_value(24)
     # Repeated ticks must keep advancing from the scrubbed position,
     # never snapping the slider back below it.
     slider_before = int(overlay._slider.get_value())
     for _ in range(10):
         overlay._on_tick()
     assert int(overlay._slider.get_value()) >= slider_before
+
+
+@pytest.mark.ui
+def test_tick_driven_slider_moves_do_not_seek(ui_context_initializer):
+    """Regression test for issue #370.
+
+    Tick-driven slider moves are driven by the simulated clock; a seek
+    per command boundary replays commands on the main thread and stalls
+    playback on large jobs.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    player = FakePlayer(n_ops=100, cmd_time=TICK_SECONDS)
+    overlay.set_player(player)
+    overlay._start_playback()
+    player.seek_count = 0
+    # Enough ticks to cross many command boundaries.
+    for _ in range(int(1.0 / TICK_SECONDS) + 10):
+        assert overlay._on_tick()
+    assert overlay._slider.get_value() > 0
+    assert player.seek_count == 0
+
+
+@pytest.mark.ui
+def test_scrub_while_playing_resyncs_clock_to_boundary(ui_context_initializer):
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    player = FakePlayer(n_ops=100, cmd_time=1.0)
+    overlay.set_player(player)
+    overlay._start_playback()
+    player.seek_count = 0
+    # Dragging the slider while playing resyncs the clock to the
+    # dragged command's completion time (command 24 -> 25 s).
+    overlay._slider.set_value(24)
+    assert player.current_index == 24
+
+
+@pytest.mark.ui
+def test_stepping_visits_every_command_exactly(ui_context_initializer):
+    """Regression test for issue #370.
+
+    Zero-duration commands share cumulative times; stepping must land
+    on every command exactly once instead of skipping clusters or
+    getting stuck.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    durations = [0.0] * 4 + [60.0] + [0.0] * 5
+    player = FakePlayer(n_ops=len(durations), cmd_times=durations)
+    overlay.set_player(player)
+    visited = []
+    for _ in range(len(durations)):
+        overlay._on_step_fwd(None)
+        while overlay._step_animating:
+            overlay._on_step_tick()
+        visited.append(player.current_index)
+    assert visited == list(range(len(durations)))
+    for _ in range(len(durations)):
+        overlay._on_step_back(None)
+        while overlay._step_animating:
+            overlay._on_step_tick()
+    assert player.current_index == 0
+
+
+@pytest.mark.ui
+def test_stepping_skips_commands_without_gcode(ui_context_initializer):
+    """Regression test for issue #370.
+
+    Marker and state commands produce no G-code lines; stepping must
+    skip them so every step selects a visible G-code line.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    player = FakePlayer(n_ops=8, cmd_time=0.5)
+    overlay.set_player(player)
+    # Ops 1 and 3-5 produced no G-code output.
+    overlay.set_op_map(
+        FakeOpMap(
+            [(0, 1), (1, 0), (2, 1), (3, 0), (4, 0), (5, 0), (6, 1), (7, 1)]
+        )
+    )
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 0
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    # Op 1 produced no G-code and is skipped.
+    assert player.current_index == 2
+    overlay._on_step_back(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 0
+
+
+@pytest.mark.ui
+def test_stepping_without_op_map_visits_every_command(
+    ui_context_initializer,
+):
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    player = FakePlayer(n_ops=6, cmd_time=1.0)
+    player.seek(0)
+    overlay.set_player(player)
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 1
+
+
+@pytest.mark.ui
+def test_slider_spans_gcode_lines_when_mapped(ui_context_initializer):
+    """Regression test for issue #370.
+
+    With an op map the slider spans G-code line numbers, so stepping
+    onto an early command must not push the slider past 50% just
+    because the preamble contains many invisible marker commands.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    # Ops 0-6 are zero-output preamble; op 7 owns "T0", op 8 "G0",
+    # op 9 owns two lines.
+    spans = [(0, 3)] + [(3, 0)] * 6 + [(3, 1), (4, 1), (5, 2)]
+    player = FakePlayer(n_ops=len(spans), cmd_time=0.5)
+    overlay.set_player(player)
+    overlay.set_op_map(FakeOpMap(spans))
+    # Slider extent is the last g-code line index (6), not the op count.
+    assert overlay._slider.get_adjustment().get_upper() == 6
+    # Pristine playhead: nothing executed yet, slider starts at zero.
+    assert int(overlay._slider.get_value()) == 0
+    # One step reaches op 0 ("G21"/"G90"/"G54" span); the second step
+    # skips all six marker commands and lands on "T0" (op 7) - yet the
+    # slider only moves from line 2 to line 3 instead of jumping ahead.
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 0
+    # Slider matches the viewer selection: op 0's action line.
+    assert int(overlay._slider.get_value()) == 2
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 7
+    assert int(overlay._slider.get_value()) == 3
+
+
+@pytest.mark.ui
+def test_scrubbing_slider_maps_back_to_op(ui_context_initializer):
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    spans = [(0, 3)] + [(3, 0)] * 2 + [(3, 1), (4, 1)]
+    player = FakePlayer(n_ops=len(spans), cmd_time=1.0)
+    overlay.set_player(player)
+    overlay.set_op_map(FakeOpMap(spans))
+    # Dragging the slider to line 4 ("G0") lands on op 4.
+    overlay._slider.set_value(4)
+    assert player.current_index == 4
+
+
+@pytest.mark.ui
+def test_stepping_reaches_slider_end(ui_context_initializer):
+    """Regression test for issue #370.
+
+    Stepping onto the last command must push the slider all the way
+    to its end, matching the G-code viewer's last-line selection.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    spans = [(0, 1), (1, 0), (1, 2)]
+    player = FakePlayer(n_ops=len(spans), cmd_time=1.0)
+    overlay.set_player(player)
+    overlay.set_op_map(FakeOpMap(spans))
+    assert int(overlay._slider.get_value()) == 0
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    assert player.current_index == 0
+    overlay._on_step_fwd(None)
+    while overlay._step_animating:
+        overlay._on_step_tick()
+    # Op 2 owns lines 1-2 including the last one; both the viewer
+    # selection and the slider sit at the final line.
+    assert player.current_index == 2
+    assert int(overlay._slider.get_value()) == 2
+    assert int(overlay._slider.get_value()) == overlay._slider_extent()
+
+
+@pytest.mark.ui
+def test_playback_completion_anchors_last_command(ui_context_initializer):
+    """Regression test for issue #370 (laser stays on at job end).
+
+    Trailing zero-duration commands (the M5 power-offs) were never
+    applied when playback completed, because the state sync anchors
+    at the command BEFORE the playhead. Completion must anchor the
+    playhead on the final command, exactly like manual stepping.
+    """
+    overlay = PlaybackOverlay()
+    overlay.set_canvas(FakeCanvas())
+    durations = [2.0, 1.0, 0.0, 0.5, 0.0, 0.0]
+    player = FakePlayer(n_ops=len(durations), cmd_times=durations)
+    overlay.set_player(player)
+    overlay._start_playback()
+    for _ in range(int(4.0 / TICK_SECONDS) + 10):
+        if not overlay._playing:
+            break
+        overlay._on_tick()
+    assert not overlay._playing
+    # The final command (a no-output M5 stand-in) is applied.
+    assert player.current_index == len(durations) - 1


### PR DESCRIPTION
Fixes #370

## Problem

Pressing play in the 3D preview jumped the slider ~1/3 of the way, froze for tens of seconds with no visual change, then burst into motion. Stepping and scrubbing were similarly desynced from the G-code viewer, and rotary playback stalled or swung the laser far off the cylinder during arcs.

## Root causes

- **Main-thread stalls:** every tick-driven slider move fired `_on_slider_changed`, which called `OpPlayer.seek()`. Until the background snapshot build finished, seeks fell back to an O(n) replay from home state — blocking the UI. The delay scaled inversely with playback speed (fewer ticks needed to cover the same simulated time), matching the reports.
- **Slider semantics:** the slider tracked raw command indices while zero-duration commands (markers, `M4`/`M5` state changes) make up a large share of any op stream, so it raced through them and parked on long commands; later, time-fraction positioning raced through rapids instead. Neither matches what the eye tracks.
- **Encoder line attribution:** deferred state lines (`M4 S800`) are bundled into the first cutting op's span, so highlighting the span start made the viewer lag one line behind the actual command.
- **Rotary arc interpolation:** mapping collapses endpoint Y onto the cylinder position, detaching the stored circle (I/J) from its mapped endpoints. Angle interpolation in that broken frame produced near-zero sweeps (rotary stalls) or full-circle X swings far off the cylinder.
- **Laser at job end:** completion anchored the state at the second-to-last command, leaving trailing `M5`s unapplied.

## Changes

- `OpPlayer.set_playhead()` / `set_progress_anchor()` anchor the playhead by command index, exact across zero-duration clusters; forward playback advances machine state incrementally via new `sync_state_to_playhead()` (amortized O(1) per tick).
- The overlay never seeks on tick-driven updates; user scrubs and G-code viewer clicks remain seek-based.
- With an op map present, the slider spans G-code line numbers, the viewer highlights each op's *action* line, and stepping skips output-less commands — so slider position ≡ selected viewer line ≡ revealed geometry after every step.
- Playback completion anchors the final command, applying trailing `M5`s (laser off, home position).
- `_interpolate_rotary_arc()` reconstructs each rotary arc in (X, surface) space from the rotary axis travel and the stored radius, solved exactly through both endpoints; flat-bed arcs and AXIS_REPLACEMENT oscillation behavior are unchanged.
- Typing: new `OpMapLike` protocol; no more `Any` in the overlay surface.

The op map is the encoder-produced `MachineCodeOpMap` held by reference only (~4 bytes/line + 8 bytes/op already allocated per job); stepping lookups are O(1) typical / linear in queued clicks worst case, never on the playback hot path.

## Testing

- New regression tests: tick-driven slider moves never seek; exact ±1 stepping across zero-duration clusters; slider/viewer line sync incl. pristine start and end-of-job; viewer action-line highlight; playback completion anchors the final command; rotary detached-frame arcs stay on-path, rotate monotonically through every arc without stalling; healthy flat arcs still interpolate along the circle.
- Full sim3d UI suite (207), simulator/encoder suites (158), lint and pyright clean.