### PR TITLE
Add parametric circular array tool to the sketcher

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/__init__.py
@@ -7,12 +7,14 @@ from .circle import CircleCommand, CirclePreviewState
 from .constraint import ModifyConstraintCommand
 from .constraint_create import CreateOrEditConstraintCommand
 from .construction import ToggleConstructionCommand
+from .create_pattern import CreatePatternCommand
 from .dimension import DimensionData
 from .distance_constraint import (
     DistanceConstraintCommand,
     DistanceConstraintParams,
 )
 from .duplicate import DuplicateCommand
+from .edit_pattern import EditPatternCommand
 from .ellipse import EllipseCommand, EllipsePreviewState
 from .equal_constraint import (
     EqualConstraintCommand,
@@ -21,7 +23,7 @@ from .equal_constraint import (
 from .fill import AddFillCommand, RemoveFillCommand, SetTextFillCommand
 from .fillet import FilletCommand
 from .grid import GridCommand
-from .items import AddItemsCommand
+from .items import AddItemsCommand, RemoveItemsCommand
 from .line import LineCommand, LinePreviewState
 from .live_text_edit import LiveTextEditCommand
 from .mirror import MirrorAxis, MirrorCommand, MirrorDirection
@@ -59,10 +61,12 @@ __all__ = [
     "CircleCommand",
     "CirclePreviewState",
     "CreateOrEditConstraintCommand",
+    "CreatePatternCommand",
     "DimensionData",
     "DistanceConstraintCommand",
     "DistanceConstraintParams",
     "DuplicateCommand",
+    "EditPatternCommand",
     "EllipseCommand",
     "EllipsePreviewState",
     "EqualConstraintCommand",
@@ -84,6 +88,7 @@ __all__ = [
     "RectangleCommand",
     "RectanglePreviewState",
     "RemoveFillCommand",
+    "RemoveItemsCommand",
     "RoundedRectCommand",
     "RoundedRectPreviewState",
     "SetTextFillCommand",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/create_pattern.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/create_pattern.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import copy
+import logging
+import math
+import uuid
+from dataclasses import replace
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any
+
+from ..constraints import PointOnLineConstraint
+from ..entities import Bezier, Circle
+from ..entities import Point as SketchPoint
+from ..patterns import (
+    CircularPatternParams,
+    PatternDefinition,
+    PatternStrategy,
+    SketchArrayMode,
+    make_pattern_strategy,
+)
+from .base import SketchChangeCommand
+from .items import AddItemsCommand
+
+if TYPE_CHECKING:
+    from ..constraints import Constraint
+    from ..entities import Entity, Point
+    from ..registry import EntityRegistry
+    from ..sketch import Sketch
+
+logger = logging.getLogger(__name__)
+
+
+class CreatePatternCommand(SketchChangeCommand):
+    """
+    Generic command that duplicates seed entities into a pattern
+    (e.g. circular array) using a PatternStrategy.
+
+    Copies are parametrically linked to the template member; the
+    strategy's master geometry (e.g. a construction guide circle)
+    carries the pattern definition, which is registered on the sketch
+    so it can be edited later.
+    """
+
+    def __init__(
+        self,
+        sketch: Sketch,
+        mode: SketchArrayMode,
+        params: CircularPatternParams,
+        seed_entity_ids: list[int],
+        name: str | None = None,
+    ):
+        super().__init__(
+            sketch, name if name is not None else _("Create Pattern")
+        )
+        self.mode = mode
+        self.params = params
+        self.seed_entity_ids = list(seed_entity_ids)
+        self.add_cmd: AddItemsCommand | None = None
+        self.pattern: PatternDefinition | None = None
+        self.created_entity_ids: list[int] = []
+        self.created_member_groups: list[list[int]] = []
+        self.guide_circle_id: int | None = None
+
+    @staticmethod
+    def collect_seed_point_ids(
+        registry: EntityRegistry, seed_entity_ids: list[int]
+    ) -> list[int]:
+        """Returns all unique point IDs referenced by the seed entities."""
+        pids: list[int] = []
+        for eid in seed_entity_ids:
+            entity = registry.get_entity(eid)
+            if entity is None:
+                continue
+            for pid in entity.get_point_ids():
+                if pid not in pids:
+                    pids.append(pid)
+        return pids
+
+    @staticmethod
+    def calculate_geometry(
+        registry: EntityRegistry,
+        strategy: PatternStrategy,
+        seed_entity_ids: list[int],
+        params: Any,
+        center_pid: int | None = None,
+        create_master: bool = True,
+    ) -> dict[str, Any] | None:
+        """
+        Computes points, entities and constraints for the pattern.
+
+        Args:
+            registry: The entity registry to read template points from.
+            strategy: The pattern strategy driving placements/linkage.
+            seed_entity_ids: Entities of the template member.
+            params: Mode-specific parameters.
+            center_pid: Reuse an existing pattern center point instead of
+                creating one (used when regenerating an array).
+            create_master: Whether to also build master geometry.
+
+        Returns a dict with 'points', 'entities', 'constraints',
+        'instance_maps', 'instance_point_groups',
+        'instance_entity_groups', 'center_pid', 'radius_pt_pid' and
+        'guide_circle' keys, or None if the pattern cannot be built.
+        """
+        seed_pids = CreatePatternCommand.collect_seed_point_ids(
+            registry, seed_entity_ids
+        )
+        if not seed_pids or len(seed_entity_ids) < 1:
+            return None
+
+        seed_points = [registry.get_point(pid) for pid in seed_pids]
+        seed_center = _points_bbox_center(seed_points)
+
+        temp_id = -1
+
+        def next_temp_id() -> int:
+            nonlocal temp_id
+            temp_id -= 1
+            return temp_id
+
+        points: list[Point] = []
+        center_is_new = center_pid is None
+        if center_is_new and strategy.needs_center_point:
+            center_pid = next_temp_id()
+            points.append(
+                SketchPoint(center_pid, params.center[0], params.center[1])
+            )
+
+        entities: list[Entity] = []
+        instance_maps: list[dict[int, int]] = []
+        instance_point_groups: list[list[Point]] = []
+        instance_entity_groups: list[list[Entity]] = []
+
+        for placement in strategy.calculate_placements(seed_center):
+            pid_map: dict[int, int] = {}
+            instance_points: list[Point] = []
+            for seed_pt in seed_points:
+                new_pid = next_temp_id()
+                nx, ny = placement.transform_point(seed_pt.x, seed_pt.y)
+                instance_points.append(SketchPoint(new_pid, nx, ny))
+                pid_map[seed_pt.id] = new_pid
+
+            instance_entities: list[Entity] = []
+            for eid in seed_entity_ids:
+                seed_entity = registry.get_entity(eid)
+                if seed_entity is None:
+                    continue
+                clone = copy.deepcopy(seed_entity)
+                clone.id = next_temp_id()
+                clone.pattern_copy = True
+                _remap_entity(clone, pid_map)
+                if isinstance(clone, Bezier):
+                    _transform_bezier_offsets(clone, placement)
+                instance_entities.append(clone)
+
+            points.extend(instance_points)
+            entities.extend(instance_entities)
+            instance_maps.append(pid_map)
+            instance_point_groups.append(instance_points)
+            instance_entity_groups.append(instance_entities)
+
+        constraints: list[Constraint] = strategy.build_linkage_constraints(
+            [(j + 1, pid_map) for j, pid_map in enumerate(instance_maps)],
+            center_pid,
+        )
+
+        radius_pt_pid: int | None = None
+        guide_circle: Circle | None = None
+        ref_pid: int | None = None
+        effective_radius = params.radius
+
+        if (
+            create_master
+            and strategy.needs_center_point
+            and center_pid is not None
+        ):
+            # Derive the guide circle radius from the anchor point so the
+            # pin constraint starts exactly satisfied. An inconsistent
+            # start would make the solver fling the geometry around.
+            if params.rotate_copies and seed_points:
+                ref_pid = _choose_reference_point(seed_points)
+                logger.debug("Pattern: anchor point pid=%s", ref_pid)
+                ref_pt = next(p for p in seed_points if p.id == ref_pid)
+                if center_is_new:
+                    cx, cy = params.center
+                else:
+                    center_pt = registry.get_point(center_pid)
+                    cx, cy = center_pt.x, center_pt.y
+                d = math.hypot(ref_pt.x - cx, ref_pt.y - cy)
+                if d > 1e-6:
+                    # Only anchor when consistent: a reference point
+                    # sitting on the center cannot be pinned onto the
+                    # circle without flinging the geometry.
+                    effective_radius = d
+                else:
+                    ref_pid = None
+            if effective_radius > 0.0:
+                radius_pt_pid = next_temp_id()
+
+        if create_master:
+            master_strategy = strategy
+            if effective_radius != params.radius:
+                master_params = replace(params, radius=effective_radius)
+                master_strategy = type(strategy)(master_params)
+            master_points, master_entities, master_constraints = (
+                master_strategy.create_master_geometry(
+                    center_pid, radius_pt_pid
+                )
+            )
+            points.extend(master_points)
+            entities.extend(master_entities)
+            constraints.extend(master_constraints)
+            guide_circle = next(
+                (e for e in master_entities if isinstance(e, Circle)),
+                None,
+            )
+
+        # Anchor the template member onto the guide circle so the array
+        # and its circle form one rigid parametric unit: the circle
+        # always crosses every member, the radius dimension resizes the
+        # array, and the radius point handle scales it interactively.
+        if guide_circle is not None and ref_pid is not None:
+            constraints.append(PointOnLineConstraint(ref_pid, guide_circle.id))
+
+        return {
+            "points": points,
+            "entities": entities,
+            "constraints": constraints,
+            "instance_maps": instance_maps,
+            "instance_point_groups": instance_point_groups,
+            "instance_entity_groups": instance_entity_groups,
+            "center_pid": center_pid,
+            "radius_pt_pid": radius_pt_pid,
+            "guide_circle": guide_circle,
+        }
+
+    def _do_execute(self) -> None:
+        if self.add_cmd:
+            return self._redo()
+
+        result = self.calculate_geometry(
+            self.sketch.registry,
+            make_pattern_strategy(self.mode, self.params),
+            self.seed_entity_ids,
+            self.params,
+        )
+        if not result:
+            return
+
+        self.add_cmd = AddItemsCommand(
+            self.sketch,
+            "",
+            points=result["points"],
+            entities=result["entities"],
+            constraints=result["constraints"],
+        )
+        self.add_cmd._do_execute()
+
+        # AddItemsCommand assigns final IDs to the created objects in
+        # place; resolve the instance groups into real IDs afterwards.
+        self.created_member_groups = [
+            [e.id for e in group] for group in result["instance_entity_groups"]
+        ]
+        self.created_entity_ids = [
+            eid for group in self.created_member_groups for eid in group
+        ]
+
+        guide_circle = result["guide_circle"]
+        self.guide_circle_id = (
+            guide_circle.id if guide_circle is not None else None
+        )
+        logger.info(
+            "PatternCreate: mode=%s params=%r members=%d groups=%r "
+            "guide_circle=e%s",
+            self.mode.value,
+            self.params,
+            len(self.created_entity_ids),
+            [len(g) for g in self.created_member_groups],
+            self.guide_circle_id,
+        )
+        self._register_pattern()
+
+    def _register_pattern(self) -> None:
+        if self.guide_circle_id is None:
+            return
+        if self.pattern is None:
+            count = max(int(self.params.count), 1)
+            members = [(0, list(self.seed_entity_ids))] + [
+                (slot, list(group))
+                for slot, group in zip(
+                    range(1, count), self.created_member_groups
+                )
+            ]
+            self.pattern = PatternDefinition(
+                uid=str(uuid.uuid4()),
+                mode=self.mode,
+                guide_circle_id=self.guide_circle_id,
+                members=members,
+                count=count,
+                total_angle_deg=self.params.total_angle_deg,
+                rotate_copies=self.params.rotate_copies,
+            )
+        existing = next(
+            (p for p in self.sketch.patterns if p.uid == self.pattern.uid),
+            None,
+        )
+        if existing is None:
+            self.sketch.patterns.append(self.pattern)
+
+    def _redo(self) -> None:
+        assert self.add_cmd is not None
+        self.add_cmd._do_execute()
+        self._register_pattern()
+
+    def _do_undo(self) -> None:
+        if self.add_cmd:
+            self.add_cmd._do_undo()
+        if self.pattern is not None:
+            self.sketch.patterns = [
+                p for p in self.sketch.patterns if p.uid != self.pattern.uid
+            ]
+
+
+def _points_bbox_center(points: list[Point]) -> tuple[float, float]:
+    xs = [p.x for p in points]
+    ys = [p.y for p in points]
+    return ((min(xs) + max(xs)) / 2.0, (min(ys) + max(ys)) / 2.0)
+
+
+def _choose_reference_point(seed_points: list[Point]) -> int:
+    """
+    Picks the anchor point that represents a member on the guide
+    circle: the unfixed point closest to the member's bbox center.
+    """
+    pool = [p for p in seed_points if not p.fixed] or seed_points
+    cx, cy = _points_bbox_center(seed_points)
+    return min(pool, key=lambda p: math.hypot(p.x - cx, p.y - cy)).id
+
+
+def _remap_entity(entity: Entity, pid_map: dict[int, int]) -> None:
+    """Rewrites point ID references on a cloned entity."""
+    for attr, value in vars(entity).items():
+        # Note: bool is an int subclass; never remap flag attributes.
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and value in pid_map
+        ):
+            setattr(entity, attr, pid_map[value])
+
+
+def _transform_bezier_offsets(clone: Bezier, placement: Any) -> None:
+    """
+    Rotates bezier control point offsets so curve orientation follows
+    rotation placements. Offsets are relative to their anchor endpoints,
+    which are already transformed.
+    """
+    if clone.cp1 is not None:
+        clone.cp1 = placement.transform_offset(*clone.cp1)
+    if clone.cp2 is not None:
+        clone.cp2 = placement.transform_offset(*clone.cp2)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/edit_pattern.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/edit_pattern.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import logging
+import math
+from gettext import gettext as _
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from ..constraints import RadiusConstraint
+from ..entities import Circle
+from ..params import ParameterContext
+from ..patterns import (
+    CircularPatternParams,
+    PatternDefinition,
+    make_pattern_strategy,
+)
+from .base import SketchChangeCommand
+from .create_pattern import CreatePatternCommand
+from .items import AddItemsCommand, RemoveItemsCommand
+
+if TYPE_CHECKING:
+    from ..constraints import Constraint
+    from ..entities import Entity, Point
+    from ..registry import EntityRegistry
+    from ..sketch import Sketch
+
+logger = logging.getLogger(__name__)
+
+
+class EditPatternCommand(SketchChangeCommand):
+    """
+    Regenerates a pattern's instances from its definition.
+
+    Members are groups of entities. The first surviving member (lowest
+    slot) acts as the template. When the pattern parameters (count,
+    angle, rotate mode) did not change, only missing slots are
+    re-created. When they changed, every other member is removed and
+    fresh copies are distributed at the new placements. In both cases
+    the existing geometry is first moved into the edited frame via a
+    similarity transform so the solver starts fully consistent.
+    """
+
+    def __init__(
+        self,
+        sketch: Sketch,
+        pattern: PatternDefinition,
+        params: CircularPatternParams,
+    ):
+        super().__init__(sketch, _("Edit Pattern"))
+        self.pattern = pattern
+        self.params = params
+        self.add_cmd: AddItemsCommand | None = None
+        self.remove_cmd: RemoveItemsCommand | None = None
+        self.created_entity_ids: list[int] = []
+        self.created_groups: list[tuple[int, list[int]]] = []
+        self._template_group: list[int] = []
+        self._full_regen: bool = False
+        self._old_frame: tuple[tuple[float, float], float] | None = None
+        self._old_pattern_state: dict[str, Any] | None = None
+        self._radius_constraint: RadiusConstraint | None = None
+        self._old_radius_value: float | None = None
+
+    @staticmethod
+    def _params_changed(
+        state: dict[str, Any], params: CircularPatternParams
+    ) -> bool:
+        return (
+            params.count != state["count"]
+            or params.total_angle_deg != state["total_angle_deg"]
+            or params.rotate_copies != state["rotate_copies"]
+        )
+
+    def _do_execute(self) -> None:
+        if self.add_cmd is not None or self.remove_cmd is not None:
+            logger.info("PatternEdit[%s]: redo", self.pattern.uid[:8])
+            self._redo()
+            return
+
+        registry = self.sketch.registry
+        living = self.pattern.living_members(registry)
+        if not living:
+            logger.warning(
+                "PatternEdit[%s]: skipped, no members survive",
+                self.pattern.uid[:8],
+            )
+            return
+
+        _template_slot, template_eids = living[0]
+        self._template_group = list(template_eids)
+        logger.info(
+            "PatternEdit[%s]: start params=%r slots=%r member_sizes=%r",
+            self.pattern.uid[:8],
+            self.params,
+            [slot for slot, _e in living],
+            [len(eids) for _s, eids in living],
+        )
+
+        self._old_pattern_state = {
+            "members": [
+                (slot, list(eids)) for slot, eids in self.pattern.members
+            ],
+            "count": self.pattern.count,
+            "total_angle_deg": self.pattern.total_angle_deg,
+            "rotate_copies": self.pattern.rotate_copies,
+        }
+        self._full_regen = self._params_changed(
+            self._old_pattern_state, self.params
+        ) or not any(slot == 0 for slot, _eids in living)
+        # Members of one pattern must be congruent shapes. If deletions
+        # left groups of differing sizes, only a full re-distribution
+        # can rebuild complete copies everywhere.
+        member_sizes = {len(eids) for _slot, eids in living}
+        if len(member_sizes) > 1:
+            self._full_regen = True
+        logger.info(
+            "PatternEdit[%s]: full_regen=%s template=e%s",
+            self.pattern.uid[:8],
+            self._full_regen,
+            template_eids,
+        )
+
+        # Move the whole existing pattern into the edited frame first
+        # (rigid translation + uniform scale about the pattern center).
+        # A similarity transform keeps every linkage/pin/dimension
+        # constraint exactly satisfied, so the solver starts from a
+        # consistent state instead of having to repair a teleported
+        # center point.
+        self._old_frame = self._capture_master_frame(registry)
+        if self._old_frame is not None:
+            (ocx, ocy), old_radius = self._old_frame
+            k = self.params.radius / old_radius if old_radius > 1e-9 else 1.0
+            logger.info(
+                "PatternEdit[%s]: similarity old_c=(%.3f,%.3f) "
+                "old_r=%.3f -> new_c=(%.3f,%.3f) new_r=%.3f k=%.4f",
+                self.pattern.uid[:8],
+                ocx,
+                ocy,
+                old_radius,
+                self.params.center[0],
+                self.params.center[1],
+                self.params.radius,
+                k,
+            )
+            self._apply_similarity(registry, self._old_frame)
+
+        occupied = {slot for slot, _eids in living}
+        count = max(int(self.params.count), 1)
+
+        if self._full_regen:
+            # Re-distribute: drop every member except the template.
+            stale = [eid for _slot, eids in living[1:] for eid in eids]
+            logger.info(
+                "PatternEdit[%s]: removing %d stale entities from %d members",
+                self.pattern.uid[:8],
+                len(stale),
+                len(living) - 1,
+            )
+            self._remove_entities(stale)
+            missing_slots = list(range(1, count))
+            kept_members = [(0, list(template_eids))]
+        else:
+            # Gap fill: keep all surviving members untouched.
+            self._remove_entities([])
+            missing_slots = [
+                slot for slot in range(1, count) if slot not in occupied
+            ]
+            kept_members = living
+            logger.info(
+                "PatternEdit[%s]: gap-fill missing slots %r",
+                self.pattern.uid[:8],
+                missing_slots,
+            )
+
+        self._create_members(missing_slots)
+        self._commit_members(kept_members)
+
+        logger.info(
+            "PatternEdit[%s]: done slots=%r sizes=%r",
+            self.pattern.uid[:8],
+            [slot for slot, _e in self.pattern.members],
+            [len(eids) for _s, eids in self.pattern.members],
+        )
+        _log_pattern_residuals(self.sketch)
+
+    def _commit_members(
+        self, kept_members: list[tuple[int, list[int]]]
+    ) -> None:
+        """Writes the post-edit member list and params onto the
+        definition."""
+        self.pattern.members = [
+            (slot, list(eids)) for slot, eids in kept_members
+        ] + [(slot, list(eids)) for slot, eids in self.created_groups]
+        self.pattern.count = self.params.count
+        self.pattern.total_angle_deg = self.params.total_angle_deg
+        self.pattern.rotate_copies = self.params.rotate_copies
+
+    def _remove_entities(self, stale_ids: list[int]) -> None:
+        """
+        Removes entities (with dependent points/constraints) without
+        triggering prune_patterns(), so the definition survives.
+        """
+        if not stale_ids:
+            return
+        sketch = self.sketch
+        points, entities, constraints = (
+            RemoveItemsCommand.calculate_dependencies(
+                sketch,
+                SimpleNamespace(
+                    entity_ids=set(stale_ids),
+                    point_ids=set(),
+                    constraint_idx=None,
+                ),
+            )
+        )
+        self.remove_cmd = RemoveItemsCommand(
+            sketch,
+            "",
+            points=points,
+            entities=entities,
+            constraints=constraints,
+        )
+        self._apply_removal(sketch, points, entities, constraints)
+
+    def _create_members(self, slots: list[int]) -> None:
+        """Creates linked copies of the template group at the slots."""
+        if not slots:
+            return
+        assert self._template_group
+        registry = self.sketch.registry
+        strategy = make_pattern_strategy(self.pattern.mode, self.params)
+
+        result = CreatePatternCommand.calculate_geometry(
+            registry,
+            strategy,
+            list(self._template_group),
+            self.params,
+            center_pid=self._pattern_center_pid(registry),
+            create_master=False,
+        )
+        if result is None:
+            return
+
+        add_points: list[Point] = []
+        add_entities: list[Entity] = []
+        add_constraints = []
+        pending_groups: list[tuple[int, list[Entity]]] = []
+
+        for slot in slots:
+            # Placements are generated in slot order starting at 1.
+            i = slot - 1
+            pid_map = result["instance_maps"][i]
+            add_points.extend(result["instance_point_groups"][i])
+            instance_entities = result["instance_entity_groups"][i]
+            add_entities.extend(instance_entities)
+            add_constraints.extend(
+                strategy.build_linkage_constraints(
+                    [(slot, pid_map)], result["center_pid"]
+                )
+            )
+            # Entity IDs are assigned by AddItemsCommand during execute;
+            # resolve them into real IDs afterwards.
+            pending_groups.append((slot, instance_entities))
+
+        self.add_cmd = AddItemsCommand(
+            self.sketch,
+            "",
+            points=add_points,
+            entities=add_entities,
+            constraints=add_constraints,
+        )
+        self.add_cmd._do_execute()
+        self.created_groups = [
+            (slot, [e.id for e in entities])
+            for slot, entities in pending_groups
+        ]
+        self.created_entity_ids = [e.id for e in add_entities]
+        logger.info(
+            "PatternEdit[%s]: created %d instances (%d entities)",
+            self.pattern.uid[:8],
+            len(self.created_groups),
+            len(add_entities),
+        )
+
+    def _pattern_center_pid(self, registry: EntityRegistry) -> int | None:
+        circle = registry.get_entity(self.pattern.guide_circle_id)
+        if isinstance(circle, Circle):
+            return circle.center_idx
+        return None
+
+    def _capture_master_frame(
+        self, registry: EntityRegistry
+    ) -> tuple[tuple[float, float], float] | None:
+        """Returns the guide circle's (center, radius) before editing."""
+        circle = registry.get_entity(self.pattern.guide_circle_id)
+        if not isinstance(circle, Circle):
+            return None
+        try:
+            center = registry.get_point(circle.center_idx)
+            radius_pt = registry.get_point(circle.radius_pt_idx)
+        except IndexError:
+            return None
+        return (
+            center.x,
+            center.y,
+        ), math.hypot(radius_pt.x - center.x, radius_pt.y - center.y)
+
+    def _apply_similarity(
+        self,
+        registry: EntityRegistry,
+        old_frame: tuple[tuple[float, float], float],
+    ) -> None:
+        """
+        Maps the whole existing pattern into the edited frame via a
+        similarity transform: translation to the new center plus a
+        uniform scale of new_radius / old_radius. A similarity keeps
+        every rotational, pin and radius constraint exactly satisfied,
+        so no solver repair is needed.
+        """
+        (ocx, ocy), old_radius = old_frame
+        ncx, ncy = self.params.center
+        k = self.params.radius / old_radius if old_radius > 1e-9 else 1.0
+
+        pids: set[int] = set()
+        for eid in self.pattern.living_entity_ids(registry):
+            entity = registry.get_entity(eid)
+            if entity is not None:
+                pids.update(entity.get_point_ids())
+        circle = registry.get_entity(self.pattern.guide_circle_id)
+        if isinstance(circle, Circle):
+            pids.update(circle.get_point_ids())
+
+        for pid in pids:
+            p = registry.get_point(pid)
+            p.x = ncx + k * (p.x - ocx)
+            p.y = ncy + k * (p.y - ocy)
+
+        # Pin the master circle geometry exactly onto the target frame.
+        if isinstance(circle, Circle):
+            radius_pt = registry.get_point(circle.radius_pt_idx)
+            radius_pt.x = ncx + self.params.radius
+            radius_pt.y = ncy
+
+        for constr in self.sketch.constraints:
+            if (
+                isinstance(constr, RadiusConstraint)
+                and constr.entity_id == self.pattern.guide_circle_id
+            ):
+                self._radius_constraint = constr
+                if self._old_radius_value is None:
+                    self._old_radius_value = constr.value
+                constr.value = self.params.radius
+                break
+
+    def _redo(self) -> None:
+        if self.remove_cmd is not None:
+            self._reexecute_remove()
+        if self.add_cmd is not None:
+            self.add_cmd._do_execute()
+        if self._old_pattern_state is None:
+            return
+        registry = self.sketch.registry
+        if self._old_frame is not None:
+            # Re-apply the similarity relative to the pre-edit frame.
+            self._apply_similarity(registry, self._old_frame)
+
+        assert self._template_group
+        if self._full_regen:
+            kept_members = [(0, list(self._template_group))]
+        else:
+            kept_members = self.pattern.living_members(registry)
+        self._commit_members(kept_members)
+
+    def _reexecute_remove(self) -> None:
+        """Re-runs a removal without triggering prune_patterns()."""
+        remove_cmd = self.remove_cmd
+        assert remove_cmd is not None
+        self._apply_removal(
+            self.sketch,
+            remove_cmd.points,
+            remove_cmd.entities,
+            remove_cmd.constraints,
+        )
+
+    @staticmethod
+    def _apply_removal(
+        sketch: Sketch,
+        points: list[Point],
+        entities: list[Entity],
+        constraints: list[Constraint],
+    ) -> None:
+        """
+        Removes points, entities and constraints from the sketch
+        directly, bypassing RemoveItemsCommand's execute so
+        prune_patterns() never sees the pattern mid-edit.
+        """
+        registry = sketch.registry
+        point_ids = {p.id for p in points}
+        entity_ids = {e.id for e in entities}
+        registry.points = [p for p in registry.points if p.id not in point_ids]
+        registry.entities = [
+            e for e in registry.entities if e.id not in entity_ids
+        ]
+        registry._entity_map = {e.id: e for e in registry.entities}
+        for c in constraints:
+            if c in sketch.constraints:
+                sketch.constraints.remove(c)
+
+    def _do_undo(self) -> None:
+        if self.add_cmd is not None:
+            self.add_cmd._do_undo()
+        if self.remove_cmd is not None:
+            self.remove_cmd._do_undo()
+        if self._old_pattern_state is None:
+            return
+        state = self._old_pattern_state
+        self.pattern.members = [
+            (slot, list(eids)) for slot, eids in state["members"]
+        ]
+        self.pattern.count = state["count"]
+        self.pattern.total_angle_deg = state["total_angle_deg"]
+        self.pattern.rotate_copies = state["rotate_copies"]
+        if (
+            self._radius_constraint is not None
+            and self._old_radius_value is not None
+        ):
+            self._radius_constraint.value = self._old_radius_value
+
+
+def _log_pattern_residuals(sketch: Sketch) -> None:
+    """
+    Logs the worst constraint residual per type so a broken edit state
+    is visible in the log immediately, before any solve runs.
+    """
+    ctx = ParameterContext()
+    worst: dict[str, float] = {}
+    for constr in sketch.constraints:
+        name = type(constr).__name__
+        err = constr.error(sketch.registry, ctx)
+        if not isinstance(err, (list, tuple)):
+            err = [err]
+        for value in err:
+            worst[name] = max(worst.get(name, 0.0), abs(value))
+    summary = ", ".join(
+        f"{name}={value:.3e}" for name, value in sorted(worst.items())
+    )
+    logger.info("Pattern residuals after edit: %s", summary or "none")

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/items.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/commands/items.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from ..constraints import EqualDistanceConstraint
 from ..entities import Arc, Ellipse, TextBoxEntity
 from .base import SketchChangeCommand
 
@@ -60,7 +61,12 @@ class AddItemsCommand(SketchChangeCommand):
         # Update point references within the entity
         for e in new_entities:
             for attr, value in vars(e).items():
-                if isinstance(value, int) and value in id_map:
+                # Note: bool is an int subclass; never remap flags.
+                if (
+                    isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value in id_map
+                ):
                     setattr(e, attr, id_map[value])
                 # Handle lists of IDs, like in TextBoxEntity
                 elif isinstance(value, list) and attr.endswith("_ids"):
@@ -71,7 +77,12 @@ class AddItemsCommand(SketchChangeCommand):
         # Update point and entity references within constraints
         for c in self.constraints:
             for attr, value in vars(c).items():
-                if isinstance(value, int) and value in id_map:
+                # Note: bool is an int subclass; never remap flags.
+                if (
+                    isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value in id_map
+                ):
                     setattr(c, attr, id_map[value])
                 elif isinstance(value, list):
                     # Handle lists of IDs, like in EqualLengthConstraint
@@ -198,8 +209,6 @@ class RemoveItemsCommand(SketchChangeCommand):
             if isinstance(e, Arc):
                 c, s, end = e.center_idx, e.start_idx, e.end_idx
                 for constr in sketch.constraints:
-                    from ..constraints import EqualDistanceConstraint
-
                     if isinstance(constr, EqualDistanceConstraint):
                         set1 = {constr.p1, constr.p2}
                         set2 = {constr.p3, constr.p4}
@@ -278,6 +287,7 @@ class RemoveItemsCommand(SketchChangeCommand):
         for c in self.constraints:
             if c in self.sketch.constraints:
                 self.sketch.constraints.remove(c)
+        self.sketch.prune_patterns()
 
     def _do_undo(self) -> None:
         registry = self.sketch.registry

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/__init__.py
@@ -17,6 +17,7 @@ from .parallelogram import ParallelogramConstraint
 from .perpendicular import PerpendicularConstraint
 from .point_on_line import PointOnLineConstraint
 from .radius import RadiusConstraint
+from .rotational import RotationalConstraint
 from .symmetry import SymmetryConstraint
 from .tangent import TangentConstraint
 from .vertical import VerticalConstraint
@@ -35,6 +36,7 @@ CONSTRAINT_TYPE_MAP: dict[str, type[Constraint]] = {
     "symmetry": SymmetryConstraint,
     "aspect_ratio": AspectRatioConstraint,
     "angle": AngleConstraint,
+    "rotational": RotationalConstraint,
 }
 
 
@@ -57,6 +59,7 @@ __all__ = [
     "PerpendicularConstraint",
     "PointOnLineConstraint",
     "RadiusConstraint",
+    "RotationalConstraint",
     "SymmetryConstraint",
     "TangentConstraint",
     "VerticalConstraint",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/rotational.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/constraints/rotational.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+from raygeo.geo.types import Point
+
+from ..types import EntityID
+from .base import Constraint
+
+if TYPE_CHECKING:
+    from ..params import ParameterContext
+    from ..registry import EntityRegistry
+
+
+class RotationalConstraint(Constraint):
+    """
+    Links a target point (p2) to a source point (p1) through a rotation
+    of `value` radians around a center point.
+
+    Used by pattern commands to keep array copies parametrically attached
+    to the template member: editing any instance propagates to the whole
+    pattern through the solver. Deleting a member deletes only its own
+    constraints, so the remaining instances are never redistributed.
+    """
+
+    def __init__(
+        self,
+        center: EntityID,
+        p1: EntityID,
+        p2: EntityID,
+        value: str | float,
+        expression: str | None = None,
+        user_visible: bool = False,
+    ):
+        super().__init__(user_visible=user_visible)
+        self.center: EntityID = center
+        self.p1: EntityID = p1
+        self.p2: EntityID = p2
+
+        if expression is not None:
+            self.expression = expression
+            self.value = float(value)
+        elif isinstance(value, str):
+            self.expression = value
+            self.value = 0.0
+        else:
+            self.expression = None
+            self.value = float(value)
+
+    @classmethod
+    def get_type_key(cls) -> str:
+        return "rotational"
+
+    @staticmethod
+    def get_type_name() -> str:
+        """Returns to human-readable name of this constraint type."""
+        return _("Rotational Pattern")
+
+    def get_title(self) -> str:
+        """Returns a human-readable title for this constraint."""
+        angle_deg = math.degrees(self.value)
+        return f"{self.get_type_name()} {angle_deg:.1f}°"
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "type": "RotationalConstraint",
+            "center": self.center,
+            "p1": self.p1,
+            "p2": self.p2,
+            "value": self.value,
+            "user_visible": self.user_visible,
+        }
+        if self.expression:
+            data["expression"] = self.expression
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RotationalConstraint:
+        return cls(
+            center=data["center"],
+            p1=data["p1"],
+            p2=data["p2"],
+            value=data["value"],
+            expression=data.get("expression"),
+            user_visible=data.get("user_visible", False),
+        )
+
+    def error(
+        self, reg: EntityRegistry, params: ParameterContext
+    ) -> list[float]:
+        c = reg.get_point(self.center)
+        s = reg.get_point(self.p1)
+        t = reg.get_point(self.p2)
+
+        ca = math.cos(self.value)
+        sa = math.sin(self.value)
+        dx = s.x - c.x
+        dy = s.y - c.y
+
+        # Target position: rotate (s - c) by angle around c.
+        ex = t.x - (c.x + ca * dx - sa * dy)
+        ey = t.y - (c.y + sa * dx + ca * dy)
+        return [ex, ey]
+
+    def gradient(
+        self, reg: EntityRegistry, params: ParameterContext
+    ) -> dict[EntityID, list[Point]]:
+        ca = math.cos(self.value)
+        sa = math.sin(self.value)
+
+        # Row 0 (x residual): t.x - c.x - ca*(s.x - c.x) + sa*(s.y - c.y)
+        # Row 1 (y residual): t.y - c.y - sa*(s.x - c.x) - ca*(s.y - c.y)
+        return {
+            self.p2: [(1.0, 0.0), (0.0, 1.0)],
+            self.p1: [(-ca, sa), (-sa, -ca)],
+            self.center: [(-1.0 + ca, -sa), (sa, -1.0 + ca)],
+        }

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/entity.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/entity.py
@@ -19,6 +19,9 @@ class Entity:
         self.id: EntityID = id
         self.construction = construction
         self.invisible = False
+        # True if this entity was created as a copy of a pattern/array
+        # instance. Rendered with a distinct dashed style.
+        self.pattern_copy = False
         self.type = "entity"
         # Constrained state is calculated by solver
         self.constrained = False
@@ -184,16 +187,15 @@ class Entity:
         }
         if self.invisible:
             data["invisible"] = True
+        if self.pattern_copy:
+            data["pattern_copy"] = True
         return data
 
-    @classmethod
-    def _from_dict_base(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Extract base entity attributes from a dictionary."""
-        return {
-            "id": data["id"],
-            "construction": data.get("construction", False),
-            "invisible": data.get("invisible", False),
-        }
+    def restore_base_flags(self, data: dict[str, Any]) -> None:
+        """Restores base flags serialized by to_dict() but not accepted
+        as constructor arguments."""
+        self.invisible = data.get("invisible", False)
+        self.pattern_copy = data.get("pattern_copy", False)
 
     def __repr__(self) -> str:
         return f"Entity(id={self.id}, type={self.type})"

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/line.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/entities/line.py
@@ -119,14 +119,12 @@ class Line(Entity):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Line":
         """Deserializes a dictionary into a Line instance."""
-        line = cls(
+        return cls(
             id=data["id"],
             p1_idx=data["p1_idx"],
             p2_idx=data["p2_idx"],
             construction=data.get("construction", False),
         )
-        line.invisible = data.get("invisible", False)
-        return line
 
     def __repr__(self) -> str:
         return (

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from .base import InstancePlacement, PatternStrategy, PlacementKind
+from .circular import CircularPatternStrategy
+from .definition import PatternDefinition, find_pattern_for_entity
+from .params import CircularPatternParams, SketchArrayMode
+
+_STRATEGIES = {
+    SketchArrayMode.CIRCULAR: CircularPatternStrategy,
+}
+
+
+def make_pattern_strategy(
+    mode: SketchArrayMode, params: CircularPatternParams
+) -> PatternStrategy:
+    """Creates the pattern strategy for the given array mode."""
+    strategy_cls = _STRATEGIES.get(mode)
+    if strategy_cls is None:
+        raise ValueError(f"Unsupported sketch array mode: {mode}")
+    return strategy_cls(params)
+
+
+__all__ = [
+    "CircularPatternParams",
+    "CircularPatternStrategy",
+    "InstancePlacement",
+    "PatternDefinition",
+    "PatternStrategy",
+    "PlacementKind",
+    "SketchArrayMode",
+    "find_pattern_for_entity",
+    "make_pattern_strategy",
+]

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/base.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from ..constraints import Constraint
+    from ..entities import Entity
+
+
+class PlacementKind(Enum):
+    ROTATION = auto()
+    TRANSLATION = auto()
+
+
+@dataclass(frozen=True)
+class InstancePlacement:
+    """Describes how one pattern instance is derived from the template."""
+
+    kind: PlacementKind
+    angle: float = 0.0
+    center: tuple[float, float] = (0.0, 0.0)
+    delta: tuple[float, float] = (0.0, 0.0)
+
+    def transform_point(self, x: float, y: float) -> tuple[float, float]:
+        if self.kind == PlacementKind.ROTATION:
+            ca = math.cos(self.angle)
+            sa = math.sin(self.angle)
+            dx = x - self.center[0]
+            dy = y - self.center[1]
+            return (
+                self.center[0] + ca * dx - sa * dy,
+                self.center[1] + sa * dx + ca * dy,
+            )
+        return (x + self.delta[0], y + self.delta[1])
+
+    def transform_offset(self, dx: float, dy: float) -> tuple[float, float]:
+        """Transforms a relative offset (e.g. a bezier control point)."""
+        if self.kind == PlacementKind.ROTATION:
+            ca = math.cos(self.angle)
+            sa = math.sin(self.angle)
+            return (ca * dx - sa * dy, sa * dx + ca * dy)
+        return (dx, dy)
+
+
+class PatternStrategy(ABC):
+    """
+    Base class for sketch pattern strategies.
+
+    A strategy computes the per-instance placements for a pattern and the
+    optional "master" construction geometry that carries the pattern's
+    definition (e.g. the guide circle of a circular array). Adding a new
+    array type (e.g. linear) means adding a strategy subclass plus its
+    parameter dataclass; commands and tools stay generic.
+    """
+
+    #: Whether the pattern is defined relative to an explicit center point.
+    needs_center_point: ClassVar[bool] = False
+
+    def __init__(self, params: Any):
+        self.params = params
+
+    @abstractmethod
+    def calculate_placements(
+        self, seed_center: tuple[float, float]
+    ) -> list[InstancePlacement]:
+        """
+        Returns placements for instances 1..N-1 (instance 0 is the
+        template member).
+
+        Args:
+            seed_center: Center of the template geometry's bounding box.
+        """
+
+    def create_master_geometry(
+        self,
+        center_pid: int | None,
+        radius_pt_pid: int | None,
+    ) -> tuple[list[Any], list[Entity], list[Constraint]]:
+        """
+        Returns the master construction geometry (points, entities,
+        constraints) that visualizes and carries the pattern definition.
+        Instances are equal static copies; only the master is special.
+        """
+        return [], [], []
+
+    def build_linkage_constraints(
+        self,
+        instances: list[tuple[int, dict[int, int]]],
+        center_pid: int | None,
+    ) -> list[Constraint]:
+        """
+        Returns constraints tying each instance's cloned points back to
+        their template points, so editing any member propagates to the
+        whole pattern while deleting a member affects only itself.
+
+        Args:
+            instances: One (slot, {template_point_id: copy_point_id})
+                pair per instance. The slot determines the instance's
+                angle; slot 1 is the first placement.
+            center_pid: ID of the pattern's center point, if any.
+        """
+        return []

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/circular.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/circular.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from ..constraints import RadiusConstraint
+from ..constraints.rotational import RotationalConstraint
+from ..entities import Circle, Point
+from .base import InstancePlacement, PatternStrategy, PlacementKind
+
+if TYPE_CHECKING:
+    from ..constraints import Constraint
+    from ..entities import Entity
+
+
+class CircularPatternStrategy(PatternStrategy):
+    """
+    Distributes copies along a circular arc around a center point.
+
+    Copies are parametrically linked to the template member through
+    RotationalConstraints: editing any member updates the whole pattern,
+    while deleting a member only removes its own constraints. The
+    construction guide circle acts as the master that carries the
+    pattern definition and can be double-clicked to edit the array.
+    """
+
+    needs_center_point = True
+
+    def calculate_placements(
+        self, seed_center: tuple[float, float]
+    ) -> list[InstancePlacement]:
+        count = max(int(self.params.count), 1)
+        total = math.radians(self.params.total_angle_deg)
+        cx, cy = self.params.center
+
+        placements: list[InstancePlacement] = []
+        for j in range(1, count):
+            theta = total * j / count
+            if self.params.rotate_copies:
+                placements.append(
+                    InstancePlacement(
+                        kind=PlacementKind.ROTATION,
+                        angle=theta,
+                        center=(cx, cy),
+                    )
+                )
+            else:
+                vx = seed_center[0] - cx
+                vy = seed_center[1] - cy
+                nx = cx + math.cos(theta) * vx - math.sin(theta) * vy
+                ny = cy + math.sin(theta) * vx + math.cos(theta) * vy
+                placements.append(
+                    InstancePlacement(
+                        kind=PlacementKind.TRANSLATION,
+                        delta=(
+                            nx - seed_center[0],
+                            ny - seed_center[1],
+                        ),
+                    )
+                )
+        return placements
+
+    def create_master_geometry(
+        self,
+        center_pid: int | None,
+        radius_pt_pid: int | None,
+    ) -> tuple[list[Point], list[Entity], list[Constraint]]:
+        if center_pid is None or radius_pt_pid is None:
+            return [], [], []
+        if self.params.radius <= 0.0:
+            return [], [], []
+
+        circle_temp_id = -(abs(radius_pt_pid) + 1)
+        guide_circle = Circle(
+            circle_temp_id,
+            center_idx=center_pid,
+            radius_pt_idx=radius_pt_pid,
+            construction=True,
+        )
+
+        constraints: list[Constraint] = [
+            RadiusConstraint(circle_temp_id, value=self.params.radius)
+        ]
+
+        radius_point = Point(
+            radius_pt_pid,
+            self.params.center[0] + self.params.radius,
+            self.params.center[1],
+        )
+        return [radius_point], [guide_circle], constraints
+
+    def build_linkage_constraints(
+        self,
+        instances: list[tuple[int, dict[int, int]]],
+        center_pid: int | None,
+    ) -> list[Constraint]:
+        if not self.params.rotate_copies or center_pid is None:
+            return []
+
+        count = max(int(self.params.count), 1)
+        total = math.radians(self.params.total_angle_deg)
+        step = total / count
+
+        constraints: list[Constraint] = []
+        for slot, mapping in instances:
+            for src_pid, copy_pid in mapping.items():
+                constraints.append(
+                    RotationalConstraint(
+                        center=center_pid,
+                        p1=src_pid,
+                        p2=copy_pid,
+                        value=step * slot,
+                    )
+                )
+        return constraints

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/definition.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/definition.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .params import SketchArrayMode
+
+logger = logging.getLogger(__name__)
+
+
+class PatternDefinition:
+    """
+    Persistent definition of a sketch pattern ("master" object).
+
+    A member is a *group* of entities (the whole shape the user picked
+    as seed), not a single entity. Groups keep their identity across
+    deletions: removing part of a member leaves a smaller group, never
+    orphaned fragments that regenerate as broken copies.
+
+    ``self.members`` holds ``(slot, [entity_id, ...])`` pairs; slot 0 is
+    the template member, slots 1..N-1 correspond to the placements.
+    """
+
+    def __init__(
+        self,
+        uid: str,
+        mode: SketchArrayMode,
+        guide_circle_id: int,
+        members: list[tuple[int, list[int]]] | None = None,
+        count: int = 6,
+        total_angle_deg: float = 360.0,
+        rotate_copies: bool = True,
+    ):
+        self.uid = uid
+        self.mode = mode
+        self.guide_circle_id = guide_circle_id
+        self.members: list[tuple[int, list[int]]] = [
+            (slot, list(eids)) for slot, eids in (members or [])
+        ]
+        self.count = count
+        self.total_angle_deg = total_angle_deg
+        self.rotate_copies = rotate_copies
+
+    def living_members(self, registry: Any) -> list[tuple[int, list[int]]]:
+        """
+        Returns (slot, [entity_id, ...]) pairs for members with at least
+        one surviving entity, pruned to surviving entities only.
+        """
+        living: list[tuple[int, list[int]]] = []
+        for slot, eids in self.members:
+            alive = [
+                eid for eid in eids if registry.get_entity(eid) is not None
+            ]
+            if alive:
+                living.append((slot, alive))
+        return sorted(living)
+
+    def living_entity_ids(self, registry: Any) -> list[int]:
+        """Flat list of all surviving member entity IDs."""
+        return [
+            eid
+            for _slot, eids in self.living_members(registry)
+            for eid in eids
+        ]
+
+    def occupied_slots(self, registry: Any) -> set[int]:
+        """Returns the slot numbers of surviving members."""
+        return {slot for slot, _eids in self.living_members(registry)}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uid": self.uid,
+            "mode": self.mode.value,
+            "guide_circle_id": self.guide_circle_id,
+            "members": [[slot, list(eids)] for slot, eids in self.members],
+            "count": self.count,
+            "total_angle_deg": self.total_angle_deg,
+            "rotate_copies": self.rotate_copies,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PatternDefinition:
+        members: list[tuple[int, list[int]]] = []
+        for entry in data.get("members", []):
+            slot, eids = entry
+            members.append((int(slot), [int(eid) for eid in eids]))
+        if not members and "entity_ids" in data:
+            # Legacy flat format: every entity was treated as its own
+            # single-entity member.
+            legacy_slots = data.get(
+                "entity_slots", range(len(data["entity_ids"]))
+            )
+            members = [
+                (int(slot), [int(eid)])
+                for slot, eid in zip(legacy_slots, data["entity_ids"])
+            ]
+        return cls(
+            uid=data["uid"],
+            mode=SketchArrayMode(data.get("mode", "circular")),
+            guide_circle_id=data["guide_circle_id"],
+            members=members,
+            count=data.get("count", 6),
+            total_angle_deg=data.get("total_angle_deg", 360.0),
+            rotate_copies=data.get("rotate_copies", True),
+        )
+
+
+def find_pattern_for_entity(
+    patterns: list[PatternDefinition], entity_id: int
+) -> PatternDefinition | None:
+    """Returns the pattern whose master circle is the given entity."""
+    for pattern in patterns:
+        if pattern.guide_circle_id == entity_id:
+            return pattern
+    return None

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/params.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/patterns/params.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class SketchArrayMode(Enum):
+    """Supported sketch pattern types."""
+
+    CIRCULAR = "circular"
+
+
+@dataclass
+class CircularPatternParams:
+    """User-facing parameters for a circular (polar) array."""
+
+    count: int = 6
+    total_angle_deg: float = 360.0
+    center: tuple[float, float] = (0.0, 0.0)
+    radius: float = 0.0
+    rotate_copies: bool = True

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/registry.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/registry.py
@@ -53,6 +53,7 @@ class EntityRegistry:
             e_cls = _ENTITY_CLASSES.get(e_type)
             if e_cls:
                 entity = e_cls.from_dict(e_data)
+                entity.restore_base_flags(e_data)
                 new_reg.entities.append(entity)
                 new_reg._entity_map[entity.id] = entity
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/sketch.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/core/sketch.py
@@ -9,19 +9,11 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from blinker import Signal
-from raygeo.geo import (
-    Arc as GeoArc,
-)
-from raygeo.geo import (
-    Bezier as GeoBezier,
-)
+from raygeo.geo import Arc as GeoArc
+from raygeo.geo import Bezier as GeoBezier
 from raygeo.geo import Geometry
-from raygeo.geo import (
-    Line as GeoLine,
-)
-from raygeo.geo import (
-    Move as GeoMove,
-)
+from raygeo.geo import Line as GeoLine
+from raygeo.geo import Move as GeoMove
 from raygeo.geo.shape.polygon import is_point_inside_polygon
 
 from rayforge.core.asset import IAsset
@@ -48,6 +40,7 @@ from .constraints import (
     PerpendicularConstraint,
     PointOnLineConstraint,
     RadiusConstraint,
+    RotationalConstraint,
     SymmetryConstraint,
     TangentConstraint,
     VerticalConstraint,
@@ -64,6 +57,7 @@ from .entities import (
 )
 from .entities.point import WaypointType
 from .params import ParameterContext
+from .patterns import PatternDefinition
 from .registry import EntityRegistry
 from .solver import Solver
 from .types import EntityID
@@ -91,6 +85,7 @@ _CONSTRAINT_CLASSES = {
     "PerpendicularConstraint": PerpendicularConstraint,
     "PointOnLineConstraint": PointOnLineConstraint,
     "RadiusConstraint": RadiusConstraint,
+    "RotationalConstraint": RotationalConstraint,
     "SymmetryConstraint": SymmetryConstraint,
     "TangentConstraint": TangentConstraint,
     "VerticalConstraint": VerticalConstraint,
@@ -176,6 +171,7 @@ class Sketch(IAsset, IGeometryProvider):
         self.registry = EntityRegistry()
         self.constraints: list[Constraint] = []
         self.fills: list[Fill] = []
+        self.patterns: list[PatternDefinition] = []
         self.input_parameters = VarSet(
             title=_DEFAULT_VARSET_TITLE,
             description=_DEFAULT_VARSET_DESCRIPTION,
@@ -394,6 +390,7 @@ class Sketch(IAsset, IGeometryProvider):
             "registry": self.registry.to_dict(),
             "constraints": [c.to_dict() for c in self.constraints],
             "fills": [f.to_dict() for f in self.fills],
+            "patterns": [p.to_dict() for p in self.patterns],
             "origin_id": self.origin_id,
             "hidden": self._hidden,
         }
@@ -438,8 +435,106 @@ class Sketch(IAsset, IGeometryProvider):
         for f_data in data.get("fills", []):
             new_sketch.fills.append(Fill.from_dict(f_data))
 
+        new_sketch.patterns = [
+            PatternDefinition.from_dict(p_data)
+            for p_data in data.get("patterns", [])
+        ]
+
         new_sketch._hidden = data.get("hidden", False)
         return new_sketch
+
+    def prune_patterns(self) -> None:
+        """
+        Removes pattern definitions whose master geometry is gone and
+        drops deleted entities from member groups. Groups themselves are
+        never dissolved by deletion; deleting them does not dissolve the
+        pattern as long as the master geometry still exists.
+        """
+        registry = self.registry
+        surviving: list[PatternDefinition] = []
+        for pattern in self.patterns:
+            if registry.get_entity(pattern.guide_circle_id) is None:
+                continue
+            pattern.members = pattern.living_members(registry)
+            surviving.append(pattern)
+        self.patterns = surviving
+
+    def get_pattern_constraint_indices_for_entities(
+        self, entity_ids: set[int]
+    ) -> set[int]:
+        """
+        Returns indices (into self.constraints) of pattern dimension
+        constraints (radius of the guide circle) for patterns containing
+        one of the given entities. These must be excluded from solves
+        during member drags so the dimension follows instead of fights.
+        """
+        wanted = set(entity_ids)
+        indices: set[int] = set()
+        for idx, constr in enumerate(self.constraints):
+            if not isinstance(constr, RadiusConstraint):
+                continue
+            for pattern in self.patterns:
+                if (
+                    pattern.guide_circle_id == constr.entity_id
+                    and set(pattern.living_entity_ids(self.registry)) & wanted
+                ):
+                    indices.add(idx)
+                    break
+        return indices
+
+    def sync_pattern_dimensions(self, entity_ids: set[int]) -> None:
+        """
+        Updates the radius dimension of every pattern touched by the
+        given entities to match the guide circle's current geometry.
+        Called after member drags, where the radius dimension was
+        excluded from the interactive solves and must follow the
+        dragged geometry instead of fighting it.
+        """
+        wanted = set(entity_ids)
+        for pattern in self.patterns:
+            member_ids = set(pattern.living_entity_ids(self.registry))
+            if not member_ids & wanted:
+                continue
+            circle = self.registry.get_entity(pattern.guide_circle_id)
+            if not isinstance(circle, Circle):
+                continue
+            try:
+                center = self.registry.get_point(circle.center_idx)
+                radius_pt = self.registry.get_point(circle.radius_pt_idx)
+            except IndexError:
+                continue
+            radius = math.hypot(radius_pt.x - center.x, radius_pt.y - center.y)
+            for constr in self.constraints:
+                if (
+                    isinstance(constr, RadiusConstraint)
+                    and constr.entity_id == pattern.guide_circle_id
+                ):
+                    constr.value = radius
+
+    def get_pattern_points_for_entities(
+        self, entity_ids: set[int]
+    ) -> set[int]:
+        """
+        Returns all points belonging to any pattern that contains one of
+        the given entities (member geometry plus master circle). During
+        drags these points must stay free of holding constraints so the
+        pattern's linkage constraints can carry the whole array.
+        """
+        result: set[int] = set()
+        wanted = set(entity_ids)
+        registry = self.registry
+        for pattern in self.patterns:
+            member_ids = set(pattern.living_entity_ids(registry))
+            if not member_ids & wanted:
+                continue
+            for eid in member_ids:
+                entity = registry.get_entity(eid)
+                if entity is not None:
+                    result.update(entity.get_point_ids())
+            guide = registry.get_entity(pattern.guide_circle_id)
+            if guide is not None:
+                result.update(guide.get_point_ids())
+        return result
 
     @classmethod
     def from_file(cls, file_path: str | Path) -> "Sketch":
@@ -1173,6 +1268,7 @@ class Sketch(IAsset, IGeometryProvider):
         extra_constraints: list[Constraint] | None = None,
         update_constraint_status: bool = True,
         variable_overrides: dict[str, Any] | None = None,
+        excluded_constraints: set[int] | None = None,
     ) -> bool:
         """
         Resolves all constraints.
@@ -1185,6 +1281,9 @@ class Sketch(IAsset, IGeometryProvider):
             variable_overrides: A dictionary of parameter values to use for
                 this solve only, without permanently changing the sketch's
                 parameters. e.g., `{'width': 150.0}`.
+            excluded_constraints: Indices (into self.constraints) of
+                constraints to skip for this solve, e.g. a pattern's radius
+                dimension while a member is being dragged.
 
         Returns:
             True if the solver converged successfully.
@@ -1232,9 +1331,13 @@ class Sketch(IAsset, IGeometryProvider):
                     )
 
             # Step 4: Update constraints with the final, resolved values.
-            all_constraints = self.constraints
+            excluded = excluded_constraints or set()
+            kept_indices = [
+                i for i in range(len(self.constraints)) if i not in excluded
+            ]
+            all_constraints = [self.constraints[i] for i in kept_indices]
             if extra_constraints:
-                all_constraints = self.constraints + extra_constraints
+                all_constraints = all_constraints + extra_constraints
             for c in all_constraints:
                 if hasattr(c, "update_from_context"):
                     c.update_from_context(ctx)
@@ -1249,25 +1352,31 @@ class Sketch(IAsset, IGeometryProvider):
             )
             success = solver.solve(update_dof=update_constraint_status)
 
-            # Step 6: Update constraint conflict status
+            # Step 6: Update constraint conflict status. Map solver indices
+            # back to sketch constraint indices when constraints were
+            # excluded.
             if update_constraint_status:
-                self._update_conflict_status(solver)
+                conflicting = solver.get_conflicting_constraints()
+                mapped = {
+                    kept_indices[i]
+                    for i in conflicting
+                    if 0 <= i < len(kept_indices)
+                }
+                self._apply_conflict_status(mapped)
 
         except Exception:
-            import logging
-
-            logging.getLogger(__name__).exception("Sketch solve failed")
+            logger.exception("Sketch solve failed")
             success = False
 
         return success
 
-    def _update_conflict_status(self, solver: Solver) -> None:
+    def _apply_conflict_status(self, conflicting_indices: set[int]) -> None:
         """
-        Updates the conflict status of all constraints based on solver results.
-        Constraints with significant residual error are marked as CONFLICTING.
+        Updates the conflict status of all constraints based on solver
+        results. Indices refer to positions in self.constraints.
+        Constraints with significant residual error are marked as
+        CONFLICTING.
         """
-        conflicting_indices = solver.get_conflicting_constraints()
-
         for idx, constraint in enumerate(self.constraints):
             if idx in conflicting_indices:
                 if constraint.status != ConstraintStatus.ERROR:

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/menu.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/menu.py
@@ -55,6 +55,10 @@ class SketchMenu(Gio.Menu):
         )
         tools_menu.append_section(_("Modify"), constr_group)
 
+        array_group = Gio.Menu()
+        array_group.append(_("Circular Array"), "sketch.tool_circular_array")
+        tools_menu.append_section(_("Arrays"), array_group)
+
         self.append_submenu(_("_Sketch"), tools_menu)
 
         # View

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/renderer.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/renderer.py
@@ -417,6 +417,17 @@ class SketchRenderer:
                 else:
                     ctx.set_source_rgb(0.3, 0.5, 0.8)
                 ctx.stroke()
+            elif entity.pattern_copy:
+                # Solid like regular geometry, slightly thinner to read
+                # as derived rather than seed geometry.
+                ctx.set_line_width(base_line_width * 0.6)
+                self._set_standard_color(
+                    ctx,
+                    is_sel or is_hovered,
+                    entity.constrained,
+                    is_sketch_fully_constrained,
+                )
+                ctx.stroke()
             else:
                 self._set_standard_color(
                     ctx,

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchelement.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/sketchelement.py
@@ -8,7 +8,8 @@ from raygeo.geo import Matrix
 from rayforge.ui_gtk.canvas import CanvasElement
 
 from ..core.commands import DuplicateCommand, MoveEntitiesCommand
-from ..core.entities import Line, Point
+from ..core.entities import Entity, Line, Point
+from ..core.patterns import find_pattern_for_entity
 from ..core.selection import SketchSelection
 from ..core.sketch import Sketch
 from ..core.snap import SnapEngine
@@ -409,6 +410,33 @@ class SketchElement(CanvasElement):
         )
         self.execute_command(cmd)
         return True
+
+    def request_pattern_edit(self, entity: Entity) -> bool:
+        """
+        Opens the edit dialog for the pattern whose master geometry is
+        the given entity. Returns True if a pattern was found and the
+        edit tool was activated.
+        """
+        pattern = find_pattern_for_entity(self.sketch.patterns, entity.id)
+        if pattern is None:
+            logging.getLogger(__name__).info(
+                "Pattern edit request: entity e%s is not a master "
+                "(%d patterns registered)",
+                entity.id,
+                len(self.sketch.patterns),
+            )
+            return False
+        logging.getLogger(__name__).info(
+            "Pattern edit request: found uid=%s for e%s",
+            pattern.uid[:8],
+            entity.id,
+        )
+        for name, tool in self.tools.items():
+            if tool.is_available_for_edit(pattern):
+                tool.set_edit_target(pattern)
+                self.set_tool(name)
+                return True
+        return False
 
     def toggle_construction_on_selection(self):
         self.tools["construction"]._toggle_construction()

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/__init__.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/__init__.py
@@ -1,9 +1,11 @@
 from .angle_constraint_tool import AngleConstraintTool
 from .arc_tool import ArcTool
+from .array_base import ArrayToolBase
 from .aspect_ratio_constraint_tool import AspectRatioConstraintTool
 from .base import SketcherKey, SketchTool
 from .chamfer_tool import ChamferTool
 from .circle_tool import CircleTool
+from .circular_array_tool import CircularArrayTool
 from .coincident_constraint_tool import CoincidentConstraintTool
 from .construction_tool import ConstructionTool
 from .delete_tool import DeleteTool
@@ -37,6 +39,7 @@ TOOL_REGISTRY = {
     "aspect_ratio": AspectRatioConstraintTool,
     "chamfer": ChamferTool,
     "circle": CircleTool,
+    "circular_array": CircularArrayTool,
     "coincident": CoincidentConstraintTool,
     "construction": ConstructionTool,
     "delete": DeleteTool,
@@ -93,9 +96,11 @@ __all__ = [
     "TOOL_REGISTRY",
     "AngleConstraintTool",
     "ArcTool",
+    "ArrayToolBase",
     "AspectRatioConstraintTool",
     "ChamferTool",
     "CircleTool",
+    "CircularArrayTool",
     "CoincidentConstraintTool",
     "ConstructionTool",
     "DeleteTool",

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/array_base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/array_base.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Callable
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import cairo
+from gi.repository import Adw, Gtk
+
+from ...core.commands import CreatePatternCommand, EditPatternCommand
+from ...core.entities import Arc, Bezier, Circle, Ellipse, Line
+from ...core.patterns import make_pattern_strategy
+from .base import SketcherKey, SketchTool
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ...core.entities import Entity
+    from ...core.patterns import PatternDefinition, SketchArrayMode
+    from ...core.registry import EntityRegistry
+
+
+class ArrayToolBase(SketchTool):
+    """
+    Base class for pattern/array tools.
+
+    Handles seed capture, a non-modal parameter dialog with live preview,
+    canvas interaction for placing the pattern anchor, and committing a
+    CreatePatternCommand. When an edit target is set before activation,
+    the tool edits an existing pattern definition instead: parameters are
+    pre-filled from its master geometry and applying regenerates the
+    instances via an EditPatternCommand.
+
+    Subclasses provide mode-specific parameters, dialog rows, and command
+    assembly.
+    """
+
+    MODE: ClassVar[SketchArrayMode]
+    DIALOG_TITLE: ClassVar[str]
+    EDIT_DIALOG_TITLE: ClassVar[str] = ""
+    GROUP_TITLE: ClassVar[str] = ""
+    GROUP_DESCRIPTION: ClassVar[str] = ""
+
+    PREVIEW_COLOR = (0.6, 0.3, 0.8, 0.85)
+    GUIDE_COLOR = (0.3, 0.5, 0.8, 0.9)
+
+    def __init__(self, element):
+        super().__init__(element)
+        self._dialog: Adw.Window | None = None
+        self._params: Any = None
+        self._edit_target: PatternDefinition | None = None
+        self._seed_entity_ids: list[int] = []
+        self._seed_points: list[tuple[float, float]] = []
+        self._updating_rows = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def is_available(self, target, target_type) -> bool:
+        return bool(self.element.selection.entity_ids)
+
+    def set_edit_target(self, pattern: PatternDefinition) -> None:
+        """
+        Arms the tool for editing an existing pattern. Must be called
+        before the tool is activated (e.g. before set_tool()).
+        """
+        self._edit_target = pattern
+
+    def is_available_for_edit(self, pattern: PatternDefinition) -> bool:
+        return self.MODE == pattern.mode
+
+    def on_activate(self):
+        if self._edit_target is not None:
+            if not self._begin_edit():
+                self.element.set_tool("select")
+            return
+
+        registry = self.element.sketch.registry
+        self._seed_entity_ids = [
+            eid
+            for eid in self.element.selection.entity_ids
+            if registry.get_entity(eid) is not None
+        ]
+        if not self._seed_entity_ids:
+            self.element.set_tool("select")
+            return
+
+        self._capture_seed_geometry(registry)
+        self._params = self._make_default_params()
+        self._show_dialog()
+
+    def _begin_edit(self) -> bool:
+        """Prepares state for editing the current _edit_target."""
+        assert self._edit_target is not None
+        registry = self.element.sketch.registry
+        living = self._edit_target.living_members(registry)
+        if not living:
+            return False
+        _template_slot, template_eids = living[0]
+        self._seed_entity_ids = list(template_eids)
+        self._capture_seed_geometry(registry)
+        self._params = self._make_params_from_target()
+        logger.info(
+            "ArrayTool: begin edit uid=%s living=%r params=%r",
+            self._edit_target.uid[:8],
+            living,
+            self._params,
+        )
+        self._show_dialog()
+        return True
+
+    def on_deactivate(self):
+        self._close_dialog()
+        self._params = None
+        self._edit_target = None
+
+    def _capture_seed_geometry(self, registry: EntityRegistry):
+        seed_pids = CreatePatternCommand.collect_seed_point_ids(
+            registry, self._seed_entity_ids
+        )
+        self._seed_points = []
+        for pid in seed_pids:
+            pt = registry.get_point(pid)
+            self._seed_points.append((pt.x, pt.y))
+
+    def _seed_bbox_center(self) -> tuple[float, float]:
+        if not self._seed_points:
+            return (0.0, 0.0)
+        xs = [p[0] for p in self._seed_points]
+        ys = [p[1] for p in self._seed_points]
+        return ((min(xs) + max(xs)) / 2.0, (min(ys) + max(ys)) / 2.0)
+
+    @property
+    def _is_editing(self) -> bool:
+        return self._edit_target is not None
+
+    # ------------------------------------------------------------------
+    # Subclass hooks
+    # ------------------------------------------------------------------
+
+    def _make_default_params(self) -> Any:
+        """Creates initial parameters for creating a new pattern."""
+        raise NotImplementedError
+
+    def _make_params_from_target(self) -> Any:
+        """Creates initial parameters from the current edit target."""
+        raise NotImplementedError
+
+    def _build_mode_rows(self, group: Adw.PreferencesGroup) -> None:
+        raise NotImplementedError
+
+    def _sync_params_from_rows(self) -> None:
+        """Reads current widget values into self._params."""
+
+    def _make_create_command(self) -> CreatePatternCommand | None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Dialog
+    # ------------------------------------------------------------------
+
+    def _show_dialog(self):
+        editor = self.element.editor
+        if not editor or not editor.parent_window:
+            self.element.set_tool("select")
+            return
+
+        title = (
+            self.EDIT_DIALOG_TITLE if self._is_editing else self.DIALOG_TITLE
+        )
+        parent_window = editor.parent_window
+        dialog = Adw.Window(
+            transient_for=parent_window,
+            modal=False,
+            destroy_with_parent=True,
+            title=title,
+        )
+        dialog.set_default_size(380, -1)
+
+        header = Adw.HeaderBar()
+        cancel_btn = Gtk.Button(label=_("_Cancel"), use_underline=True)
+        cancel_btn.connect("clicked", lambda *_: self._on_cancel())
+        header.pack_start(cancel_btn)
+
+        apply_btn = Gtk.Button(label=_("_Apply"), use_underline=True)
+        apply_btn.add_css_class("suggested-action")
+        apply_btn.connect("clicked", lambda *_: self._on_apply())
+        header.pack_end(apply_btn)
+
+        group = Adw.PreferencesGroup()
+        if self.GROUP_TITLE:
+            group.set_title(self.GROUP_TITLE)
+        if self.GROUP_DESCRIPTION:
+            group.set_description(self.GROUP_DESCRIPTION)
+        self._build_mode_rows(group)
+
+        page = Adw.PreferencesPage()
+        page.add(group)
+
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(header)
+        toolbar.set_content(page)
+
+        dialog.set_content(toolbar)
+        dialog.connect("close-request", self._on_close_request)
+        self._dialog = dialog
+        dialog.present()
+
+    def _close_dialog(self):
+        if self._dialog is not None:
+            dialog = self._dialog
+            self._dialog = None
+            dialog.destroy()
+
+    def _on_apply(self):
+        cmd = self._collect_command()
+        if cmd is None:
+            logger.warning("ArrayTool: apply skipped, no command built")
+            return
+        logger.info(
+            "ArrayTool: applying %s with %r", type(cmd).__name__, cmd.params
+        )
+        self.element.execute_command(cmd)
+        if cmd.created_entity_ids:
+            self._select_entities(cmd.created_entity_ids)
+        self._close_dialog()
+        self.element.mark_dirty()
+        self.element.set_tool("select")
+
+    def _on_cancel(self):
+        self.element.set_tool("select")
+
+    def _on_close_request(self, *_args) -> bool:
+        """
+        Handles the window manager closing the dialog (X button).
+        Returns False so the window is allowed to close.
+        """
+        if self._dialog is not None:
+            self._dialog = None
+            self.element.set_tool("select")
+        return False
+
+    def _collect_command(self):
+        if self._is_editing:
+            assert self._params is not None
+            assert self._edit_target is not None
+            return EditPatternCommand(
+                self.element.sketch, self._edit_target, self._params
+            )
+        return self._make_create_command()
+
+    def _select_entities(self, entity_ids: list[int]):
+        registry = self.element.sketch.registry
+        selection = self.element.selection
+        selection.clear()
+        for eid in entity_ids:
+            entity = registry.get_entity(eid)
+            if entity is not None:
+                selection.select_entity(entity, False)
+
+    # ------------------------------------------------------------------
+    # Canvas interaction
+    # ------------------------------------------------------------------
+
+    def on_press(self, world_x: float, world_y: float, n_press: int) -> bool:
+        """
+        Canvas clicks are deliberately ignored: an accidental click or
+        pan attempt must never relocate the pattern center. The center
+        is set numerically (and stays draggable afterwards via the guide
+        circle's own center point).
+        """
+        return True
+
+    def on_drag(self, world_dx: float, world_dy: float):
+        pass
+
+    def on_release(self, world_x: float, world_y: float):
+        pass
+
+    def handle_key_event(
+        self, key: SketcherKey, shift: bool = False, ctrl: bool = False
+    ) -> bool:
+        if key == SketcherKey.ESCAPE and self._dialog is not None:
+            self.element.set_tool("select")
+            return True
+        return False
+
+    def get_active_shortcuts(
+        self,
+    ) -> list[tuple[str | list[str], str, Callable[[], bool] | None]]:
+        return []
+
+    # ------------------------------------------------------------------
+    # Live preview
+    # ------------------------------------------------------------------
+
+    def draw_overlay(self, ctx: cairo.Context):
+        if self._dialog is None or self._params is None:
+            return
+        registry = self.element.sketch.registry
+        strategy = self._make_strategy()
+        placements = strategy.calculate_placements(self._seed_bbox_center())
+        # Preview must mirror what Apply will do: when the parameters
+        # changed, everything but the template is re-distributed, so
+        # ghost every non-template slot. Otherwise only truly missing
+        # slots are filled and occupied ones stay untouched.
+        occupied_slots: set[int] = set()
+        if self._edit_target is not None:
+            if self._would_full_regen():
+                occupied_slots = {0}
+            else:
+                occupied_slots = self._edit_target.occupied_slots(registry)
+
+        model_to_screen = self.element.hittester.get_model_to_screen_transform(
+            self.element
+        )
+
+        ctx.save()
+        ctx.set_line_width(1.5)
+        ctx.set_dash([5.0, 4.0])
+        ctx.set_source_rgba(*self.PREVIEW_COLOR)
+
+        polylines = _collect_seed_polylines(registry, self._seed_entity_ids)
+        for index, placement in enumerate(placements):
+            if index + 1 in occupied_slots:
+                continue
+            for polyline in polylines:
+                transformed = [
+                    placement.transform_point(x, y) for x, y in polyline
+                ]
+                _stroke_polyline(ctx, model_to_screen, transformed)
+
+        self._draw_guide(ctx, model_to_screen, strategy)
+        ctx.restore()
+
+    def _would_full_regen(self) -> bool:
+        """True if applying now would re-distribute all members."""
+        target = self._edit_target
+        assert self._params is not None
+        if target is None:
+            return False
+        return (
+            self._params.count != target.count
+            or self._params.total_angle_deg != target.total_angle_deg
+            or self._params.rotate_copies != target.rotate_copies
+        )
+
+    def _make_strategy(self):
+        assert self._params is not None
+        return make_pattern_strategy(self.MODE, self._params)
+
+    def _draw_guide(self, ctx: cairo.Context, model_to_screen, strategy):
+        """Draws the guide circle and center marker."""
+        if not strategy.needs_center_point:
+            return
+        center = self._params.center
+        sx, sy = model_to_screen.transform_point(*center)
+        ctx.save()
+        cross = 8.0
+        ctx.set_source_rgba(*self.GUIDE_COLOR)
+        ctx.set_line_width(1.0)
+        ctx.move_to(sx - cross, sy)
+        ctx.line_to(sx + cross, sy)
+        ctx.move_to(sx, sy - cross)
+        ctx.line_to(sx, sy + cross)
+        ctx.stroke()
+
+        radius = self._params.radius
+        if radius > 0.0:
+            radius_pt = model_to_screen.transform_point(
+                center[0] + radius, center[1]
+            )
+            screen_radius = math.hypot(radius_pt[0] - sx, radius_pt[1] - sy)
+            ctx.set_dash([5.0, 4.0])
+            ctx.new_sub_path()
+            ctx.arc(sx, sy, screen_radius, 0, 2 * math.pi)
+            ctx.stroke()
+        ctx.restore()
+
+
+# ----------------------------------------------------------------------
+# Preview geometry sampling helpers
+# ----------------------------------------------------------------------
+
+
+def _collect_seed_polylines(
+    registry: EntityRegistry, entity_ids: list[int]
+) -> list[list[tuple[float, float]]]:
+    polylines: list[list[tuple[float, float]]] = []
+    for eid in entity_ids:
+        entity = registry.get_entity(eid)
+        if entity is None:
+            continue
+        polylines.extend(_entity_polylines(entity, registry))
+    return polylines
+
+
+def _entity_polylines(
+    entity: Entity, registry: EntityRegistry
+) -> list[list[tuple[float, float]]]:
+
+    def point(pid):
+        pt = registry.get_point(pid)
+        return (pt.x, pt.y)
+
+    if isinstance(entity, Line):
+        return [[point(entity.p1_idx), point(entity.p2_idx)]]
+
+    if isinstance(entity, Circle):
+        c = point(entity.center_idx)
+        r_pt = point(entity.radius_pt_idx)
+        radius = math.hypot(r_pt[0] - c[0], r_pt[1] - c[1])
+        return [_sample_arc(c, radius, 0.0, 2 * math.pi, clockwise=False)]
+
+    if isinstance(entity, Arc):
+        start = point(entity.start_idx)
+        end = point(entity.end_idx)
+        c = point(entity.center_idx)
+        radius = math.hypot(start[0] - c[0], start[1] - c[1])
+        start_a = math.atan2(start[1] - c[1], start[0] - c[0])
+        end_a = math.atan2(end[1] - c[1], end[0] - c[0])
+        return [
+            _sample_arc(c, radius, start_a, end_a, clockwise=entity.clockwise)
+        ]
+
+    if isinstance(entity, Ellipse):
+        c = point(entity.center_idx)
+        rx_pt = point(entity.radius_x_pt_idx)
+        ry_pt = point(entity.radius_y_pt_idx)
+        rx = math.hypot(rx_pt[0] - c[0], rx_pt[1] - c[1])
+        ry = math.hypot(ry_pt[0] - c[0], ry_pt[1] - c[1])
+        rotation = math.atan2(rx_pt[1] - c[1], rx_pt[0] - c[0])
+        return [_sample_ellipse(c, rx, ry, rotation)]
+
+    if isinstance(entity, Bezier):
+        start = point(entity.start_idx)
+        end = point(entity.end_idx)
+        cp1 = start
+        if entity.cp1 is not None:
+            cp1 = (start[0] + entity.cp1[0], start[1] + entity.cp1[1])
+        cp2 = end
+        if entity.cp2 is not None:
+            cp2 = (end[0] + entity.cp2[0], end[1] + entity.cp2[1])
+        return [_sample_bezier(start, cp1, cp2, end)]
+
+    return []
+
+
+def _sample_arc(
+    center: tuple[float, float],
+    radius: float,
+    start_a: float,
+    end_a: float,
+    clockwise: bool,
+) -> list[tuple[float, float]]:
+    two_pi = 2 * math.pi
+    sweep = end_a - start_a
+    if clockwise:
+        while sweep >= 0:
+            sweep -= two_pi
+    else:
+        while sweep <= 0:
+            sweep += two_pi
+
+    segments = max(8, int(abs(sweep) / two_pi * 48))
+    return [
+        (
+            center[0] + radius * math.cos(start_a + sweep * i / segments),
+            center[1] + radius * math.sin(start_a + sweep * i / segments),
+        )
+        for i in range(segments + 1)
+    ]
+
+
+def _sample_ellipse(
+    center: tuple[float, float],
+    rx: float,
+    ry: float,
+    rotation: float,
+) -> list[tuple[float, float]]:
+    cos_r = math.cos(rotation)
+    sin_r = math.sin(rotation)
+    segments = 48
+    result = []
+    for i in range(segments + 1):
+        t = 2 * math.pi * i / segments
+        ex = rx * math.cos(t)
+        ey = ry * math.sin(t)
+        result.append(
+            (
+                center[0] + ex * cos_r - ey * sin_r,
+                center[1] + ex * sin_r + ey * cos_r,
+            )
+        )
+    return result
+
+
+def _sample_bezier(p0, p1, p2, p3):
+    segments = 24
+    result = []
+    for i in range(segments + 1):
+        t = i / segments
+        u = 1.0 - t
+        x = (
+            u * u * u * p0[0]
+            + 3 * u * u * t * p1[0]
+            + 3 * u * t * t * p2[0]
+            + t * t * t * p3[0]
+        )
+        y = (
+            u * u * u * p0[1]
+            + 3 * u * u * t * p1[1]
+            + 3 * u * t * t * p2[1]
+            + t * t * t * p3[1]
+        )
+        result.append((x, y))
+    return result
+
+
+def _stroke_polyline(ctx: cairo.Context, model_to_screen, points) -> None:
+    if len(points) < 2:
+        return
+    ctx.new_sub_path()
+    sx, sy = model_to_screen.transform_point(*points[0])
+    ctx.move_to(sx, sy)
+    for x, y in points[1:]:
+        sx, sy = model_to_screen.transform_point(x, y)
+        ctx.line_to(sx, sy)
+    ctx.stroke()

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/base.py
@@ -141,6 +141,19 @@ class SketchTool(ABC):
         """
         return self.ICON is not None and self.LABEL is not None
 
+    def is_available_for_edit(self, pattern) -> bool:
+        """
+        Returns True if this tool can edit the given pattern definition.
+        Pattern tools override this; all other tools return False.
+        """
+        return False
+
+    def set_edit_target(self, pattern) -> None:
+        """
+        Arms a pattern tool for editing an existing pattern definition.
+        Must be called before the tool is activated. No-op by default.
+        """
+
     def shortcut_is_active(self) -> bool:
         """
         Determines if this tool's shortcut should be shown in the status bar.

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/circular_array_tool.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/circular_array_tool.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import logging
+import math
+from gettext import gettext as _
+from typing import ClassVar
+
+from gi.repository import Adw, Gtk
+
+from rayforge.ui_gtk.shared.pref_rows import (
+    AngleSpinRow,
+    LengthSpinRow,
+    SpinRow,
+)
+
+from ...core.commands import CreatePatternCommand
+from ...core.commands.create_pattern import _choose_reference_point
+from ...core.entities import Circle
+from ...core.patterns import CircularPatternParams, SketchArrayMode
+from .array_base import ArrayToolBase
+
+logger = logging.getLogger(__name__)
+
+
+class CircularArrayTool(ArrayToolBase):
+    """
+    Creates and edits circular (polar) arrays of sketch entities.
+
+    Instances are equal static copies distributed along a circular arc.
+    The dashed construction guide circle is the array's master: it can
+    be double-clicked to re-open this dialog, and applying an edit
+    regenerates missing or moved instances from the first surviving
+    member.
+    """
+
+    ICON = "sketch-array-symbolic"
+    LABEL = _("Circular Array")
+    SHORTCUTS: ClassVar[list[str]] = ["gy"]
+
+    MODE = SketchArrayMode.CIRCULAR
+    DIALOG_TITLE = _("Circular Array")
+    EDIT_DIALOG_TITLE = _("Edit Circular Array")
+    GROUP_TITLE = _("Circular")
+    GROUP_DESCRIPTION = _(
+        "Places copies along a circular arc around a centre."
+    )
+
+    def is_available(self, target, target_type) -> bool:
+        return len(self.element.selection.entity_ids) > 0
+
+    def _make_default_params(self) -> CircularPatternParams:
+        center = self._default_center()
+        return CircularPatternParams(
+            count=6,
+            total_angle_deg=360.0,
+            center=center,
+            radius=self._default_radius(center),
+            rotate_copies=True,
+        )
+
+    def _make_params_from_target(self) -> CircularPatternParams:
+        """Pre-fills parameters from the edit target's master geometry."""
+        assert self._edit_target is not None
+        registry = self.element.sketch.registry
+        circle = registry.get_entity(self._edit_target.guide_circle_id)
+        center = (0.0, 0.0)
+        radius = 10.0
+        if isinstance(circle, Circle):
+            try:
+                center_pt = registry.get_point(circle.center_idx)
+                radius_pt = registry.get_point(circle.radius_pt_idx)
+                center = (center_pt.x, center_pt.y)
+                radius = math.hypot(
+                    radius_pt.x - center_pt.x, radius_pt.y - center_pt.y
+                )
+                logger.info(
+                    "ArrayTool: master circle read back center=%r radius=%.3f",
+                    center,
+                    radius,
+                )
+            except IndexError:
+                pass
+        params = CircularPatternParams(
+            count=self._edit_target.count,
+            total_angle_deg=self._edit_target.total_angle_deg,
+            center=center,
+            radius=radius,
+            rotate_copies=self._edit_target.rotate_copies,
+        )
+        logger.info("ArrayTool: prefilled params %r", params)
+        return params
+
+    def _default_center(self) -> tuple[float, float]:
+        """Defaults to the sketch origin, like a clock/speaker center."""
+        return (0.0, 0.0)
+
+    def _default_radius(self, center: tuple[float, float]) -> float:
+        """
+        Derives the guide circle radius from the anchor point — exactly
+        like CreatePatternCommand does — so the previewed circle matches
+        the applied one without any jump.
+        """
+        registry = self.element.sketch.registry
+        pids = CreatePatternCommand.collect_seed_point_ids(
+            registry, self._seed_entity_ids
+        )
+        if not pids:
+            return 10.0
+        seed_points = [registry.get_point(pid) for pid in pids]
+        ref_pid = _choose_reference_point(seed_points)
+        ref_pt = registry.get_point(ref_pid)
+        radius = math.hypot(ref_pt.x - center[0], ref_pt.y - center[1])
+        return radius if radius > 1e-6 else 10.0
+
+    def _build_mode_rows(self, group: Adw.PreferencesGroup):
+        params = self._params
+
+        self._count_row = SpinRow(
+            _("Count"),
+            lower=1,
+            upper=360,
+            digits=0,
+            value=params.count,
+        )
+        self._angle_row = AngleSpinRow(
+            _("Total angle (deg)"),
+            lower=1.0,
+            upper=360.0,
+            value=params.total_angle_deg,
+        )
+        self._center_x_row = LengthSpinRow(
+            _("Center X"),
+            lower=-10000,
+            upper=10000,
+            value_in_base=params.center[0],
+        )
+        self._center_y_row = LengthSpinRow(
+            _("Center Y"),
+            lower=-10000,
+            upper=10000,
+            value_in_base=params.center[1],
+        )
+        self._radius_row = LengthSpinRow(
+            _("Radius"),
+            subtitle=self._radius_row_subtitle(),
+            lower=0.0,
+            upper=10000,
+            value_in_base=params.radius,
+        )
+
+        # At creation time the radius is derived from where the anchor
+        # point sits, so editing it here would silently be overridden.
+        if not self._is_editing:
+            self._radius_row.set_sensitive(False)
+
+        for row in (
+            self._count_row,
+            self._angle_row,
+            self._center_x_row,
+            self._center_y_row,
+            self._radius_row,
+        ):
+            row.value_changed.connect(lambda *a: self._sync_params())
+            group.add(row)
+
+        rotate_row = Adw.ActionRow()
+        rotate_row.set_title(_("Rotate copies"))
+        self._rotate_switch = Gtk.Switch()
+        self._rotate_switch.set_active(params.rotate_copies)
+        self._rotate_switch.set_valign(Gtk.Align.CENTER)
+        self._rotate_switch.connect(
+            "notify::active", lambda *a: self._sync_params()
+        )
+        rotate_row.add_suffix(self._rotate_switch)
+        rotate_row.set_activatable_widget(self._rotate_switch)
+        group.add(rotate_row)
+
+    def _radius_row_subtitle(self) -> str:
+        if self._is_editing:
+            return _("Resizes the whole array.")
+        return _("Derived from the seed's anchor point.")
+
+    def _sync_params(self):
+        if self._updating_rows or self._params is None:
+            return
+        self._params.count = self._count_row.get_int_value()
+        self._params.total_angle_deg = self._angle_row.get_value()
+        cx = self._center_x_row.get_value_in_base_units()
+        cy = self._center_y_row.get_value_in_base_units()
+        self._params.center = (cx, cy)
+        self._params.radius = self._radius_row.get_value_in_base_units()
+        if not self._is_editing:
+            # At creation the circle always passes through the seed's
+            # anchor point; keep the row in sync so preview matches
+            # the applied result exactly.
+            derived = self._default_radius((cx, cy))
+            self._params.radius = derived
+            self._updating_rows = True
+            try:
+                self._radius_row.set_value_in_base_units(derived)
+            finally:
+                self._updating_rows = False
+        self._params.rotate_copies = self._rotate_switch.get_active()
+        self.element.mark_dirty()
+
+    def _make_create_command(self) -> CreatePatternCommand | None:
+        if self._params is None:
+            return None
+        return CreatePatternCommand(
+            self.element.sketch,
+            SketchArrayMode.CIRCULAR,
+            self._params,
+            list(self._seed_entity_ids),
+        )

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/select_tool.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/sketcher/ui_gtk/tools/select_tool.py
@@ -177,6 +177,8 @@ class SelectTool(SnapMixin, SketchTool):
         if n_press == 2 and hit_type == "entity":
             logger.debug("Double-click on entity detected.")
             entity = cast(Entity, hit_obj)
+            if self.element.request_pattern_edit(entity):
+                return True
             if isinstance(entity, (Arc, Line, Circle)):
                 cmd = CreateOrEditConstraintCommand(
                     self.element.sketch, entity
@@ -416,6 +418,19 @@ class SelectTool(SnapMixin, SketchTool):
                 )
                 self.element.execute_command(cmd)
 
+        # Sync pattern radius dimensions to the dragged geometry: while
+        # dragging they were excluded from the solve so they must follow
+        # the members instead of snapping them back.
+        affected = set(self.element.selection.entity_ids)
+        if self.dragged_point_id is not None:
+            affected |= {
+                e.id
+                for e in self.element.sketch.registry.entities
+                if self.dragged_point_id in e.get_point_ids()
+            }
+        if affected:
+            self.element.sketch.sync_pattern_dimensions(affected)
+
         # Clear all drag-related state
         self.dragged_point_id = None
         self.drag_point_start_pos = None
@@ -582,6 +597,24 @@ class SelectTool(SnapMixin, SketchTool):
         mdx, mdy = ct_vec.transform_vector((ldx, ldy))
         return mdx, mdy
 
+    def _get_dragged_pattern_constraint_indices(self) -> set[int]:
+        """
+        Returns indices of pattern radius constraints that must yield
+        during a drag of pattern members. The radius dimension would
+        otherwise fight the radial component of the drag and distort
+        the array; instead it is excluded from the solve and follows
+        the geometry (synced on release).
+        """
+        sketch = self.element.sketch
+        dragged = set(self.element.selection.entity_ids)
+        if self.dragged_point_id is not None:
+            dragged |= {
+                e.id
+                for e in sketch.registry.entities
+                if self.dragged_point_id in e.get_point_ids()
+            }
+        return sketch.get_pattern_constraint_indices_for_entities(dragged)
+
     def _handle_point_drag(self, world_dx: float, world_dy: float):
         """Logic for dragging a single point."""
         if self.dragged_point_id is None or self.drag_point_start_pos is None:
@@ -660,9 +693,20 @@ class SelectTool(SnapMixin, SketchTool):
         max_hops = max(
             (d for d in self.drag_point_distances.values() if d > 0), default=1
         )
+        # Points of a pattern containing the dragged point's entities are
+        # exempt from holding: the linkage constraints must stay in full
+        # control so the whole array follows the drag smoothly.
+        owning_entities = {
+            e.id
+            for e in self.element.sketch.registry.entities
+            if self.dragged_point_id in e.get_point_ids()
+        }
+        excluded = self.element.sketch.get_pattern_points_for_entities(
+            owning_entities
+        )
         for pid, pos in self.drag_initial_positions.items():
             # Skip any point that is part of the actively dragged group.
-            if pid in dragged_group:
+            if pid in dragged_group or pid in excluded:
                 continue
 
             p = self._safe_get_point(pid)
@@ -679,8 +723,16 @@ class SelectTool(SnapMixin, SketchTool):
                     DragConstraint(pid, pos[0], pos[1], weight=weight)
                 )
 
+        excluded = self._get_dragged_pattern_constraint_indices()
+        logger.debug(
+            "PointDrag: pid=%s radius dims excluded: %r",
+            self.dragged_point_id,
+            sorted(excluded),
+        )
         self.element.sketch.solve(
-            extra_constraints=drag_constraints, update_constraint_status=False
+            extra_constraints=drag_constraints,
+            update_constraint_status=False,
+            excluded_constraints=excluded,
         )
         self.element.mark_dirty()
 
@@ -741,10 +793,16 @@ class SelectTool(SnapMixin, SketchTool):
                     )
                 )
 
-        # 3. Add weak "holding" constraints for all other points
+        # 3. Add weak "holding" constraints for all other points.
+        # Points belonging to a pattern that contains dragged geometry
+        # are exempt: their linkage constraints must stay in full
+        # control so the whole array follows the drag smoothly.
+        excluded = self.element.sketch.get_pattern_points_for_entities(
+            set(self.element.selection.entity_ids)
+        )
         hold_weight = 0.01
         for pid, pos in self.drag_initial_positions.items():
-            if pid in points_to_drag:
+            if pid in points_to_drag or pid in excluded:
                 continue
             p = self._safe_get_point(pid)
             if not p or p.fixed:
@@ -754,8 +812,16 @@ class SelectTool(SnapMixin, SketchTool):
             )
 
         # 4. Solve and update
+        excluded = self._get_dragged_pattern_constraint_indices()
+        logger.debug(
+            "EntityDrag: %d points dragged, radius dims excluded: %r",
+            len(points_to_drag),
+            sorted(excluded),
+        )
         self.element.sketch.solve(
-            extra_constraints=drag_constraints, update_constraint_status=False
+            extra_constraints=drag_constraints,
+            update_constraint_status=False,
+            excluded_constraints=excluded,
         )
         self.element.mark_dirty()
 

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_create_pattern_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_create_pattern_cmd.py
@@ -1,0 +1,239 @@
+import pytest
+from sketcher.core.commands import CreatePatternCommand
+from sketcher.core.constraints import RadiusConstraint, RotationalConstraint
+from sketcher.core.patterns import CircularPatternParams, SketchArrayMode
+from sketcher.core.sketch import Sketch
+
+
+@pytest.fixture
+def sketch_with_seed():
+    sketch = Sketch()
+    p0 = sketch.registry.add_point(0, 0)
+    p1 = sketch.registry.add_point(20, 0)
+    line = sketch.registry.add_line(p0, p1)
+    return sketch, line, p0, p1
+
+
+def make_params(count=4, radius=20.0, rotate=True):
+    return CircularPatternParams(
+        count=count,
+        total_angle_deg=360.0,
+        center=(0.0, 0.0),
+        radius=radius,
+        rotate_copies=rotate,
+    )
+
+
+def test_creates_copies_and_master(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+
+    entities = sketch.registry.entities
+    assert len(entities) == 5
+
+    copies = [e for e in entities if e.pattern_copy]
+    assert len(copies) == 3
+
+    # The master is a construction circle with a radius constraint.
+    master = next(e for e in entities if e.type == "circle")
+    assert master.construction is True
+
+    radius_constraints = [
+        c for c in sketch.constraints if isinstance(c, RadiusConstraint)
+    ]
+    assert len(radius_constraints) == 1
+    assert radius_constraints[0].entity_id == master.id
+
+
+def test_members_linked_to_template(sketch_with_seed):
+    """Copies carry rotational constraints back to the template member."""
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+
+    rotational = [
+        c for c in sketch.constraints if isinstance(c, RotationalConstraint)
+    ]
+    # Two template points x three copies.
+    assert len(rotational) == 6
+
+    template_pids = set(
+        CreatePatternCommand.collect_seed_point_ids(sketch.registry, [line])
+    )
+    master = next(e for e in sketch.registry.entities if e.type == "circle")
+    for c in rotational:
+        assert c.p1 in template_pids
+        assert c.center == master.center_idx
+
+
+def test_deleting_a_member_keeps_others_in_place(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+    pattern = cmd.pattern
+    assert pattern is not None
+    positions_before = sorted(
+        (round(p.x, 3), round(p.y, 3)) for p in sketch.registry.points
+    )
+
+    victim = pattern.living_entity_ids(sketch.registry)[3]
+    sketch.registry.remove_entities_by_id([victim])
+    sketch.prune_patterns()
+
+    assert len(pattern.living_entity_ids(sketch.registry)) == 3
+    # The emptied member group is dropped by pruning.
+    assert len(pattern.members) == 3
+    positions_after = sorted(
+        (round(p.x, 3), round(p.y, 3)) for p in sketch.registry.points
+    )
+    # Survivors did not move: only the deleted member is gone.
+    removed = set(positions_before) - set(positions_after)
+    assert len(removed) <= 2
+
+
+def test_registers_pattern_definition(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(count=5), [line]
+    )
+    cmd.execute()
+
+    assert len(sketch.patterns) == 1
+    pattern = sketch.patterns[0]
+    assert pattern.count == 5
+    assert [slot for slot, _eids in pattern.members] == list(range(5))
+    assert all(len(eids) == 1 for _s, eids in pattern.members)
+    flat = [eid for _s, eids in pattern.members for eid in eids]
+    assert cmd.guide_circle_id == pattern.guide_circle_id
+    assert registry_has_all(sketch, flat)
+
+
+def registry_has_all(sketch, entity_ids):
+    return all(
+        sketch.registry.get_entity(eid) is not None for eid in entity_ids
+    )
+
+
+def test_copy_positions_are_rotated(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+
+    positions = sorted(
+        (round(p.x, 6), round(p.y, 6)) for p in sketch.registry.points
+    )
+    assert (20.0, 0.0) in positions
+    assert (0.0, 20.0) in positions
+    assert (-20.0, 0.0) in positions
+    assert (round(-0.0, 6), -20.0) in positions or (0.0, -20.0) in positions
+
+
+def test_apply_does_not_move_geometry(sketch_with_seed):
+    """Creating the pattern must not shift existing geometry."""
+    sketch, line, _p0, _p1 = sketch_with_seed
+    before = [(p.id, p.x, p.y) for p in sketch.registry.points]
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+
+    for pid, x, y in before:
+        pt = sketch.registry.get_point(pid)
+        assert (pt.x, pt.y) == (x, y)
+
+
+def test_translate_mode_bakes_static_copies(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    params = CircularPatternParams(
+        count=3,
+        total_angle_deg=180.0,
+        center=(0.0, 0.0),
+        rotate_copies=False,
+    )
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, params, [line]
+    )
+    cmd.execute()
+    assert len([e for e in sketch.registry.entities if e.pattern_copy]) == 2
+
+
+def test_undo_removes_everything_including_pattern(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    num_points_before = len(sketch.registry.points)
+    num_entities_before = len(sketch.registry.entities)
+
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+    assert len(sketch.registry.entities) == num_entities_before + 4
+    assert len(sketch.patterns) == 1
+
+    cmd.undo()
+    assert len(sketch.registry.entities) == num_entities_before
+    assert len(sketch.registry.points) == num_points_before
+    assert sketch.constraints == []
+    assert sketch.patterns == []
+
+
+def test_redo_restores_pattern(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+    cmd.undo()
+    cmd.execute()
+
+    assert len([e for e in sketch.registry.entities if e.pattern_copy]) == 3
+    assert len(sketch.patterns) == 1
+
+
+def test_serialization_round_trip_preserves_pattern(sketch_with_seed):
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(count=3), [line]
+    )
+    cmd.execute()
+
+    restored = Sketch.from_dict(sketch.to_dict())
+    copies = [e for e in restored.registry.entities if e.pattern_copy]
+    assert len(copies) >= 2
+    assert len(restored.patterns) == 1
+    assert restored.patterns[0].count == 3
+
+
+def test_empty_selection_creates_nothing():
+    sketch = Sketch()
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), []
+    )
+    cmd.execute()
+    assert cmd.created_entity_ids == []
+    assert sketch.registry.entities == []
+    assert sketch.patterns == []
+
+
+def test_solver_keeps_geometry_stable_after_apply(sketch_with_seed):
+    """Solving after creation must not visibly move geometry."""
+    sketch, line, _p0, _p1 = sketch_with_seed
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+
+    before = [(p.id, p.x, p.y) for p in sketch.registry.points]
+    sketch.solve()
+    for pid, x, y in before:
+        pt = sketch.registry.get_point(pid)
+        assert pt.x == pytest.approx(x, abs=1e-3)
+        assert pt.y == pytest.approx(y, abs=1e-3)

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_edit_pattern_cmd.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/commands/test_edit_pattern_cmd.py
@@ -1,0 +1,344 @@
+import math
+
+import pytest
+from sketcher.core.commands import CreatePatternCommand, EditPatternCommand
+from sketcher.core.constraints import RadiusConstraint, RotationalConstraint
+from sketcher.core.params import ParameterContext
+from sketcher.core.patterns import CircularPatternParams, SketchArrayMode
+from sketcher.core.sketch import Sketch
+
+
+def make_params(count=6, radius=40.0, center=(0.0, 0.0), rotate=True):
+    return CircularPatternParams(
+        count=count,
+        total_angle_deg=360.0,
+        center=center,
+        radius=radius,
+        rotate_copies=rotate,
+    )
+
+
+@pytest.fixture
+def sketch_with_pattern():
+    sketch = Sketch()
+    p0 = sketch.registry.add_point(30, 0)
+    p1 = sketch.registry.add_point(50, 0)
+    line = sketch.registry.add_line(p0, p1)
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+    return sketch, cmd.pattern
+
+
+def count_circles(sketch):
+    return [e for e in sketch.registry.entities if e.type == "circle"]
+
+
+def member_count(sketch, pattern):
+    return len(pattern.living_members(sketch.registry))
+
+
+def test_edit_fills_missing_slots_only(sketch_with_pattern):
+    """With unchanged parameters, surviving members stay untouched."""
+    sketch, pattern = sketch_with_pattern
+    template_eids = pattern.living_members(sketch.registry)[0][1]
+
+    # Delete two non-template members.
+    victims = [eid for slot, eids in pattern.members[1:3] for eid in eids]
+    sketch.registry.remove_entities_by_id(victims)
+    sketch.prune_patterns()
+    assert member_count(sketch, pattern) == 4
+    survivors_before = [
+        (slot, eids)
+        for slot, eids in pattern.living_members(sketch.registry)[1:]
+    ]
+
+    edit_cmd = EditPatternCommand(sketch, pattern, make_params())
+    edit_cmd.execute()
+
+    living = pattern.living_members(sketch.registry)
+    assert len(living) == 6
+    # The template and surviving copies kept their entity IDs (they
+    # were not regenerated).
+    assert living[0][1] == template_eids
+    surviving_flat = {eid for _s, eids in survivors_before for eid in eids}
+    living_flat = {eid for _s, eids in living[1:] for eid in eids}
+    assert surviving_flat <= living_flat
+
+    # No duplicate masters were created.
+    assert len(count_circles(sketch)) == 1
+    radius_constraints = [
+        c for c in sketch.constraints if isinstance(c, RadiusConstraint)
+    ]
+    assert len(radius_constraints) == 1
+
+
+def test_edit_full_regen_when_template_deleted(sketch_with_pattern):
+    """Without the template member, the array is fully re-distributed."""
+    sketch, pattern = sketch_with_pattern
+    first_two = [eid for slot, eids in pattern.members[:2] for eid in eids]
+    sketch.registry.remove_entities_by_id(first_two)
+    sketch.prune_patterns()
+    assert member_count(sketch, pattern) == 4
+
+    EditPatternCommand(sketch, pattern, make_params()).execute()
+
+    living = pattern.living_members(sketch.registry)
+    assert len(living) == 6
+    assert [slot for slot, _e in living] == list(range(6))
+    assert len(count_circles(sketch)) == 1
+
+
+def test_edit_repeated_edits_do_not_duplicate_masters(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    for i in range(3):
+        edit_cmd = EditPatternCommand(
+            sketch, pattern, make_params(count=6 + i)
+        )
+        edit_cmd.execute()
+
+    assert len(count_circles(sketch)) == 1
+    radius_constraints = [
+        c for c in sketch.constraints if isinstance(c, RadiusConstraint)
+    ]
+    assert len(radius_constraints) == 1
+    assert member_count(sketch, pattern) == 8
+
+
+def test_edit_updates_slots_consistently(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    edit_cmd = EditPatternCommand(sketch, pattern, make_params(count=5))
+    edit_cmd.execute()
+
+    assert sorted(
+        slot for slot, _e in pattern.living_members(sketch.registry)
+    ) == list(range(5))
+    assert len(pattern.members) == 5
+
+
+def test_multi_entity_seed_stays_grouped():
+    """
+    Regression: a multi-entity seed must regenerate as whole shapes.
+    Deleting fragments of one member must not turn its leftovers into
+    a template that produces broken partial copies.
+    """
+    sketch = Sketch()
+    # Square seed: 4 entities.
+    corners = [
+        sketch.registry.add_point(x, y)
+        for x, y in ((30, 0), (50, 0), (50, 20), (30, 20))
+    ]
+    seed_ids = [
+        sketch.registry.add_line(corners[i], corners[(i + 1) % 4])
+        for i in range(4)
+    ]
+    cmd = CreatePatternCommand(
+        sketch,
+        SketchArrayMode.CIRCULAR,
+        make_params(count=4),
+        list(seed_ids),
+    )
+    cmd.execute()
+    pattern = cmd.pattern
+    assert pattern is not None
+
+    # Every member is a 4-entity group.
+    assert all(len(eids) == 4 for _s, eids in pattern.members)
+
+    # Delete one full copy and ONE LINE of another copy (fragmentation).
+    _slot1, group1 = pattern.members[1]
+    full_victim = list(group1)
+    _slot2, group2 = pattern.members[2]
+    fragment_victim = group2[0]
+    sketch.registry.remove_entities_by_id(full_victim + [fragment_victim])
+    sketch.prune_patterns()
+    assert len(pattern.members) == 3
+    # The damaged group keeps its three surviving lines.
+    damaged = next(eids for _s, eids in pattern.members if len(eids) == 3)
+    assert set(damaged) == set(group2) - {fragment_victim}
+
+    EditPatternCommand(sketch, pattern, make_params(count=4)).execute()
+
+    living = pattern.living_members(sketch.registry)
+    assert len(living) == 4
+    # No fragmentation: every regenerated member is a complete copy of
+    # whatever the template member now is (the damaged 3-line shape),
+    # never a mix of single leftover lines.
+    sizes = [len(eids) for _slot, eids in living]
+    assert len(set(sizes)) == 1
+
+    # No collapsed duplicates among MEMBER geometry: every member
+    # occupies a distinct location.
+    registry = sketch.registry
+    member_points = set()
+    for eid in pattern.living_entity_ids(registry):
+        entity = registry.get_entity(eid)
+        if entity is not None:
+            member_points.update(entity.get_point_ids())
+    positions = sorted(
+        (
+            round(registry.get_point(pid).x, 3),
+            round(registry.get_point(pid).y, 3),
+        )
+        for pid in member_points
+    )
+    assert len(positions) == len(set(positions))
+
+
+def test_edit_moves_master_geometry(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    new_params = make_params(count=6, center=(10.0, 5.0), radius=30.0)
+    edit_cmd = EditPatternCommand(sketch, pattern, new_params)
+    edit_cmd.execute()
+
+    circle = sketch.registry.get_entity(pattern.guide_circle_id)
+    center = sketch.registry.get_point(circle.center_idx)
+    radius_pt = sketch.registry.get_point(circle.radius_pt_idx)
+    assert (center.x, center.y) == pytest.approx((10.0, 5.0))
+    assert math.hypot(radius_pt.x - center.x, radius_pt.y - center.y) == (
+        pytest.approx(30.0)
+    )
+
+    rc = next(
+        c
+        for c in sketch.constraints
+        if isinstance(c, RadiusConstraint) and c.entity_id == circle.id
+    )
+    assert rc.value == pytest.approx(30.0)
+
+
+def test_edit_undo_restores_previous_state(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    members_before = list(pattern.members)
+    points_before = sorted((p.x, p.y) for p in sketch.registry.points)
+
+    edit_cmd = EditPatternCommand(
+        sketch, pattern, make_params(count=8, center=(5.0, 5.0), radius=20.0)
+    )
+    edit_cmd.execute()
+    assert member_count(sketch, pattern) == 8
+
+    edit_cmd.undo()
+    assert pattern.members == members_before
+    assert member_count(sketch, pattern) == 6
+    points_after = sorted((p.x, p.y) for p in sketch.registry.points)
+    assert points_after == pytest.approx(points_before)
+
+
+def test_edit_redo_reapplies_changes(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    edit_cmd = EditPatternCommand(sketch, pattern, make_params(count=9))
+    edit_cmd.execute()
+    assert member_count(sketch, pattern) == 9
+
+    edit_cmd.undo()
+    assert member_count(sketch, pattern) == 6
+
+    edit_cmd.execute()
+    assert member_count(sketch, pattern) == 9
+    # Still exactly one master after undo/redo cycles.
+    assert len(count_circles(sketch)) == 1
+
+
+def test_edit_keeps_master_alive_while_members_deleted(sketch_with_pattern):
+    """Deleting all members must keep the definition (master survives)."""
+    sketch, pattern = sketch_with_pattern
+    all_ids = [eid for _slot, eids in pattern.members for eid in eids]
+    sketch.registry.remove_entities_by_id(all_ids)
+    sketch.prune_patterns()
+
+    assert len(sketch.patterns) == 1
+    assert pattern.living_members(sketch.registry) == []
+
+
+def test_deleting_master_dissolves_pattern(sketch_with_pattern):
+    sketch, pattern = sketch_with_pattern
+    sketch.registry.remove_entities_by_id([pattern.guide_circle_id])
+    sketch.prune_patterns()
+
+    assert sketch.patterns == []
+
+
+def test_edited_copies_are_linked_to_template(sketch_with_pattern):
+    """Newly created copies carry fresh rotational constraints."""
+    sketch, pattern = sketch_with_pattern
+    template_group = pattern.living_members(sketch.registry)[0][1]
+
+    # Delete everything except the template, then regenerate.
+    stale = [
+        eid
+        for _slot, eids in pattern.members
+        for eid in eids
+        if eids != template_group
+    ]
+    sketch.registry.remove_entities_by_id(stale)
+    sketch.prune_patterns()
+
+    EditPatternCommand(sketch, pattern, make_params()).execute()
+
+    rotational = [
+        c for c in sketch.constraints if isinstance(c, RotationalConstraint)
+    ]
+    assert len(rotational) > 0
+    template_pids = set(
+        CreatePatternCommand.collect_seed_point_ids(
+            sketch.registry, template_group
+        )
+    )
+    for c in rotational:
+        assert c.p1 in template_pids
+
+
+def test_edit_leaves_zero_residual_before_any_solve(sketch_with_pattern):
+    """
+    Regression: editing used to teleport the master center while members
+    stayed behind, leaving huge constraint residuals for the solver to
+    "repair" (which collapsed the geometry). The command must leave the
+    sketch fully consistent immediately after execute.
+    """
+    sketch, pattern = sketch_with_pattern
+    edit_cmd = EditPatternCommand(
+        sketch,
+        pattern,
+        make_params(count=9, center=(15.0, -10.0), radius=55.0),
+    )
+    edit_cmd.execute()
+
+    ctx = ParameterContext()
+    worst_rot = max(
+        (
+            max(abs(v) for v in c.error(sketch.registry, ctx))
+            for c in sketch.constraints
+            if isinstance(c, RotationalConstraint)
+        ),
+        default=0.0,
+    )
+    assert worst_rot < 1e-6
+
+    pins = [
+        c
+        for c in sketch.constraints
+        if type(c).__name__ == "PointOnLineConstraint"
+    ]
+    for pin in pins:
+        err = pin.error(sketch.registry, ctx)
+        err = err if isinstance(err, (list, tuple)) else [err]
+        assert max(abs(v) for v in err) < 1e-6
+
+    radius_constraints = [
+        c for c in sketch.constraints if isinstance(c, RadiusConstraint)
+    ]
+    for rc in radius_constraints:
+        assert abs(rc.error(sketch.registry, ctx)) < 1e-6
+
+
+def test_empty_selection_creates_nothing():
+    sketch = Sketch()
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), []
+    )
+    cmd.execute()
+    assert cmd.created_entity_ids == []
+    assert sketch.registry.entities == []
+    assert sketch.patterns == []

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/constraints/test_rotational_constraint.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/constraints/test_rotational_constraint.py
@@ -1,0 +1,105 @@
+import math
+
+import pytest
+from sketcher.core.constraints import RotationalConstraint
+from sketcher.core.params import ParameterContext
+from sketcher.core.registry import EntityRegistry
+
+
+@pytest.fixture
+def setup_env():
+    reg = EntityRegistry()
+    params = ParameterContext()
+    return reg, params
+
+
+def test_error_zero_when_satisfied(setup_env):
+    reg, params = setup_env
+    center = reg.add_point(0, 0)
+    source = reg.add_point(10, 0)
+    target = reg.add_point(0, 10)
+
+    c = RotationalConstraint(center, source, target, math.pi / 2)
+    assert c.error(reg, params) == pytest.approx([0.0, 0.0])
+
+
+def test_error_nonzero_when_violated(setup_env):
+    reg, params = setup_env
+    center = reg.add_point(0, 0)
+    source = reg.add_point(10, 0)
+    target = reg.add_point(5, 5)
+
+    c = RotationalConstraint(center, source, target, math.pi / 2)
+    err_x, err_y = c.error(reg, params)
+    assert err_x == pytest.approx(5.0)
+    assert err_y == pytest.approx(-5.0)
+
+
+def test_rotation_about_offset_center(setup_env):
+    reg, params = setup_env
+    center = reg.add_point(100, -50)
+    source = reg.add_point(110, -50)
+    angle = math.radians(30)
+    target = reg.add_point(
+        100 + 10 * math.cos(angle), -50 + 10 * math.sin(angle)
+    )
+
+    c = RotationalConstraint(center, source, target, angle)
+    assert c.error(reg, params) == pytest.approx([0.0, 0.0])
+
+
+def test_gradient_matches_finite_difference(setup_env):
+    reg, _ = setup_env
+    params = ParameterContext()
+    center = reg.add_point(3, -2)
+    source = reg.add_point(12.0, 4.0)
+    target = reg.add_point(-6.0, 9.0)
+
+    c = RotationalConstraint(center, source, target, math.radians(37))
+
+    eps = 1e-7
+    for row in range(2):
+        for pid in (source, target, center):
+            pt = reg.get_point(pid)
+            for axis in (0, 1):
+                attr = "x" if axis == 0 else "y"
+                original = getattr(pt, attr)
+                setattr(pt, attr, original + eps)
+                e_plus = c.error(reg, params)[row]
+                setattr(pt, attr, original - eps)
+                e_minus = c.error(reg, params)[row]
+                setattr(pt, attr, original)
+                fd = (e_plus - e_minus) / (2 * eps)
+                analytic = c.gradient(reg, params)[pid][row][axis]
+                assert fd == pytest.approx(analytic, abs=1e-4)
+
+
+def test_serialization_round_trip(setup_env):
+    _reg, _params = setup_env
+    c = RotationalConstraint(
+        center=1, p1=2, p2=3, value=math.radians(45), user_visible=False
+    )
+    data = c.to_dict()
+    restored = RotationalConstraint.from_dict(data)
+    assert restored.center == 1
+    assert restored.p1 == 2
+    assert restored.p2 == 3
+    assert restored.value == pytest.approx(c.value)
+    assert restored.user_visible is False
+
+
+def test_expression_value_update(setup_env):
+    _reg, _params = setup_env
+    c = RotationalConstraint(0, 1, 2, value=0.0, expression="pi / 3")
+    c.update_from_context({"pi": math.pi})
+    assert c.value == pytest.approx(math.pi / 3)
+
+
+def test_deleted_points_are_depended_on():
+    """The generic constraint cleanup must catch this constraint via
+    depends_on_points (attribute names p1/p2/center)."""
+    c = RotationalConstraint(center=7, p1=8, p2=9, value=1.0)
+    assert c.depends_on_points({8})
+    assert c.depends_on_points({9})
+    assert c.depends_on_points({7})
+    assert not c.depends_on_points({10})

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/test_pattern_scenarios.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/test_pattern_scenarios.py
@@ -1,0 +1,365 @@
+"""
+End-to-end scenario tests simulating real UI flows for patterns:
+create, delete individual members, re-open via double-click lookup,
+edit/regenerate, undo/redo, and solver stability.
+"""
+
+import math
+
+import pytest
+from sketcher.core.commands import (
+    CreatePatternCommand,
+    EditPatternCommand,
+    RemoveItemsCommand,
+)
+from sketcher.core.constraints import (
+    DragConstraint,
+    PointOnLineConstraint,
+    RadiusConstraint,
+    RotationalConstraint,
+)
+from sketcher.core.entities import Circle
+from sketcher.core.patterns import (
+    CircularPatternParams,
+    SketchArrayMode,
+    find_pattern_for_entity,
+)
+from sketcher.core.sketch import Sketch
+
+
+def make_params(count=6, radius=40.0, center=(0.0, 0.0)):
+    return CircularPatternParams(
+        count=count,
+        total_angle_deg=360.0,
+        center=center,
+        radius=radius,
+        rotate_copies=True,
+    )
+
+
+def ui_delete(sketch, entity_ids):
+    """Deletes like the DeleteTool: dependency-based removal."""
+    points, entities, constraints = RemoveItemsCommand.calculate_dependencies(
+        sketch,
+        SimpleNamespaceSelection(set(entity_ids)),
+    )
+    cmd = RemoveItemsCommand(
+        sketch,
+        "",
+        points=points,
+        entities=entities,
+        constraints=constraints,
+    )
+    cmd.execute()
+
+
+class SimpleNamespaceSelection:
+    def __init__(self, entity_ids):
+        self.entity_ids = entity_ids
+        self.point_ids = set()
+        self.constraint_idx = None
+
+
+@pytest.fixture
+def app_flow():
+    """Sketch with one array created through the full create flow."""
+    sketch = Sketch()
+    p0 = sketch.registry.add_point(30, 0)
+    p1 = sketch.registry.add_point(50, 0)
+    line = sketch.registry.add_line(p0, p1)
+
+    cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, make_params(), [line]
+    )
+    cmd.execute()
+    sketch.solve()
+    return sketch, cmd.pattern
+
+
+def members_on_circle(sketch, pattern):
+    """All living members' geometry sits at the guide circle radius."""
+    circle = sketch.registry.get_entity(pattern.guide_circle_id)
+    assert isinstance(circle, Circle)
+    center = sketch.registry.get_point(circle.center_idx)
+    radius_pt = sketch.registry.get_point(circle.radius_pt_idx)
+    radius = math.hypot(radius_pt.x - center.x, radius_pt.y - center.y)
+
+    pins = [
+        c
+        for c in sketch.constraints
+        if isinstance(c, PointOnLineConstraint)
+        and c.shape_id == pattern.guide_circle_id
+    ]
+    assert pins, "no members are anchored to the guide circle"
+    for pin in pins:
+        pt = sketch.registry.get_point(pin.point_id)
+        d = math.hypot(pt.x - center.x, pt.y - center.y)
+        assert d == pytest.approx(radius, abs=1e-3)
+
+
+def test_created_array_is_fully_registered(app_flow):
+    sketch, pattern = app_flow
+    assert len(sketch.patterns) == 1
+    assert (
+        find_pattern_for_entity(sketch.patterns, pattern.guide_circle_id)
+        is pattern
+    )
+    assert len(pattern.living_entity_ids(sketch.registry)) == 6
+    assert [slot for slot, _e in pattern.members] == list(range(6))
+    members_on_circle(sketch, pattern)
+
+
+def test_dragging_member_keeps_circle_anchored(app_flow):
+    """
+    After an incremental member drag (solver per frame, like the real
+    UI) the system settles with the guide circle still crossing every
+    member and the pattern definition intact.
+    """
+    sketch, pattern = app_flow
+    template_id = pattern.living_entity_ids(sketch.registry)[0]
+    pids = CreatePatternCommand.collect_seed_point_ids(
+        sketch.registry, [template_id]
+    )
+    for _step in range(10):
+        for pid in pids:
+            sketch.registry.get_point(pid).x += 2.0
+        sketch.solve()
+
+    members_on_circle(sketch, pattern)
+    assert len(pattern.living_entity_ids(sketch.registry)) == 6
+    assert (
+        find_pattern_for_entity(sketch.patterns, pattern.guide_circle_id)
+        is pattern
+    )
+
+
+def test_radius_dimension_resizes_the_array(app_flow):
+    """Editing the radius constraint value re-sizes the whole array."""
+    sketch, pattern = app_flow
+    circle = sketch.registry.get_entity(pattern.guide_circle_id)
+    rc = next(
+        c
+        for c in sketch.constraints
+        if isinstance(c, RadiusConstraint) and c.entity_id == circle.id
+    )
+    rc.value = 60.0
+    sketch.solve()
+
+    members_on_circle(sketch, pattern)
+    # The anchored reference point of the template was carried to the
+    # new radius.
+    pin = next(
+        c
+        for c in sketch.constraints
+        if isinstance(c, PointOnLineConstraint)
+        and c.shape_id == pattern.guide_circle_id
+    )
+    pt = sketch.registry.get_point(pin.point_id)
+    center = sketch.registry.get_point(circle.center_idx)
+    assert math.hypot(pt.x - center.x, pt.y - center.y) == pytest.approx(
+        60.0, abs=1e-3
+    )
+
+
+def test_deleting_one_member_keeps_the_rest(app_flow):
+    sketch, pattern = app_flow
+    victims = pattern.living_entity_ids(sketch.registry)[2:3]
+    before = set(pattern.living_entity_ids(sketch.registry))
+
+    ui_delete(sketch, victims)
+
+    living = set(pattern.living_entity_ids(sketch.registry))
+    assert living == before - set(victims)
+    # Definition survives; double-click lookup still works.
+    assert (
+        find_pattern_for_entity(sketch.patterns, pattern.guide_circle_id)
+        is pattern
+    )
+    members_on_circle(sketch, pattern)
+
+
+def test_edit_after_deletion_recreates_members(app_flow):
+    sketch, pattern = app_flow
+    victims = pattern.living_entity_ids(sketch.registry)[1:4]
+    ui_delete(sketch, victims)
+    assert len(pattern.living_entity_ids(sketch.registry)) == 3
+
+    edit_cmd = EditPatternCommand(sketch, pattern, make_params())
+    edit_cmd.execute()
+    sketch.solve()
+
+    assert len(pattern.living_entity_ids(sketch.registry)) == 6
+    members_on_circle(sketch, pattern)
+
+    # Exactly one master, still found by double-click.
+    circles = [e for e in sketch.registry.entities if e.type == "circle"]
+    assert len(circles) == 1
+    assert (
+        find_pattern_for_entity(sketch.patterns, pattern.guide_circle_id)
+        is pattern
+    )
+
+
+def test_repeated_edit_cycles_are_stable(app_flow):
+    sketch, pattern = app_flow
+    for count in (8, 5, 6):
+        EditPatternCommand(sketch, pattern, make_params(count=count)).execute()
+        sketch.solve()
+        assert len(pattern.living_entity_ids(sketch.registry)) == count
+
+    circles = [e for e in sketch.registry.entities if e.type == "circle"]
+    assert len(circles) == 1
+    radius_constraints = [
+        c for c in sketch.constraints if type(c).__name__ == "RadiusConstraint"
+    ]
+    assert len(radius_constraints) == 1
+
+
+def test_gap_fill_places_members_at_their_slot_angles(app_flow):
+    """
+    Regression: regenerated members must be constrained at their own
+    slot's angle, not the first placement. Otherwise two copies collapse
+    onto one position when the solver runs.
+    """
+    sketch, pattern = app_flow
+    # Delete members in slots 1 and 2 (non-template).
+    victims = [eid for _slot, eids in pattern.members[1:3] for eid in eids]
+    ui_delete(sketch, victims)
+
+    EditPatternCommand(sketch, pattern, make_params()).execute()
+    sketch.solve()
+
+    # All six members must sit at distinct slot angles on the circle.
+    step = 60.0
+    circle = sketch.registry.get_entity(pattern.guide_circle_id)
+    center = sketch.registry.get_point(circle.center_idx)
+
+    angles = []
+    for eid in pattern.living_entity_ids(sketch.registry):
+        entity = sketch.registry.get_entity(eid)
+        for pid in entity.get_point_ids():
+            pt = sketch.registry.get_point(pid)
+            # The template is radial: both of its points share a slot
+            # angle, and so does every rotated copy.
+            angles.append(
+                round(
+                    math.degrees(math.atan2(pt.y - center.y, pt.x - center.x))
+                    / step
+                )
+                * step
+                % 360.0
+            )
+
+    expected = sorted(step * j for j in range(6))
+    seen_slots = sorted(set(angles))
+    assert seen_slots == expected
+    # Every slot holds exactly one member (two points each).
+    assert len(angles) == 12
+    assert sorted(angles) == sorted(expected + expected)
+
+
+def test_pattern_points_helper_scopes_to_touched_pattern(app_flow):
+    sketch, pattern = app_flow
+    member_ids = set(pattern.living_entity_ids(sketch.registry))
+
+    # Dragging an unrelated entity yields no exempt points.
+    sp0 = sketch.registry.add_point(200, 200)
+    sp1 = sketch.registry.add_point(210, 210)
+    stranger = sketch.registry.add_line(sp0, sp1)
+    assert sketch.get_pattern_points_for_entities({stranger}) == set()
+
+    # Dragging a member exempts all member points plus master points.
+    first_member = min(member_ids)
+    points = sketch.get_pattern_points_for_entities({first_member})
+    expected = set()
+    for eid in member_ids:
+        entity = sketch.registry.get_entity(eid)
+        expected.update(entity.get_point_ids())
+    guide = sketch.registry.get_entity(pattern.guide_circle_id)
+    expected.update(guide.get_point_ids())
+    assert points == expected
+
+
+def test_radial_drag_does_not_distort_the_array(app_flow):
+    """
+    Regression: dragging a member radially used to fight the fixed
+    radius dimension, violating constraints mid-drag and collapsing
+    the geometry on release. The dimension now yields during the drag
+    (excluded from the solve) and follows the geometry afterwards.
+    """
+    sketch, pattern = app_flow
+    template_id = pattern.living_entity_ids(sketch.registry)[0]
+    pids = CreatePatternCommand.collect_seed_point_ids(
+        sketch.registry, [template_id]
+    )
+
+    # Simulate a substantial radial drag: strong drag targets (like
+    # _handle_entity_drag) solved per frame with the pattern's radius
+    # constraint excluded.
+    excluded = sketch.get_pattern_constraint_indices_for_entities(
+        {template_id}
+    )
+    assert excluded, "radius dimension was not excluded"
+
+    for frame in range(10):
+        extra = [
+            DragConstraint(pid, p.x + 3.0, p.y, weight=1.0)
+            for pid, p in (
+                (pid, sketch.registry.get_point(pid)) for pid in pids
+            )
+        ]
+        sketch.solve(
+            extra_constraints=extra,
+            update_constraint_status=False,
+            excluded_constraints=excluded,
+        )
+
+    # Mid-drag: every member stays congruent (no distortion) and sits
+    # on the guide circle at distinct slot angles.
+    members_on_circle(sketch, pattern)
+
+    # Release: dimensions follow geometry; final solve keeps everything
+    # consistent instead of snapping back.
+    sketch.sync_pattern_dimensions({template_id})
+    sketch.solve()
+
+    members_on_circle(sketch, pattern)
+    assert len(pattern.living_entity_ids(sketch.registry)) == 6
+    circle = sketch.registry.get_entity(pattern.guide_circle_id)
+    center = sketch.registry.get_point(circle.center_idx)
+    radius_pt = sketch.registry.get_point(circle.radius_pt_idx)
+    new_radius = math.hypot(radius_pt.x - center.x, radius_pt.y - center.y)
+    assert new_radius > 45.0  # grew substantially with the drag
+
+    # Congruence: all copies still rigid rotations of the template.
+    for c in sketch.constraints:
+        if isinstance(c, RotationalConstraint):
+            src = sketch.registry.get_point(c.p1)
+            dst = sketch.registry.get_point(c.p2)
+            ctr = sketch.registry.get_point(c.center)
+            ca, sa = math.cos(c.value), math.sin(c.value)
+            dx, dy = src.x - ctr.x, src.y - ctr.y
+            ex = dst.x - (ctr.x + ca * dx - sa * dy)
+            ey = dst.y - (ctr.y + sa * dx + ca * dy)
+            assert math.hypot(ex, ey) < 1e-3
+
+
+def test_edit_undo_restores_geometry_and_membership(app_flow):
+    sketch, pattern = app_flow
+    ui_delete(
+        sketch,
+        [
+            eid
+            for _slot, eids in pattern.living_members(sketch.registry)[1:4]
+            for eid in eids
+        ],
+    )
+    members_before = list(pattern.members)
+
+    edit_cmd = EditPatternCommand(sketch, pattern, make_params())
+    edit_cmd.execute()
+    assert len(pattern.living_entity_ids(sketch.registry)) == 6
+
+    edit_cmd.undo()
+    assert pattern.members == members_before
+    assert len(pattern.living_members(sketch.registry)) == 3

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/test_pattern_strategies.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/core/test_pattern_strategies.py
@@ -1,0 +1,211 @@
+import math
+from typing import cast
+
+import pytest
+from sketcher.core.constraints import RotationalConstraint
+from sketcher.core.patterns import (
+    CircularPatternParams,
+    CircularPatternStrategy,
+    InstancePlacement,
+    PlacementKind,
+    SketchArrayMode,
+    find_pattern_for_entity,
+    make_pattern_strategy,
+)
+from sketcher.core.patterns.definition import PatternDefinition
+
+
+def test_factory_returns_circular_strategy():
+    params = CircularPatternParams()
+    strategy = make_pattern_strategy(SketchArrayMode.CIRCULAR, params)
+    assert isinstance(strategy, CircularPatternStrategy)
+    assert strategy.needs_center_point is True
+
+
+def test_factory_rejects_unknown_mode():
+    bogus_mode = cast(SketchArrayMode, "bogus")
+    with pytest.raises(ValueError):
+        make_pattern_strategy(bogus_mode, CircularPatternParams())
+
+
+def test_full_circle_rotation_placements():
+    params = CircularPatternParams(
+        count=4, total_angle_deg=360.0, center=(0.0, 0.0), rotate_copies=True
+    )
+    strategy = CircularPatternStrategy(params)
+    placements = strategy.calculate_placements((5.0, 0.0))
+    assert len(placements) == 3
+    angles = [p.angle for p in placements]
+    assert angles == [
+        pytest.approx(math.pi / 2),
+        pytest.approx(math.pi),
+        pytest.approx(3 * math.pi / 2),
+    ]
+    assert all(p.kind == PlacementKind.ROTATION for p in placements)
+
+
+def test_partial_arc_placements():
+    params = CircularPatternParams(
+        count=3, total_angle_deg=90.0, center=(0.0, 0.0), rotate_copies=True
+    )
+    strategy = CircularPatternStrategy(params)
+    placements = strategy.calculate_placements((0.0, 0.0))
+    angles = [math.degrees(p.angle) for p in placements]
+    assert angles == [pytest.approx(30.0), pytest.approx(60.0)]
+
+
+def test_translate_mode_placements():
+    params = CircularPatternParams(
+        count=3,
+        total_angle_deg=180.0,
+        center=(0.0, 0.0),
+        rotate_copies=False,
+    )
+    strategy = CircularPatternStrategy(params)
+    seed_center = (10.0, 0.0)
+    placements = strategy.calculate_placements(seed_center)
+    assert all(p.kind == PlacementKind.TRANSLATION for p in placements)
+
+    # First copy: seed center rotated by the 60 deg step around origin.
+    dx, dy = placements[0].delta
+    assert (seed_center[0] + dx, seed_center[1] + dy) == (
+        pytest.approx(5.0),
+        pytest.approx(10.0 * math.sin(math.radians(60))),
+    )
+
+
+def test_placement_transform_point():
+    placement = InstancePlacement(
+        kind=PlacementKind.ROTATION,
+        angle=math.pi / 2,
+        center=(1.0, 1.0),
+    )
+    x, y = placement.transform_point(2.0, 1.0)
+    assert x == pytest.approx(1.0)
+    assert y == pytest.approx(2.0)
+
+    translation = InstancePlacement(
+        kind=PlacementKind.TRANSLATION, delta=(3.0, -4.0)
+    )
+    x, y = translation.transform_point(2.0, 1.0)
+    assert (x, y) == (5.0, -3.0)
+
+
+def test_linkage_constraints_rotate_mode():
+    params = CircularPatternParams(
+        count=3,
+        total_angle_deg=360.0,
+        center=(0.0, 0.0),
+        rotate_copies=True,
+    )
+    strategy = CircularPatternStrategy(params)
+    instances = [(1, {11: 21, 12: 22}), (2, {11: 31, 12: 32})]
+    constraints = strategy.build_linkage_constraints(instances, 99)
+    assert len(constraints) == 4
+    step = math.radians(120)
+    values = sorted(c.value for c in constraints)
+    assert values == pytest.approx(sorted([step, step, 2 * step, 2 * step]))
+    for c in constraints:
+        assert isinstance(c, RotationalConstraint)
+        assert c.center == 99
+
+
+def test_linkage_constraints_empty_in_translate_mode():
+    params = CircularPatternParams(
+        count=3, total_angle_deg=360.0, rotate_copies=False
+    )
+    strategy = CircularPatternStrategy(params)
+    assert strategy.build_linkage_constraints([(1, {1: 2})], 9) == []
+
+
+def test_master_geometry():
+    params = CircularPatternParams(
+        count=6,
+        total_angle_deg=360.0,
+        center=(0.0, 0.0),
+        radius=15.0,
+        rotate_copies=True,
+    )
+    strategy = CircularPatternStrategy(params)
+    points, entities, constraints = strategy.create_master_geometry(
+        center_pid=1, radius_pt_pid=2
+    )
+    assert len(points) == 1
+    assert points[0].x == pytest.approx(15.0)
+    assert len(entities) == 1
+    assert entities[0].construction is True
+    assert len(constraints) == 1
+
+
+def test_master_geometry_skipped_without_radius():
+    params = CircularPatternParams(radius=0.0)
+    strategy = CircularPatternStrategy(params)
+    assert strategy.create_master_geometry(1, 2) == ([], [], [])
+
+
+# ----------------------------------------------------------------------
+# PatternDefinition
+# ----------------------------------------------------------------------
+
+
+def test_definition_serialization_round_trip():
+    pattern = PatternDefinition(
+        uid="abc",
+        mode=SketchArrayMode.CIRCULAR,
+        guide_circle_id=7,
+        members=[(0, [1]), (1, [2]), (2, [3])],
+        count=8,
+        total_angle_deg=270.0,
+        rotate_copies=False,
+    )
+    restored = PatternDefinition.from_dict(pattern.to_dict())
+    assert restored.uid == "abc"
+    assert restored.mode == SketchArrayMode.CIRCULAR
+    assert restored.guide_circle_id == 7
+    assert restored.members == [(0, [1]), (1, [2]), (2, [3])]
+    assert restored.count == 8
+    assert restored.total_angle_deg == 270.0
+    assert restored.rotate_copies is False
+
+
+def test_definition_legacy_flat_format_migrates():
+    restored = PatternDefinition.from_dict(
+        {
+            "uid": "old",
+            "mode": "circular",
+            "guide_circle_id": 5,
+            "entity_ids": [1, 2],
+            "entity_slots": [0, 3],
+            "count": 6,
+        }
+    )
+    assert restored.members == [(0, [1]), (3, [2])]
+
+
+def test_find_pattern_for_entity():
+    p1 = PatternDefinition("a", SketchArrayMode.CIRCULAR, 11, [], 6, 360, True)
+    p2 = PatternDefinition("b", SketchArrayMode.CIRCULAR, 22, [], 6, 360, True)
+    patterns = [p1, p2]
+    assert find_pattern_for_entity(patterns, 22) is p2
+    assert find_pattern_for_entity(patterns, 99) is None
+
+
+def test_living_members_filters_deleted_and_keeps_groups():
+    class FakeRegistry:
+        def get_entity(self, eid):
+            return eid if eid in (1, 2, 5) else None
+
+    # Member at slot 1 lost one of its two entities but survives.
+    pattern = PatternDefinition(
+        "x",
+        SketchArrayMode.CIRCULAR,
+        9,
+        members=[(0, [1, 2]), (1, [3, 4]), (2, [5])],
+        count=6,
+    )
+    assert pattern.living_members(FakeRegistry()) == [
+        (0, [1, 2]),
+        (2, [5]),
+    ]
+    assert pattern.living_entity_ids(FakeRegistry()) == [1, 2, 5]
+    assert pattern.occupied_slots(FakeRegistry()) == {0, 2}

--- a/rayforge/builtin_addons/rayforge-addon-sketcher/tests/ui_gtk/tools/test_circular_array_tool.py
+++ b/rayforge/builtin_addons/rayforge-addon-sketcher/tests/ui_gtk/tools/test_circular_array_tool.py
@@ -1,0 +1,339 @@
+import math
+from unittest.mock import MagicMock, patch
+
+import cairo
+import pytest
+from sketcher.core.commands import CreatePatternCommand, EditPatternCommand
+from sketcher.core.constraints import RotationalConstraint
+from sketcher.core.entities import Circle
+from sketcher.core.params import ParameterContext
+from sketcher.core.patterns import CircularPatternParams, SketchArrayMode
+from sketcher.core.patterns.definition import PatternDefinition
+from sketcher.core.sketch import Sketch
+from sketcher.ui_gtk.tools import CircularArrayTool
+from sketcher.ui_gtk.tools.base import SketcherKey
+
+
+def make_pattern(sketch=None, guide_circle_id=99):
+    return PatternDefinition(
+        uid="test-uid",
+        mode=SketchArrayMode.CIRCULAR,
+        guide_circle_id=guide_circle_id,
+        members=[],
+        count=8,
+        total_angle_deg=270.0,
+        rotate_copies=False,
+    )
+
+
+@pytest.fixture
+def sketch_with_selection():
+    sketch = Sketch()
+    p0 = sketch.registry.add_point(5, 0)
+    p1 = sketch.registry.add_point(25, 5)
+    line = sketch.registry.add_line(p0, p1)
+    return sketch, line, p0, p1
+
+
+@pytest.fixture
+def mock_element(sketch_with_selection):
+    sketch, line, _p0, _p1 = sketch_with_selection
+    element = MagicMock()
+    element.sketch = sketch
+    element.editor = MagicMock()
+    element.editor.parent_window = MagicMock()
+    element.execute_command = MagicMock()
+    element.selection.entity_ids = [line]
+    element.hittester.screen_to_model.return_value = (5.0, -7.0)
+    return element
+
+
+@pytest.fixture
+def tool(mock_element):
+    return CircularArrayTool(mock_element)
+
+
+def test_initialization(tool):
+    assert tool.ICON == "sketch-array-symbolic"
+    assert tool.LABEL is not None
+    assert "gy" in tool.SHORTCUTS
+
+
+def test_is_available_requires_selection(tool, mock_element):
+    mock_element.selection.entity_ids = []
+    assert tool.is_available(None, None) is False
+    mock_element.selection.entity_ids = [3]
+    assert tool.is_available(None, None) is True
+
+
+def test_on_activate_without_selection_switches_back(tool, mock_element):
+    mock_element.selection.entity_ids = []
+    tool.on_activate()
+    mock_element.set_tool.assert_called_once_with("select")
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_on_activate_captures_seeds(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    _sketch, line, _p0, _p1 = sketch_with_selection
+    tool.on_activate()
+    mock_show_dialog.assert_called_once()
+    assert tool._seed_entity_ids == [line]
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_default_params_derived_from_seed(
+    mock_show_dialog, tool, sketch_with_selection
+):
+    _sketch, _line, _p0, _p1 = sketch_with_selection
+    tool.on_activate()
+    params = tool._params
+    assert isinstance(params, CircularPatternParams)
+    assert params.count == 6
+    assert params.total_angle_deg == 360.0
+    assert params.rotate_copies is True
+    # Radius is derived from the anchor point (first seed point here),
+    # matching what CreatePatternCommand will apply.
+    assert params.radius == pytest.approx(5.0)
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_creation_radius_always_matches_anchor(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    """User-entered radius must not diverge from the anchor-derived
+    circle at creation time (that mismatch caused the jump on apply)."""
+    tool.on_activate()
+    tool._count_row = MagicMock()
+    tool._count_row.get_int_value.return_value = 6
+    tool._angle_row = MagicMock()
+    tool._angle_row.get_value.return_value = 360.0
+    tool._center_x_row = MagicMock()
+    tool._center_x_row.get_value_in_base_units.return_value = 0.0
+    tool._center_y_row = MagicMock()
+    tool._center_y_row.get_value_in_base_units.return_value = 0.0
+    tool._radius_row = MagicMock()
+    tool._radius_row.get_value_in_base_units.return_value = 200.0
+    tool._rotate_switch = MagicMock()
+    tool._rotate_switch.get_active.return_value = True
+    assert tool._params is not None
+    tool._params.radius = 200.0
+    tool._sync_params()
+    assert tool._params.radius == pytest.approx(5.0)
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_collect_command_builds_create_command(
+    mock_show_dialog, tool, sketch_with_selection
+):
+    _sketch, line, _p0, _p1 = sketch_with_selection
+    tool.on_activate()
+    cmd = tool._collect_command()
+    assert isinstance(cmd, CreatePatternCommand)
+    assert cmd.seed_entity_ids == [line]
+    assert not isinstance(cmd, EditPatternCommand)
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_edit_target_builds_edit_command(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    """Edit mode pre-fills params from the master and builds an edit."""
+    sketch, line, _p0, _p1 = sketch_with_selection
+
+    # Master circle geometry: center (10, 2), radius point (30, 2).
+    c = sketch.registry.add_point(10.0, 2.0)
+    r = sketch.registry.add_point(30.0, 2.0)
+    circle = sketch.registry.add_circle(c, r, construction=True)
+
+    pattern = make_pattern(sketch, guide_circle_id=circle)
+    pattern.members = [(0, [line])]
+    pattern.count = 8
+    pattern.total_angle_deg = 270.0
+    pattern.rotate_copies = False
+
+    tool.set_edit_target(pattern)
+    tool.on_activate()
+
+    assert tool._is_editing
+    params = tool._params
+    assert params.count == 8
+    assert params.total_angle_deg == 270.0
+    assert params.rotate_copies is False
+    assert params.center == pytest.approx((10.0, 2.0))
+    assert params.radius == pytest.approx(20.0)
+
+    cmd = tool._collect_command()
+    assert isinstance(cmd, EditPatternCommand)
+    assert cmd.pattern is pattern
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_apply_executes_command_and_selects_copies(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    sketch, _line, _p0, _p1 = sketch_with_selection
+    tool.on_activate()
+
+    created = MagicMock()
+    created.id = 42
+    created.pattern_copy = True
+
+    fake_cmd = MagicMock()
+    fake_cmd.created_entity_ids = [42]
+    mock_element.execute_command.side_effect = lambda cmd: None
+
+    with (
+        patch.object(tool, "_collect_command", return_value=fake_cmd),
+        patch.object(tool, "_close_dialog"),
+        patch.object(
+            sketch.registry,
+            "get_entity",
+            side_effect=lambda eid: created if eid == 42 else None,
+        ),
+    ):
+        tool._on_apply()
+
+    mock_element.set_tool.assert_called_once_with("select")
+    mock_element.selection.select_entity.assert_called_once_with(
+        created, False
+    )
+
+
+def test_draw_overlay_noop_without_dialog(tool):
+    tool._dialog = None
+    tool._params = None
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+    ctx = cairo.Context(surface)
+    tool.draw_overlay(ctx)
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_on_press_does_not_move_center(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    """Canvas clicks must never relocate the pattern center (they
+    conflict with panning/navigation while the dialog is open)."""
+    tool.on_activate()
+    tool._dialog = MagicMock()
+    center_before = tool._params.center
+
+    tool.on_press(100.0, 200.0, 1)
+
+    assert tool._params.center == center_before
+    mock_element.mark_dirty.assert_not_called()
+
+
+def test_escape_deactivates_tool(tool, mock_element):
+    tool._dialog = MagicMock()
+    handled = tool.handle_key_event(SketcherKey.ESCAPE)
+    assert handled is True
+    mock_element.set_tool.assert_called_once_with("select")
+
+
+def test_close_request_deactivates_tool_and_allows_close(tool, mock_element):
+    tool._dialog = MagicMock()
+    assert tool._on_close_request() is False
+    assert tool._dialog is None
+    mock_element.set_tool.assert_called_once_with("select")
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_full_edit_flow_through_tool_does_not_collapse(
+    mock_show_dialog,
+):
+    """
+    Integration: double-click edit flow (tool -> EditPatternCommand)
+    must leave all members at distinct slot angles with zero constraint
+    residual - never collapsed onto one position.
+    """
+    sketch = Sketch()
+    p0 = sketch.registry.add_point(30, 0)
+    p1 = sketch.registry.add_point(50, 0)
+    line = sketch.registry.add_line(p0, p1)
+    params = CircularPatternParams(
+        count=6,
+        total_angle_deg=360.0,
+        center=(0.0, 0.0),
+        radius=40.0,
+        rotate_copies=True,
+    )
+    create_cmd = CreatePatternCommand(
+        sketch, SketchArrayMode.CIRCULAR, params, [line]
+    )
+    create_cmd.execute()
+    sketch.solve()
+    pattern = sketch.patterns[0]
+
+    element = MagicMock()
+    element.sketch = sketch
+    element.editor.parent_window = MagicMock()
+    element.editor.history_manager.execute.side_effect = lambda cmd: (
+        cmd.execute()
+    )
+    element.execute_command.side_effect = lambda cmd: cmd.execute()
+    element.selection.entity_ids = []
+    element.hittester.screen_to_model.return_value = (0.0, 0.0)
+
+    tool = CircularArrayTool(element)
+    tool.set_edit_target(pattern)
+    tool.on_activate()
+
+    # User changes the count in the dialog and hits Apply.
+    assert tool._params is not None
+    tool._params.count = 8
+    tool._on_apply()
+
+    sketch.solve()
+
+    circle = next(e for e in sketch.registry.entities if isinstance(e, Circle))
+    center = sketch.registry.get_point(circle.center_idx)
+
+    living = pattern.living_entity_ids(sketch.registry)
+    assert len(living) == 8
+
+    angles = []
+    for eid in living:
+        entity = sketch.registry.get_entity(eid)
+        assert entity is not None
+        pid = entity.get_point_ids()[0]
+        pt = sketch.registry.get_point(pid)
+        angles.append(
+            round(
+                math.degrees(math.atan2(pt.y - center.y, pt.x - center.x))
+                / 45.0
+            )
+            * 45.0
+            % 360.0
+        )
+    assert sorted(set(angles)) == [
+        0.0,
+        45.0,
+        90.0,
+        135.0,
+        180.0,
+        225.0,
+        270.0,
+        315.0,
+    ]
+
+    worst = max(
+        max(abs(v) for v in c.error(sketch.registry, ParameterContext()))
+        for c in sketch.constraints
+        if isinstance(c, RotationalConstraint)
+    )
+    assert worst < 1e-6
+
+
+@patch.object(CircularArrayTool, "_show_dialog")
+def test_cancel_clears_edit_target(
+    mock_show_dialog, tool, mock_element, sketch_with_selection
+):
+    pattern = make_pattern()
+    tool.set_edit_target(pattern)
+    tool.on_activate()
+    assert tool._is_editing
+
+    tool.on_deactivate()
+    assert tool._edit_target is None

--- a/rayforge/resources/icons/sketch-array-symbolic.svg
+++ b/rayforge/resources/icons/sketch-array-symbolic.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="32"
+   viewBox="0 0 24 24"
+   width="32"
+   fill="#000000"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g id="pattern-copies">
+    <rect
+       id="copy-1"
+       width="4.2"
+       height="4.2"
+       x="-2.1"
+       y="-8.9"
+       rx="0.6"
+       transform="rotate(0 12 12) translate(12 12)" />
+    <rect
+       id="copy-2"
+       width="4.2"
+       height="4.2"
+       x="-2.1"
+       y="-8.9"
+       rx="0.6"
+       transform="rotate(72 12 12) translate(12 12)" />
+    <rect
+       id="copy-3"
+       width="4.2"
+       height="4.2"
+       x="-2.1"
+       y="-8.9"
+       rx="0.6"
+       transform="rotate(144 12 12) translate(12 12)" />
+    <rect
+       id="copy-4"
+       width="4.2"
+       height="4.2"
+       x="-2.1"
+       y="-8.9"
+       rx="0.6"
+       transform="rotate(216 12 12) translate(12 12)" />
+    <rect
+       id="copy-5"
+       width="4.2"
+       height="4.2"
+       x="-2.1"
+       y="-8.9"
+       rx="0.6"
+       transform="rotate(288 12 12) translate(12 12)" />
+  </g>
+  <circle
+     id="center"
+     cx="12"
+     cy="12"
+     r="1.4" />
+</svg>


### PR DESCRIPTION
Implements circular arrays (polar patterns) for the sketcher, one of the tools requested in #358.

## Features

- **Circular Array tool** (`gy` / Sketch > Arrays > Circular Array): distributes linked copies of the selected entities along a circular arc. Non-modal dialog with live ghost preview, mirroring the main-canvas array dialog (Count, Total angle, Center X/Y, Radius, Rotate copies).
- **Parametric members**: copies are entity *groups* tied to the template member through new `RotationalConstraint`s — moving/editing any member propagates to the whole array; deleting a member removes only its own constraints and never redistributes survivors.
- **Guide circle as the "master"**: a construction circle carries the pattern definition, with a radius dimension that resizes the whole array. Double-clicking it reopens the edit dialog, which re-creates missing instances or fully re-distributes when count/angle changed.
- **Generic pattern framework** (`sketcher/core/patterns/`): strategies provide placements, linkage constraints and master geometry; a future linear array only needs a strategy subclass plus its parameter dataclass.

## Implementation notes

- Edits first move the existing pattern into the edited frame via a similarity transform (translation + uniform scale), which keeps every constraint exactly satisfied — no solver "repair", zero residual straight after execute.
- During member drags the radius dimension is temporarily excluded from the solve and synced afterwards, so large drags don't distort or collapse the geometry.
- Members are tracked as entity groups: partial deletion of a shape degrades gracefully instead of regenerating broken single-line copies.
- Copies render solid like regular geometry at 70% stroke width.
- Canvas clicks are ignored while the dialog is open so panning/navigation can never relocate the center.

## Testing

- New unit tests for the rotational constraint (incl. finite-difference gradient check), pattern strategies/definition, create/edit commands (execute, undo, redo, serialization round-trip) and end-to-end scenario tests simulating real UI flows (create → delete → drag → edit cycles).
- Full sketcher suite: 1108 core + 152 UI tests passing; ruff + pyright clean.

Closes #358 (circular array portion).