### PR TITLE
Land auto-device-discovery wizard + first-run setup flow

### DIFF
--- a/rayforge/context.py
+++ b/rayforge/context.py
@@ -226,6 +226,9 @@ class RayforgeContext:
             logger.info("Lazy loading machine manager")
             self._machine_mgr = MachineManager(MACHINE_DIR)
             if not self._machine_mgr.machines:
+                # Creates a marked placeholder machine so the app stays
+                # usable. On first launch the UI presents the setup
+                # wizard instead of silently keeping the placeholder.
                 self._machine_mgr.create_default_machine()
         return self._machine_mgr
 

--- a/rayforge/core/config.py
+++ b/rayforge/core/config.py
@@ -114,6 +114,10 @@ class Config:
         self.default_stock_material_uid: str | None = None
         # Default stock thickness in mm, applied to new stock assets.
         self.default_stock_thickness_mm: float = 18.0
+        # Whether the first-run machine setup wizard has been completed
+        # (or dismissed). Absent in older configs; the wizard itself
+        # only triggers while placeholder machines are the only ones.
+        self.setup_completed: bool = False
         self.changed = Signal()
 
     def set_machine(self, machine: Machine | None):
@@ -246,6 +250,13 @@ class Config:
         self.default_stock_thickness_mm = thickness_mm
         self.changed.send(self)
 
+    def set_setup_completed(self, completed: bool):
+        """Marks the first-run machine setup wizard as handled."""
+        if self.setup_completed == completed:
+            return
+        self.setup_completed = completed
+        self.changed.send(self)
+
     def set_usage_consent(self, consent: bool):
         """Sets the usage tracking consent preference."""
         new_value = ""
@@ -303,6 +314,7 @@ class Config:
             "language": self.language,
             "default_stock_material_uid": self.default_stock_material_uid,
             "default_stock_thickness_mm": self.default_stock_thickness_mm,
+            "setup_completed": self.setup_completed,
         }
 
     @classmethod
@@ -390,6 +402,9 @@ class Config:
         config.default_stock_thickness_mm = data.get(
             "default_stock_thickness_mm", 18.0
         )
+
+        # Load first-run setup flag
+        config.setup_completed = data.get("setup_completed", False)
 
         # Get the machine by ID. add fallbacks in case the machines
         # no longer exist.

--- a/rayforge/machine/device/manager.py
+++ b/rayforge/machine/device/manager.py
@@ -9,6 +9,11 @@ from typing import TYPE_CHECKING, Optional
 import yaml
 
 from ...core.model import ModelLibrary
+from ..driver.discovery import (
+    GENERIC_TOKENS,
+    DeviceIdentity,
+    normalize_tokens,
+)
 from .lightburn_importer import (
     ImportSummary,
     convert_to_profile,
@@ -140,6 +145,56 @@ class DeviceProfileManager:
 
     def get_load_errors(self) -> dict[str, str]:
         return dict(self._load_errors)
+
+    def match_device(self, identity: DeviceIdentity) -> "DeviceProfile | None":
+        """
+        Match a discovered device's *identity* against the known
+        device profiles.
+
+        A profile matches when all tokens of its ``vendor`` (and, if
+        set, its ``model``) appear among the identity's tokens —
+        e.g. a vendor branded into the USB description or a
+        ``/dev/serial/by-id`` link name. Generic USB-serial chip
+        names (CH340, CP210x, ...) never count as a match. Profiles
+        whose model matched are preferred over model-less profiles
+        of the same vendor.
+
+        Returns the single unambiguous candidate, or ``None`` when
+        nothing matches or multiple profiles match equally well.
+        """
+        candidates: list[tuple[bool, DeviceProfile]] = []
+        for profile in self._profiles.values():
+            vendor = (profile.meta.vendor or "").strip()
+            if not vendor:
+                continue
+            vendor_tokens = normalize_tokens(vendor)
+            if not vendor_tokens or vendor_tokens <= GENERIC_TOKENS:
+                continue
+            if not vendor_tokens <= identity.tokens:
+                continue
+            model_matched = False
+            model = (profile.meta.model or "").strip()
+            if model:
+                model_tokens = normalize_tokens(model)
+                if model_tokens and not model_tokens <= identity.tokens:
+                    continue
+                model_matched = bool(model_tokens)
+            candidates.append((model_matched, profile))
+
+        # A profile whose model tokens matched is more specific than
+        # a model-less profile of the same vendor; the latter cannot
+        # win while any specific match exists.
+        if any(model_matched for model_matched, _ in candidates):
+            candidates = [entry for entry in candidates if entry[0]]
+
+        if len(candidates) == 1:
+            return candidates[0][1]
+        if len(candidates) > 1:
+            logger.debug(
+                "Device identity matched %d profiles ambiguously",
+                len(candidates),
+            )
+        return None
 
     def load_profile(self, path: Path) -> DeviceProfile:
         """

--- a/rayforge/machine/device/profile.py
+++ b/rayforge/machine/device/profile.py
@@ -610,11 +610,18 @@ class DeviceProfile:
         )
 
     def create_machine(self, context: "RayforgeContext") -> Machine:
+        # Imported here: schema_migration transitively imports this
+        # module, so a module-level import would be circular.
+        from .schema_migration import CURRENT_SCHEMA_VERSION
+
         m = Machine(context)
         m.name = self.meta.name
         cfg = self.machine_config
         m.source_profile_id = self.id
         m.reviewed_profile_hash = self.content_hash()
+        # Fresh machines already carry current defaults; stamp them so
+        # they never trigger the schema-migration review dialog.
+        m.schema_version = CURRENT_SCHEMA_VERSION
 
         context.machine_mgr.add_machine(m)
 

--- a/rayforge/machine/driver/__init__.py
+++ b/rayforge/machine/driver/__init__.py
@@ -1,6 +1,13 @@
 import inspect
 from typing import cast
 
+from .discovery import (
+    DeviceIdentity,
+    DeviceRecognizer,
+    DiscoveredDevice,
+    find_all_devices,
+    normalize_tokens,
+)
 from .driver import (
     DRIVER_MATURITY_LABELS,
     Driver,
@@ -44,6 +51,9 @@ def register_driver(driver: type[Driver]):
 
 __all__ = [
     "DRIVER_MATURITY_LABELS",
+    "DeviceIdentity",
+    "DeviceRecognizer",
+    "DiscoveredDevice",
     "Driver",
     "DriverMaturity",
     "GrblNetworkDriver",
@@ -56,4 +66,6 @@ __all__ = [
     "PWMParams",
     "RuidaDriver",
     "SmoothieDriver",
+    "find_all_devices",
+    "normalize_tokens",
 ]

--- a/rayforge/machine/driver/discovery.py
+++ b/rayforge/machine/driver/discovery.py
@@ -1,0 +1,346 @@
+"""Automatic device discovery.
+
+Discovery is split into two processes:
+
+* **Scanning** (one per discovery run) —
+  :func:`rayforge.machine.transport.serial_scan.scan_serial_ports`
+  opens every serial port once and captures what the device sends
+  as a :class:`PortObservation`. This is transport work and knows
+  nothing about firmware.
+
+* **Evaluating** (this module) — each driver that wants to be
+  discoverable declares a :class:`DeviceRecognizer` as its
+  ``DISCOVERY`` class attribute: what its device's output looks
+  like, how to label it, which firmware it runs. Recognition is a
+  pure function over the captured bytes; no port is ever opened on
+  behalf of a single driver, so adding drivers never multiplies
+  scan cost.
+
+:func:`find_all_devices` ties the two together: one scan, every
+recognizer, merged results. The module also defines the
+:class:`DiscoveredDevice` / :class:`DeviceIdentity` result types
+plus identity-token helpers used for profile matching.
+
+This module is GTK-free so it can be unit-tested in isolation.
+"""
+
+import asyncio
+import logging
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from ..transport.serial import SerialPortInfo
+from ..transport.serial_scan import (
+    PortObservation,
+    scan_serial_ports,
+)
+
+if TYPE_CHECKING:
+    from ..device.profile import DeviceProfile
+
+logger = logging.getLogger(__name__)
+
+# Upper bound for the whole discovery scan.
+_SCAN_TIMEOUT = 20.0
+
+# USB vendor/product strings that identify the USB-serial chip, not
+# the machine built around it. Never used for profile matching.
+GENERIC_TOKENS = frozenset(
+    {
+        "usb",
+        "serial",
+        "uart",
+        "bridge",
+        "controller",
+        "device",
+        "machine",
+        "printer",
+        "board",
+        "port",
+        "if00",
+        "cdc",
+        "acm",
+        "modem",
+        "ch340",
+        "ch340g",
+        "ch340k",
+        "ch9102",
+        "ch9102f",
+        "cp210x",
+        "cp2101",
+        "cp2102",
+        "cp2104",
+        "cp2109",
+        "ftdi",
+        "ft232",
+        "ft232r",
+        "ft231x",
+        "ft2232",
+        "prolific",
+        "pl2303",
+        "arduino",
+        "leonardo",
+        "mega2560",
+        "inc",
+        "ltd",
+        "limited",
+        "corp",
+        "co",
+        "technology",
+        "electronics",
+        "semiconductor",
+        "integrated",
+        "circuits",
+        "quantities",
+        "industry",
+        "industrial",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DeviceIdentity:
+    """
+    Everything known about a discovered device that can be used to
+    match it against a known device profile.
+    """
+
+    firmware: str | None = None
+    banner: str | None = None
+    usb_vid: int | None = None
+    usb_pid: int | None = None
+    tokens: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class DiscoveredDevice:
+    """A device found by evaluating a scan against a driver's
+    ``DISCOVERY`` recognizer."""
+
+    driver_name: str
+    #: Connection parameters that seed ``driver_args`` (port,
+    #: baudrate, ...).
+    params: dict
+    #: Short display name, e.g. "GRBL device".
+    label: str
+    #: One-line connection detail, e.g. "/dev/ttyUSB0 at 115200 baud".
+    detail: str
+    identity: DeviceIdentity = field(default_factory=DeviceIdentity)
+    #: Profile data collected by probing the device after discovery
+    #: (firmware build info, axis extents, speeds). Attached by the
+    #: discovery UI once available; ``None`` until then.
+    probe_profile: "DeviceProfile | None" = None
+
+    @property
+    def key(self) -> str:
+        """Stable identity for deduplication in the UI."""
+        return f"{self.driver_name}:{self.params.get('port', '')}"
+
+    @property
+    def probe_name(self) -> str | None:
+        """The machine name the device itself reported, if any."""
+        if self.probe_profile is None:
+            return None
+        name = (self.probe_profile.meta.name or "").strip()
+        if not name or name.startswith("Unknown"):
+            return None
+        return name
+
+
+@dataclass(frozen=True)
+class DeviceRecognizer:
+    """
+    Declarative description of what a driver's device looks like on
+    the wire. Declared by drivers as the ``DISCOVERY`` class
+    attribute; evaluated against captured scan output by
+    :func:`find_all_devices`.
+    """
+
+    #: Display label, called at discovery time so translations are
+    #: looked up at runtime.
+    label: Callable[[], str]
+    #: Returns True if *data* — the bytes captured from a port —
+    #: was produced by this driver's firmware.
+    matches: Callable[[bytes], bool]
+    #: Optional: extracts a human-readable device name from the
+    #: captured bytes (e.g. Grbl's ``[MSG:machine:...]`` line). The
+    #: name becomes the identity banner and feeds profile matching.
+    name: Callable[[bytes], str | None] | None = None
+    #: Firmware identifier used for identity/profile matching.
+    firmware: str | None = None
+
+
+def extract_banner(data: bytes) -> str | None:
+    """
+    Returns the first non-empty line of *data* as a human-readable
+    hint (e.g. the Grbl version banner), or ``None`` if there is none.
+    """
+    text = data.decode("ascii", errors="replace")
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line[:80]
+    return None
+
+
+def normalize_tokens(*texts: str | None) -> frozenset[str]:
+    """
+    Splits arbitrary identification strings (descriptions, by-id link
+    names, manufacturer strings) into lowercase word tokens suitable
+    for containment checks.
+    """
+    words: set[str] = set()
+    for text in texts:
+        if not text:
+            continue
+        for word in re.split(r"[^0-9a-zA-Z]+", text.lower()):
+            if len(word) >= 3:
+                words.add(word)
+    return frozenset(words)
+
+
+def build_identity(
+    firmware: str | None,
+    data: bytes | None,
+    port_info: SerialPortInfo | None,
+    device_name: str | None = None,
+) -> DeviceIdentity:
+    """
+    Assembles a :class:`DeviceIdentity` from scan artifacts. A
+    *device_name* extracted from the device's own output (when the
+    recognizer provides one) takes precedence over the raw banner
+    and contributes matching tokens.
+    """
+    tokens = normalize_tokens(
+        port_info.description if port_info else None,
+        port_info.manufacturer if port_info else None,
+        device_name,
+    )
+    return DeviceIdentity(
+        firmware=firmware,
+        banner=device_name or (extract_banner(data) if data else None),
+        usb_vid=port_info.vid if port_info else None,
+        usb_pid=port_info.pid if port_info else None,
+        tokens=tokens,
+    )
+
+
+async def find_all_devices(
+    driver_classes: Iterable[type] | None = None,
+    ports: Iterable[str] | None = None,
+    baud_rates: Iterable[int] | None = None,
+    exclude_ports: Iterable[str] | None = None,
+) -> list[DiscoveredDevice]:
+    """
+    Runs a single serial scan and lets every driver's ``DISCOVERY``
+    recognizer evaluate the captured output.
+
+    *exclude_ports* keeps the scan away from ports whose devices
+    are already held (e.g. being probed by the caller).
+
+    A failing or slow scan never raises: it is bounded by a timeout
+    and exceptions are logged. A recognizer that raises is skipped
+    so one broken driver cannot break discovery for the rest.
+    """
+    if driver_classes is None:
+        from . import drivers
+
+        driver_classes = drivers
+
+    recognizers = _collect_recognizers(driver_classes)
+    if not recognizers:
+        return []
+
+    try:
+        observations = await asyncio.wait_for(
+            scan_serial_ports(
+                ports=ports,
+                baud_rates=baud_rates,
+                exclude_ports=exclude_ports,
+            ),
+            timeout=_SCAN_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("Device discovery scan timed out")
+        return []
+    except Exception:
+        logger.exception("Device discovery scan failed")
+        return []
+
+    devices: list[DiscoveredDevice] = []
+    for observation in observations:
+        devices.extend(_evaluate(observation, recognizers))
+    return devices
+
+
+def _collect_recognizers(
+    driver_classes: Iterable[type],
+) -> list[tuple[type, DeviceRecognizer]]:
+    """Pairs every driver that declares a valid recognizer with it."""
+    recognizers = []
+    for cls in driver_classes:
+        recognizer = getattr(cls, "DISCOVERY", None)
+        if isinstance(recognizer, DeviceRecognizer):
+            recognizers.append((cls, recognizer))
+    return recognizers
+
+
+def _evaluate(
+    observation: PortObservation,
+    recognizers: list[tuple[type, DeviceRecognizer]],
+) -> list[DiscoveredDevice]:
+    """Runs every recognizer against one observation."""
+    devices: list[DiscoveredDevice] = []
+    for cls, recognizer in recognizers:
+        try:
+            if not recognizer.matches(observation.data):
+                continue
+        except Exception:
+            logger.exception(
+                "Discovery recognizer for %s failed", cls.__name__
+            )
+            continue
+        devices.append(_build_device(cls, recognizer, observation))
+    return devices
+
+
+def _build_device(
+    cls: type,
+    recognizer: DeviceRecognizer,
+    observation: PortObservation,
+) -> DiscoveredDevice:
+    device_name = (
+        recognizer.name(observation.data) if recognizer.name else None
+    )
+    return DiscoveredDevice(
+        driver_name=cls.__name__,
+        params={
+            "port": observation.port,
+            "baudrate": observation.baud_rate,
+        },
+        label=recognizer.label(),
+        detail=_("{port} at {baud} baud").format(
+            port=observation.port, baud=observation.baud_rate
+        ),
+        identity=build_identity(
+            recognizer.firmware,
+            observation.data,
+            observation.info,
+            device_name,
+        ),
+    )
+
+
+__all__ = [
+    "GENERIC_TOKENS",
+    "DeviceIdentity",
+    "DeviceRecognizer",
+    "DiscoveredDevice",
+    "build_identity",
+    "extract_banner",
+    "find_all_devices",
+    "normalize_tokens",
+]

--- a/rayforge/machine/driver/driver.py
+++ b/rayforge/machine/driver/driver.py
@@ -7,6 +7,7 @@ from gettext import gettext as _
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Optional,
 )
 
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from ..models.head import Head
     from ..models.laser import Laser
     from ..models.machine import Machine
+    from .discovery import DeviceRecognizer
 
 
 logger = logging.getLogger(__name__)
@@ -220,6 +222,12 @@ class Driver(ABC):
     # When True, the driver can query the device to detect its
     # native unit system (metric vs imperial).
     supports_unit_detection: bool = False
+    # Declarative description of what a device this driver can talk
+    # to looks like on the wire. When set, the driver participates
+    # in automatic device discovery: discovery scans each transport
+    # once and evaluates the captured output against every
+    # recognizer (see rayforge.machine.driver.discovery).
+    DISCOVERY: ClassVar["DeviceRecognizer | None"] = None
 
     @property
     @abstractmethod

--- a/rayforge/machine/driver/grbl/grbl_serial.py
+++ b/rayforge/machine/driver/grbl/grbl_serial.py
@@ -34,6 +34,7 @@ from ...transport.grbl import (
     GrblSerialTransport,
 )
 from ...transport.serial import SerialPortPermissionError
+from ..discovery import DeviceRecognizer
 from ..driver import (
     Axis,
     DeviceConnectionError,
@@ -50,9 +51,11 @@ from .grbl_util import (
     alarm_code_to_device_error,
     detect_unit_system_from_settings,
     error_code_to_device_error,
+    extract_device_name_from_output,
     gcode_to_p_number,
     get_grbl_setting_varsets,
     grbl_setting_re,
+    is_grbl_output,
     is_report_in_inches,
     parse_grbl_parser_state,
     parse_opt_info,
@@ -87,6 +90,12 @@ class GrblSerialDriver(Driver):
     reports_granular_progress = True
     supports_probing = True
     supports_unit_detection = True
+    DISCOVERY = DeviceRecognizer(
+        label=lambda: _("GRBL device"),
+        firmware="grbl",
+        matches=is_grbl_output,
+        name=extract_device_name_from_output,
+    )
 
     # Buffer-stall timeout bounds for a single gcode line. The actual
     # timeout scales with the estimated duration of the command

--- a/rayforge/machine/driver/grbl/grbl_telnet.py
+++ b/rayforge/machine/driver/grbl/grbl_telnet.py
@@ -24,6 +24,10 @@ class GrblTelnetDriver(GrblSerialDriver):
 
     label = _("GRBL (Telnet)")
     subtitle = _("GRBL-compatible controller over a raw TCP/telnet connection")
+    # Serial-port discovery is inherited from GrblSerialDriver but
+    # makes no sense here: a telnet connection has no serial port and
+    # must not claim devices found on one.
+    DISCOVERY = None
 
     def __init__(self, context, machine):
         super().__init__(context, machine)

--- a/rayforge/machine/driver/grbl/grbl_util.py
+++ b/rayforge/machine/driver/grbl/grbl_util.py
@@ -18,6 +18,23 @@ GRBL_REPORT_INCHES_KEY = "13"
 # be queued behind buffered gcode, and never produce an 'ok' ack.
 GRBL_REALTIME_COMMANDS = frozenset({"?", "~", "!"})
 
+# Matches Grbl / grblHAL welcome banners ("Grbl 1.1f ['$' for help]")
+# and realtime status reports ("<Idle|MPos:...>"). Also matches
+# build-info / feedback messages ("[VER:...]", "[OPT:...]",
+# "[MSG:...]"): some forks never mention Grbl in their boot output
+# and instead greet with $I-style lines (e.g. the Sculpfun iCube).
+# Used to claim a serial port during device discovery.
+grbl_discovery_re = re.compile(
+    rb"\bgrbl(?:hal)?\b|<(?:Idle|Run|Hold|Alarm|Home)[,|>]"
+    rb"|\[(?:VER|OPT|MSG|GC):",
+    re.IGNORECASE,
+)
+
+
+def is_grbl_output(data: bytes) -> bool:
+    """True when raw serial output identifies a Grbl device."""
+    return bool(grbl_discovery_re.search(data))
+
 
 def split_realtime_commands(
     lines: list[str],
@@ -666,6 +683,21 @@ def extract_device_name(build_info: list[str]) -> str:
             if build_name:
                 return build_name
     return "Unknown Grbl Device"
+
+
+def extract_device_name_from_output(data: bytes) -> str | None:
+    """
+    Extract a human-readable device name from raw serial output, as
+    captured during device discovery.
+
+    Returns None when the output carries no usable name (e.g. a stock
+    Grbl whose banner only states its version).
+    """
+    lines = data.decode("ascii", errors="replace").splitlines()
+    name = extract_device_name(lines)
+    if not name or name == "Unknown Grbl Device":
+        return None
+    return name
 
 
 def version_supports_single_axis_homing(

--- a/rayforge/machine/driver/marlin/marlin_serial.py
+++ b/rayforge/machine/driver/marlin/marlin_serial.py
@@ -26,6 +26,7 @@ from ....pipeline.encoder.gcode import GcodeEncoder
 from ....shared.units.system import UnitSystem
 from ...transport import SerialTransport, TransportStatus
 from ...transport.serial import SerialPortPermissionError
+from ..discovery import DeviceRecognizer
 from ..driver import (
     Axis,
     DeviceConnectionError,
@@ -43,6 +44,7 @@ from .marlin_util import (
     gcode_to_p_number,
     is_boot_message,
     is_error_response,
+    is_marlin_output,
     is_ok_response,
     m114_pos_re,
 )
@@ -66,6 +68,11 @@ class MarlinSerialDriver(Driver):
     maturity = DriverMaturity.EXPERIMENTAL
     supports_probing = True
     supports_unit_detection = True
+    DISCOVERY = DeviceRecognizer(
+        label=lambda: _("Marlin device"),
+        firmware="marlin",
+        matches=is_marlin_output,
+    )
 
     def __init__(self, context: RayforgeContext, machine: "Machine"):
         super().__init__(context, machine)

--- a/rayforge/machine/driver/marlin/marlin_util.py
+++ b/rayforge/machine/driver/marlin/marlin_util.py
@@ -128,6 +128,17 @@ def is_boot_message(line: str) -> bool:
     return any(stripped.startswith(p) for p in prefixes)
 
 
+def is_marlin_output(data: bytes) -> bool:
+    """
+    True when raw serial output identifies a Marlin device.
+
+    Reuses :func:`is_boot_message` so device discovery and the
+    driver itself agree on what a Marlin boot banner looks like.
+    """
+    text = data.decode("ascii", errors="replace")
+    return any(is_boot_message(line) for line in text.splitlines())
+
+
 def parse_m115_firmware_info(
     response_lines: list[str],
 ) -> dict[str, str]:

--- a/rayforge/machine/models/machine.py
+++ b/rayforge/machine/models/machine.py
@@ -122,6 +122,9 @@ class Machine:
         self.auto_connect: bool = True
         self.home_on_start: bool = False
         self.clear_alarm_on_connect: bool = False
+        # True while this machine is the auto-created placeholder that
+        # keeps the app usable before the user sets up a real machine.
+        self.placeholder: bool = False
         self.single_axis_homing_enabled: bool = True
         self.dialect_uid: str | None = "grbl"
         self.dialect_migrated: bool = False
@@ -1515,6 +1518,7 @@ class Machine:
                 "driver_config": self.driver_config,
                 "auto_connect": self.auto_connect,
                 "clear_alarm_on_connect": self.clear_alarm_on_connect,
+                "placeholder": self.placeholder,
                 "home_on_start": self.home_on_start,
                 "single_axis_homing_enabled": self.single_axis_homing_enabled,
                 "dialect_uid": self.dialect_uid,
@@ -1692,6 +1696,7 @@ class Machine:
             "clear_alarm_on_connect",
             ma.clear_alarm_on_connect,
         )
+        ma.placeholder = ma_data.pop("placeholder", ma.placeholder)
         ma.home_on_start = ma_data.pop("home_on_start", ma.home_on_start)
         ma.single_axis_homing_enabled = ma_data.pop(
             "single_axis_homing_enabled",

--- a/rayforge/machine/models/manager.py
+++ b/rayforge/machine/models/manager.py
@@ -211,12 +211,22 @@ class MachineManager:
     def get_machine_by_id(self, machine_id):
         return self.machines.get(machine_id)
 
+    def get_placeholder_machines(self) -> list["Machine"]:
+        """Returns all machines that are still untouched placeholders."""
+        return [m for m in self.machines.values() if m.placeholder]
+
     def get_machines(self) -> list["Machine"]:
         """Returns a list of all managed machines, sorted by name."""
         return sorted(self.machines.values(), key=lambda m: m.name)
 
     def create_default_machine(self):
         machine = Machine(get_context())
+        # Mark it so the UI can offer the setup wizard while this
+        # placeholder is still the active machine.
+        machine.placeholder = True
+        # Fresh machines already carry current defaults; stamp them so
+        # they never trigger the schema-migration review dialog.
+        machine.schema_version = CURRENT_SCHEMA_VERSION
         self.add_machine(machine)
         return machine
 

--- a/rayforge/machine/transport/serial.py
+++ b/rayforge/machine/transport/serial.py
@@ -29,11 +29,14 @@ class SerialPortPermissionError(Exception):
 
 @dataclass(frozen=True)
 class SerialPortInfo:
-    """A serial port path together with an optional human-readable
-    description."""
+    """A serial port path together with optional metadata used to
+    identify the underlying USB device."""
 
     device: str
     description: str | None = None
+    manufacturer: str | None = None
+    vid: int | None = None
+    pid: int | None = None
 
 
 def is_usb_serial_port(port: str) -> bool:
@@ -177,7 +180,15 @@ class SerialTransport(Transport):
                 desc = port.description
                 if not desc or desc == "n/a":
                     desc = None
-                infos.append(SerialPortInfo(port.device, desc))
+                infos.append(
+                    SerialPortInfo(
+                        device=port.device,
+                        description=desc,
+                        manufacturer=getattr(port, "manufacturer", None),
+                        vid=getattr(port, "vid", None),
+                        pid=getattr(port, "pid", None),
+                    )
+                )
             infos.sort(key=lambda info: _port_sort_key(info.device))
             return infos
         except (OSError, serial.SerialException, TypeError) as e:

--- a/rayforge/machine/transport/serial_scan.py
+++ b/rayforge/machine/transport/serial_scan.py
@@ -1,0 +1,259 @@
+"""Serial port scanning.
+
+Scanning is a transport-level process, independent of any driver
+or firmware: every serial port is opened exactly once per scan,
+probed at a sequence of baud rates, and whatever the connected
+device sends (welcome banner first, then responses to nudge
+characters) is captured as a :class:`PortObservation`.
+
+Interpreting an observation — deciding which driver could talk to
+the device — is a separate concern that lives with the drivers (see
+:mod:`rayforge.machine.driver.discovery`).
+
+This module is GTK-free so it can be unit-tested in isolation. The
+blocking pyserial work runs in an executor; everything is bounded by
+short timeouts so a full scan stays fast.
+"""
+
+import asyncio
+import logging
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import serial
+
+from .serial import SerialPortInfo, SerialTransport, sort_ports
+
+logger = logging.getLogger(__name__)
+
+# Baud rates tried in order. 115200 is by far the most common for
+# laser controllers, so it is probed across all ports first.
+BAUD_CANDIDATES = [115200, 57600, 9600]
+
+# How long to listen for an unsolicited welcome banner before nudging.
+_BANNER_TIMEOUT = 2.0
+# How long to wait for a response after sending a nudge character.
+_NUDGE_TIMEOUT = 1.0
+# Once a device is talking, how long the line must stay quiet before
+# its output burst is considered complete.
+_QUIET_GAP = 0.3
+# Upper bound for the final drain of trailing burst data.
+_DRAIN_TIMEOUT = 1.0
+_READ_CHUNK = 0.2
+
+_NUDGES = (b"\n", b"?")
+
+
+@dataclass(frozen=True)
+class PortObservation:
+    """Raw output captured from one port during a scan."""
+
+    port: str
+    baud_rate: int
+    #: Everything the device sent while the port was open.
+    data: bytes
+    #: USB metadata for the port, when available.
+    info: SerialPortInfo | None = None
+
+
+def looks_like_device_output(data: bytes) -> bool:
+    """
+    Generic, firmware-agnostic test for "a device is talking on
+    this port": the capture contains at least one line of
+    mostly-printable ASCII. Output received at a wrong baud rate is
+    typically framing garbage and fails this test.
+    """
+    for line in data.split(b"\n"):
+        line = line.strip(b" \t\r\x00")
+        if not line:
+            continue
+        printable = sum(0x20 <= byte <= 0x7E or byte == 0x09 for byte in line)
+        if printable / len(line) >= 0.8:
+            return True
+    return False
+
+
+# Per-port locks so concurrent scans don't fight over the same
+# physical port (pyserial opens exclusively). Safe to create lazily:
+# the event loop is single-threaded, so there is no check-then-set
+# race.
+_port_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_port_lock(port: str) -> asyncio.Lock:
+    lock = _port_locks.get(port)
+    if lock is None:
+        lock = asyncio.Lock()
+        _port_locks[port] = lock
+    return lock
+
+
+async def scan_serial_ports(
+    ports: Iterable[str] | None = None,
+    baud_rates: Iterable[int] | None = None,
+    exclude_ports: Iterable[str] | None = None,
+) -> list[PortObservation]:
+    """
+    Probes every *port* at *baud_rates* and returns one observation
+    per port that produced device-like output. Ports named in
+    *exclude_ports* are skipped entirely (used by callers that hold
+    devices on those ports). Ports that are busy, absent, or silent
+    are skipped silently.
+    """
+    if ports is None:
+        port_list = sort_ports(SerialTransport.list_usb_ports())
+    else:
+        port_list = list(ports)
+    if exclude_ports is not None:
+        excluded = set(exclude_ports)
+        port_list = [p for p in port_list if p not in excluded]
+    rates = list(baud_rates) if baud_rates is not None else BAUD_CANDIDATES
+
+    info_map = {info.device: info for info in SerialTransport.list_port_info()}
+
+    observations: list[PortObservation] = []
+    for port in port_list:
+        async with _get_port_lock(port):
+            result = await _probe_port(port, rates)
+        if result is None:
+            continue
+        baudrate, data = result
+        observations.append(
+            PortObservation(
+                port=port,
+                baud_rate=baudrate,
+                data=data,
+                info=info_map.get(port),
+            )
+        )
+    return observations
+
+
+async def _probe_port(
+    port: str,
+    rates: list[int],
+) -> tuple[int, bytes] | None:
+    """
+    Attempts to get a device on *port* to talk. Tries *rates* in
+    order and returns ``(baudrate, accumulated_bytes)`` for the
+    first rate at which the device produces plausible output, or
+    None.
+    """
+    loop = asyncio.get_running_loop()
+    for baudrate in rates:
+        result = await _try_port(port, baudrate, loop)
+        if result is not None:
+            return baudrate, result
+    return None
+
+
+async def _try_port(
+    port: str,
+    baudrate: int,
+    loop: asyncio.AbstractEventLoop,
+) -> bytes | None:
+    try:
+        return await loop.run_in_executor(
+            None, _probe_port_blocking, port, baudrate
+        )
+    except OSError as e:
+        logger.debug("Probe of %s failed: %s", port, e)
+        return None
+
+
+def _probe_port_blocking(port: str, baudrate: int) -> bytes | None:
+    """
+    Synchronous probe of a single port/baud combination. Opens the
+    port, listens for a banner, nudges a silent device, and returns
+    everything it sent if the output looks like a device.
+
+    Recognition happens later, on the captured bytes, so the probe
+    always collects as much signal as it can: every nudge is sent
+    even after the device starts talking (different firmwares
+    identify themselves in different responses — a bare ``ok`` ack
+    is not enough to tell them apart), and a trailing drain catches
+    the rest of a multi-line burst.
+    """
+    try:
+        ser = serial.Serial(port=port, baudrate=baudrate, timeout=_READ_CHUNK)
+    except (OSError, serial.SerialException) as e:
+        logger.debug("Cannot open %s at %d: %s", port, baudrate, e)
+        return None
+    try:
+        buf = bytearray()
+        saw_output = _listen(ser, buf, _BANNER_TIMEOUT)
+
+        for nudge in _NUDGES:
+            try:
+                ser.write(nudge)
+                ser.flush()
+            except (OSError, serial.SerialException) as e:
+                logger.debug("Write to %s failed: %s", port, e)
+                return None
+            saw_output |= _listen(ser, buf, _NUDGE_TIMEOUT)
+
+        if not saw_output or not looks_like_device_output(bytes(buf)):
+            return None
+        _drain(ser, buf)
+        logger.debug(
+            "Observed output on %s at %d baud (%d bytes)",
+            port,
+            baudrate,
+            len(buf),
+        )
+        return bytes(buf)
+    finally:
+        try:
+            ser.close()
+        except (OSError, serial.SerialException):
+            pass
+
+
+def _listen(ser: serial.Serial, buf: bytearray, timeout: float) -> bool:
+    """
+    Reads from *ser* into *buf* for up to *timeout* seconds,
+    returning True as soon as the data captured during this call
+    looks like device output. Only new data is tested: plausible
+    output from earlier phases must not cut short later ones.
+    """
+    start = len(buf)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            chunk = ser.read(256)
+        except (OSError, serial.SerialException):
+            return False
+        if not chunk:
+            continue
+        buf.extend(chunk)
+        if looks_like_device_output(bytes(buf[start:])):
+            return True
+    return looks_like_device_output(bytes(buf[start:]))
+
+
+def _drain(ser: serial.Serial, buf: bytearray) -> None:
+    """Collects trailing burst data until the line stays quiet."""
+    deadline = time.monotonic() + _DRAIN_TIMEOUT
+    quiet = 0.0
+    last = time.monotonic()
+    while time.monotonic() < deadline and quiet < _QUIET_GAP:
+        try:
+            chunk = ser.read(256)
+        except (OSError, serial.SerialException):
+            return
+        now = time.monotonic()
+        if chunk:
+            buf.extend(chunk)
+            quiet = 0.0
+        else:
+            quiet = now - last
+        last = now
+
+
+__all__ = [
+    "BAUD_CANDIDATES",
+    "PortObservation",
+    "looks_like_device_output",
+    "scan_serial_ports",
+]

--- a/rayforge/resources/devices/acmer-p3/device.yaml
+++ b/rayforge/resources/devices/acmer-p3/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Acmer P3
+  vendor: Acmer
+  model: P3
   description: Dual-head diode laser engraver with 400x390mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/acmer-s1/device.yaml
+++ b/rayforge/resources/devices/acmer-s1/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Acmer S1
+  vendor: Acmer
+  model: S1
   description: Compact diode laser engraver with 130x130mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/atomstack-a70/device.yaml
+++ b/rayforge/resources/devices/atomstack-a70/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Atomstack A70
+  vendor: Atomstack
+  model: A70
   description: 70W diode laser cutter with 500x500mm work area and spot compression
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/atomstack-x40-pro/device.yaml
+++ b/rayforge/resources/devices/atomstack-x40-pro/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Atomstack X40 Pro
+  vendor: Atomstack
+  model: X40 Pro
   description: 40W diode laser engraver with 400x400mm work area and air assist
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/carvera-air/device.yaml
+++ b/rayforge/resources/devices/carvera-air/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Carvera Air
+  vendor: Carvera
+  model: Air
   description: Desktop laser engraver with Smoothieware controller and 300x200mm work area
 machine:
   driver: SmoothieDriver

--- a/rayforge/resources/devices/carvera/device.yaml
+++ b/rayforge/resources/devices/carvera/device.yaml
@@ -1,6 +1,7 @@
 api_version: 1
 device:
   name: Carvera
+  vendor: Carvera
   description: Desktop CNC machine with Smoothieware controller and 210x170mm work area
 machine:
   driver: SmoothieDriver

--- a/rayforge/resources/devices/creality-falcon-10w/device.yaml
+++ b/rayforge/resources/devices/creality-falcon-10w/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Creality Falcon 10W
+  vendor: Creality
+  model: Falcon 10W
   description: 10W diode laser engraver with 400x415mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/creality-falcon-2-pro/device.yaml
+++ b/rayforge/resources/devices/creality-falcon-2-pro/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Creality Falcon 2 Pro 40W
+  vendor: Creality
+  model: Falcon 2 Pro 40W
   description: Enclosed 40W diode laser engraver with 300x300mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/creality-falcon-a1/device.yaml
+++ b/rayforge/resources/devices/creality-falcon-a1/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Creality Falcon A1
+  vendor: Creality
+  model: Falcon A1
   description: Diode laser engraver with 381x305mm work area and rotary support
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/grbl-mks-dlc32/device.yaml
+++ b/rayforge/resources/devices/grbl-mks-dlc32/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Grbl MKS DLC32
+  vendor: Makerbase
+  model: DLC32
   description: GRBL-based controller board for custom laser builds
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/longer-ray5/device.yaml
+++ b/rayforge/resources/devices/longer-ray5/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Longer Ray5 20W
+  vendor: Longer
+  model: Ray5 20W
   description: Diode laser engraver with 375x375mm work area and touchscreen display
 machine:
   driver: GrblNetworkDriver

--- a/rayforge/resources/devices/monport-60w-co2/device.yaml
+++ b/rayforge/resources/devices/monport-60w-co2/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Monport 60W CO2
+  vendor: Monport
+  model: 60W CO2
   description: 60W CO2 laser cutter with 600x400mm work area and Ruida controller
 machine:
   driver: RuidaDriver

--- a/rayforge/resources/devices/neje-master-2s/device.yaml
+++ b/rayforge/resources/devices/neje-master-2s/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: NEJE Master 2s
+  vendor: NEJE
+  model: Master 2S
   description: Diode laser engraver with 170x170mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/neje-master-3-max/device.yaml
+++ b/rayforge/resources/devices/neje-master-3-max/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: NEJE Master 3 Max
+  vendor: NEJE
+  model: Master 3 Max
   description: 40W diode laser engraver with 460x460mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/omtech-k40plus/device.yaml
+++ b/rayforge/resources/devices/omtech-k40plus/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: OMTech K40+
+  vendor: OMTech
+  model: K40+
   description: CO2 laser cutter with 300x200mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/omtech-polar/device.yaml
+++ b/rayforge/resources/devices/omtech-polar/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: OMTech Polar 50W
+  vendor: OMTech
+  model: Polar 50W
   description: Desktop 50W CO2 laser cutter with 508x305mm work area and Ruida controller
 machine:
   driver: RuidaDriver

--- a/rayforge/resources/devices/ortur-laser-master-3/device.yaml
+++ b/rayforge/resources/devices/ortur-laser-master-3/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Ortur Laser Master 3
+  vendor: Ortur
+  model: Laser Master 3
   description: Diode laser engraver with 400x400mm work area and 32-bit controller
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/ortur-laser-master-4/device.yaml
+++ b/rayforge/resources/devices/ortur-laser-master-4/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Ortur Laser Master 4
+  vendor: Ortur
+  model: Laser Master 4
   description: Diode laser engraver with 400x400mm work area and high-speed capabilities
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/sculpfun-c1/device.yaml
+++ b/rayforge/resources/devices/sculpfun-c1/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun C1
+  vendor: Sculpfun
+  model: C1
   description: Budget diode laser engraver with 150x130mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/sculpfun-icube/device.yaml
+++ b/rayforge/resources/devices/sculpfun-icube/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun iCube
+  vendor: Sculpfun
+  model: iCube
   description: Compact diode laser engraver with 120x120mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/sculpfun-s30-pro-max/device.yaml
+++ b/rayforge/resources/devices/sculpfun-s30-pro-max/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun S30 Pro Max
+  vendor: Sculpfun
+  model: S30 Pro Max
   description: 20W diode laser engraver with 370x360mm work area and automatic
     air-assist
 machine:

--- a/rayforge/resources/devices/sculpfun-s30/device.yaml
+++ b/rayforge/resources/devices/sculpfun-s30/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun S30
+  vendor: Sculpfun
+  model: S30
   description: Budget diode laser engraver with 400x400mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/sculpfun-s40-max/device.yaml
+++ b/rayforge/resources/devices/sculpfun-s40-max/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun S40 MAX
+  vendor: Sculpfun
+  model: S40 MAX
   description: 48W diode laser cutter with 830x800mm work area and auto-focus
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/sculpfun-s70-max/device.yaml
+++ b/rayforge/resources/devices/sculpfun-s70-max/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Sculpfun S70 MAX
+  vendor: Sculpfun
+  model: S70 MAX
   description: 70W diode laser cutter with 830x800mm work area and auto-focus
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/thunder-laser-nova35/device.yaml
+++ b/rayforge/resources/devices/thunder-laser-nova35/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: Thunder Laser Nova 35
+  vendor: Thunder Laser
+  model: Nova 35
   description: 80W CO2 laser cutter with 900x600mm work area and Ruida controller
 machine:
   driver: RuidaDriver

--- a/rayforge/resources/devices/twotrees-tts55/device.yaml
+++ b/rayforge/resources/devices/twotrees-tts55/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: TwoTrees TTS-55
+  vendor: TwoTrees
+  model: TTS-55
   description: 55W diode laser engraver with 400x400mm work area
 machine:
   driver: GrblSerialDriver

--- a/rayforge/resources/devices/xtool-d1-pro/device.yaml
+++ b/rayforge/resources/devices/xtool-d1-pro/device.yaml
@@ -1,6 +1,8 @@
 api_version: 1
 device:
   name: xTool D1 Pro
+  vendor: xTool
+  model: D1 Pro
   description: Diode laser engraver with 430x390mm work area, connected via Wi-Fi
 machine:
   driver: GrblNetworkDriver

--- a/rayforge/ui_gtk/machine/laser_control_widget.py
+++ b/rayforge/ui_gtk/machine/laser_control_widget.py
@@ -141,9 +141,18 @@ class LaserControlWidget(Gtk.Box):
                 self._on_connection_status_changed
             )
             self.machine.changed.disconnect(self._on_machine_changed)
-            self.machine.controller.laser_power_changed.disconnect(
-                self._on_laser_power_changed
-            )
+            # The laser power signal is sourced directly from the
+            # controller object rather than proxied through the
+            # machine. When the old machine has been removed (e.g. the
+            # user deleted it), its controller is torn down before
+            # this handler runs, so accessing ``controller`` would
+            # lazily fail with a ValueError. Skip the disconnect in
+            # that case: the controller (and its signal) is already
+            # gone, so there is nothing left to detach.
+            if self.machine.has_controller:
+                self.machine.controller.laser_power_changed.disconnect(
+                    self._on_laser_power_changed
+                )
         self.machine = machine
         self.machine_cmd = machine_cmd
         if self.machine:

--- a/rayforge/ui_gtk/machine/unified_wizard.py
+++ b/rayforge/ui_gtk/machine/unified_wizard.py
@@ -27,7 +27,12 @@ from ...camera.v4l import display_name
 from ...context import get_context
 from ...core.ai.spec_lookup import is_ai_configured
 from ...machine.device.profile import DeviceProfile
-from ...machine.driver import get_driver_cls
+from ...machine.driver import (
+    DeviceIdentity,
+    DiscoveredDevice,
+    get_driver_cls,
+    normalize_tokens,
+)
 from ...machine.driver.dummy import NoDeviceDriver
 from ..camera.wizard.wizard import CameraWizard
 from ..shared.patched_dialog_window import PatchedDialogWindow
@@ -36,6 +41,7 @@ from .wizard_pages.ai_lookup_page import AILookupPage
 from .wizard_pages.camera_page import CameraPage
 from .wizard_pages.connection_page import ConnectionPage
 from .wizard_pages.controller_page import ControllerPage
+from .wizard_pages.discover_page import DiscoverPage
 from .wizard_pages.hardware_page import HardwarePage
 from .wizard_pages.head_page import HeadPage
 from .wizard_pages.probe_page import ProbePage
@@ -50,6 +56,7 @@ logger = logging.getLogger(__name__)
 # Ordered list of step names the wizard knows about. Adaptive routing
 # may skip individual entries based on the user's choices.
 _STEP_ORDER: list[str] = [
+    "discover",
     "profile",
     "controller",
     "connect",
@@ -137,8 +144,8 @@ class UnifiedWizard(PatchedDialogWindow):
 
         self._build_buttons(self._main_box)
 
-        # Initial state: profile page is step 1.
-        self._navigate_to("profile", record_history=False)
+        # Initial state: discovery page is step 1.
+        self._navigate_to("discover", record_history=False)
 
     # ----- public API ----------------------------------------------------
 
@@ -204,7 +211,9 @@ class UnifiedWizard(PatchedDialogWindow):
     def _get_page(self, name: str) -> WizardPage | None:
         # Step 1 traverses the wizard in declared order — only "next",
         # "back", "skip", and the adaptive router call this.
-        if name == "profile":
+        if name == "discover":
+            cls = DiscoverPage
+        elif name == "profile":
             cls = ProfilePage
         elif name == "controller":
             cls = ControllerPage
@@ -247,7 +256,9 @@ class UnifiedWizard(PatchedDialogWindow):
             return None
 
     def _wire_page_signals(self, page: WizardPage, name: str) -> None:
-        if isinstance(page, ProfilePage):
+        if isinstance(page, DiscoverPage):
+            page.device_selected.connect(self._on_device_selected)
+        elif isinstance(page, ProfilePage):
             page.source_selected.connect(self._on_profile_source_selected)
         elif isinstance(page, ControllerPage):
             page.controller_selected.connect(self._on_controller_selected)
@@ -308,7 +319,10 @@ class UnifiedWizard(PatchedDialogWindow):
         # Next vs Create: Create replaces Next on the final step
         # ("review"). Pages that opt out of the generic Next (e.g.
         # Step 1, which advances via explicit source selection) hide
-        # it entirely so no dead buttons sit on the footer.
+        # it entirely so no dead buttons sit on the footer. Pages may
+        # relabel Next (e.g. "Configure Manually" on the discover
+        # step).
+        self.next_btn.set_label(page.next_label or _("Next"))
         self.next_btn.set_visible(name != "review" and page.next_on_footer)
         self.create_btn.set_visible(name == "review")
 
@@ -400,11 +414,11 @@ class UnifiedWizard(PatchedDialogWindow):
         """Where the wizard enters the AI flow after probing/connection.
 
         A known profile or import already carries the machine specs,
-        so the AI provider / lookup steps are skipped entirely. A known
-        *profile* also trusts the work-area and head specs, so the
-        hardware and head steps are skipped too (the user still adds
-        rotary modules / cameras). Imports are not 100% reliable, so
-        the user is walked through hardware and head with prefilled
+        so the AI provider / lookup steps are skipped entirely. A
+        known *profile* is the source of truth for the whole machine
+        — specs, head, rotary modules, cameras — so everything up to
+        the review is skipped. Imports are not 100% reliable, so the
+        user is walked through hardware and head with prefilled
         values they can correct. For "Other / unknown machine", the
         user is first asked on the provider page when none is
         configured; otherwise the lookup page comes up directly.
@@ -412,9 +426,16 @@ class UnifiedWizard(PatchedDialogWindow):
         kind = self._source_kind()
         if kind == "profile":
             self._skipped_steps_set.update(
-                {"ai_provider", "ai_lookup", "hardware", "head"}
+                {
+                    "ai_provider",
+                    "ai_lookup",
+                    "hardware",
+                    "head",
+                    "rotary",
+                    "camera",
+                }
             )
-            return "rotary"
+            return "review"
         if kind == "import":
             self._skipped_steps_set.update({"ai_provider", "ai_lookup"})
             return "hardware"
@@ -423,6 +444,12 @@ class UnifiedWizard(PatchedDialogWindow):
     def _next_step_after(self, name: str) -> str | None:
         """Decides the next step using the adaptive routing rules."""
         mc = self.profile.machine_config
+
+        if name == "discover":
+            # Plain Next means "Configure Manually" — the regular
+            # profile-first flow. (Selecting a found device routes
+            # via _on_device_selected instead.)
+            return "profile"
 
         if name == "profile":
             # Routing is set by source_selected signal. If we got here
@@ -460,6 +487,11 @@ class UnifiedWizard(PatchedDialogWindow):
             return self._ai_entry_step()
 
         if name == "probe":
+            # A discovery-originated probe that did not resolve to a
+            # profile continues on the (vendor-filtered) profile
+            # picker; manual flows go on to the AI/manual steps.
+            if self._source is None and self.aux_state.get("discovered"):
+                return "profile"
             return self._ai_entry_step()
 
         if name == "ai_provider":
@@ -494,19 +526,189 @@ class UnifiedWizard(PatchedDialogWindow):
             return
         self._navigate_to(next_step)
 
+    def _on_device_selected(self, sender, *, device: DiscoveredDevice) -> None:
+        """Step 1: the user picked an automatically discovered device.
+
+        The device arrives with everything collected without
+        interaction: driver, connection parameters, and — when the
+        driver supports probing — the machine's own answers about
+        its identity and specs. All of it feeds one profile match;
+        on a unique match the curated profile is adopted and the
+        wizard continues with whatever data is still missing.
+        Otherwise the user picks a profile from a vendor-filtered
+        list, with the collected data already in place.
+        """
+        self.profile = empty_profile()
+        self.profile.machine_config.driver = device.driver_name
+        self._overlay_driver_args(device)
+        if device.probe_profile is not None:
+            self._merge_driver_config(device.probe_profile)
+
+        matched: DeviceProfile | None = None
+        try:
+            matched = get_context().device_profile_mgr.match_device(
+                self._probe_identity(device)
+            )
+        except Exception:
+            logger.exception("Profile matching failed")
+
+        if matched is not None:
+            self._adopt_matched_profile(matched, device)
+            self.aux_state = {}
+            if self._connection_args_complete():
+                self._skipped_steps_set.add("connect")
+                self._navigate_to(self._device_selected_next_step(device))
+            else:
+                self._navigate_to("connect")
+            return
+
+        # No profile match. The collected data still pre-fills the
+        # machine; the user confirms which one it is from a filtered
+        # list. The wizard-level probe page only comes up when the
+        # page-level probe could not produce data.
+        self.aux_state = {"discovered": device}
+        self._source = None
+        self._skipped_steps_set.add("controller")
+        if device.probe_profile is not None:
+            self._merge_probe_specs(device.probe_profile)
+            self._skipped_steps_set.add("probe")
+        if not self._connection_args_complete():
+            self._navigate_to("profile")
+            return
+        self._skipped_steps_set.add("connect")
+        if device.probe_profile is None and self._driver_can_probe(device):
+            self._navigate_to("probe")
+            return
+        self._navigate_to("profile")
+
+    def _device_selected_next_step(self, device: DiscoveredDevice) -> str:
+        """Where to go after adopting a discovered device's parameters.
+
+        With probe data already collected there is nothing left to
+        run; otherwise a probe on the dedicated page verifies the
+        connection and collects the machine's specs.
+        """
+        if device.probe_profile is not None:
+            self._skipped_steps_set.add("probe")
+            return self._ai_entry_step()
+        if self._driver_can_probe(device):
+            return "probe"
+        return self._ai_entry_step()
+
+    def _driver_can_probe(self, device: DiscoveredDevice) -> bool:
+        driver_cls = get_driver_cls(device.driver_name)
+        return (
+            driver_cls is not None
+            and driver_cls is not NoDeviceDriver
+            and driver_cls.supports_probing
+        )
+
+    def _probe_identity(self, device: DiscoveredDevice) -> DeviceIdentity:
+        """The device's identity, strengthened by what its probe
+        reported (e.g. Grbl's ``[MSG:machine:...]`` name)."""
+        identity = device.identity
+        name = device.probe_name
+        if name is None:
+            return identity
+        return DeviceIdentity(
+            firmware=identity.firmware,
+            banner=name,
+            usb_vid=identity.usb_vid,
+            usb_pid=identity.usb_pid,
+            tokens=identity.tokens | normalize_tokens(name),
+        )
+
+    def _adopt_matched_profile(
+        self, matched: DeviceProfile, device: DiscoveredDevice
+    ) -> None:
+        """Adopts a curated profile, keeping the live connection
+        facts (driver_args and driver_config) collected from the
+        actual device."""
+        live_args = dict(self.profile.machine_config.driver_args or {})
+        live_config = dict(self.profile.machine_config.driver_config or {})
+        self.profile = self._clone_profile(matched)
+        self.profile.machine_config.driver_args = live_args or None
+        if live_config:
+            curated = self.profile.machine_config.driver_config or {}
+            self.profile.machine_config.driver_config = {
+                **curated,
+                **live_config,
+            }
+        self._source = {
+            "kind": "profile",
+            "profile": matched,
+            "device": device,
+        }
+        self._skipped_steps_set.update({"profile", "controller"})
+
+    def _merge_driver_config(self, probed: DeviceProfile) -> None:
+        """Overlays hardware facts a probe measured (RX buffer size,
+        firmware version) onto the working profile."""
+        config = probed.machine_config.driver_config
+        if not config:
+            return
+        merged = dict(self.profile.machine_config.driver_config or {})
+        merged.update(config)
+        self.profile.machine_config.driver_config = merged
+
+    def _merge_probe_specs(self, probed: DeviceProfile) -> None:
+        """Overlays every machine spec a probe collected onto the
+        working profile."""
+        dst = self.profile.machine_config
+        for field_name in self._PROBE_MERGE_FIELDS:
+            value = getattr(probed.machine_config, field_name, None)
+            if value is not None:
+                setattr(dst, field_name, value)
+
+    def _connection_args_complete(self) -> bool:
+        """True when driver_args cover every required setup variable."""
+        mc = self.profile.machine_config
+        if not mc.driver:
+            return False
+        driver_cls = get_driver_cls(mc.driver)
+        if driver_cls is None or driver_cls is NoDeviceDriver:
+            return True
+        saved = mc.driver_args or {}
+        for var in driver_cls.get_setup_vars():
+            if var.default in (None, "") and saved.get(var.key) in (
+                None,
+                "",
+            ):
+                return False
+        return True
+
+    def _overlay_driver_args(self, device: DiscoveredDevice) -> None:
+        """Merges a discovered device's connection parameters into the
+        working profile's driver_args."""
+        args = dict(self.profile.machine_config.driver_args or {})
+        args.update(device.params)
+        self.profile.machine_config.driver_args = args or None
+
     def _on_profile_source_selected(
         self, sender, *, kind: str, profile: DeviceProfile | None
     ) -> None:
-        """Step 1: the user picked a starting point."""
+        """Step 2: the user picked a starting point."""
+        discovered = self.aux_state.get("discovered")
         if kind == "other":
-            # Start fresh; the controller page takes over.
+            # Start fresh; the controller page takes over. Connection
+            # parameters and probe data from a discovered device (if
+            # any) survive.
             self.profile = empty_profile()
+            if isinstance(discovered, DiscoveredDevice):
+                self.profile.machine_config.driver = discovered.driver_name
+                self._overlay_driver_args(discovered)
+                if discovered.probe_profile is not None:
+                    self._merge_probe_specs(discovered.probe_profile)
             self.aux_state = {}
             self._source = None
         elif kind in ("profile", "import") and profile is not None:
-            # Adopt the picked profile's data as our working state; we
-            # still require Step 3 (Connection) per design decision #5.
+            # Adopt the picked profile's data as our working state;
+            # live connection facts from the discovery survive.
             self.profile = self._clone_profile(profile)
+            if isinstance(discovered, DiscoveredDevice):
+                self._overlay_driver_args(discovered)
+                if discovered.probe_profile is not None:
+                    self._merge_driver_config(discovered.probe_profile)
             self.aux_state = {}
             # Stash chosen source for later sanity feedback
             self._source = {"kind": kind, "profile": profile}
@@ -515,46 +717,68 @@ class UnifiedWizard(PatchedDialogWindow):
             self.aux_state = {}
             self._source = None
 
-        # Step 1 → Step 3 for known/import, Step 1 → Step 2 for "Other".
-        # Navigate with history recording so "profile" stays on the
-        # stack: the user can press Back to change their source choice.
-        target: str
-        if kind == "other":
-            target = "controller"
-        else:
-            # Jump straight to connection (the picked profile fixes the
-            # controller); Back returns to the profile picker.
+        if kind == "other" and discovered is None:
+            self._navigate_to("controller")
+            return
+        if not isinstance(discovered, DiscoveredDevice):
+            # Manual flow: profiles never carry host-specific values,
+            # so the connection step is always required.
             self._skipped_steps_set.add("controller")
-            target = "connect"
-        self._navigate_to(target)
+            self._navigate_to("connect")
+            return
+        # Discovery flow: driver and connection data are set; the
+        # probe already ran (or cannot run).
+        self._skipped_steps_set.update({"controller", "probe"})
+        if self._connection_args_complete():
+            self._skipped_steps_set.add("connect")
+            self._navigate_to(self._ai_entry_step())
+        else:
+            self._navigate_to("connect")
+
+    # Machine-config fields a probe can collect; overlaid onto the
+    # working profile when no curated profile is adopted.
+    _PROBE_MERGE_FIELDS = (
+        "driver_args",
+        "driver_config",
+        "axis_extents",
+        "origin",
+        "max_travel_speed",
+        "max_cut_speed",
+        "acceleration",
+        "single_axis_homing_enabled",
+        "home_on_start",
+        "heads",
+        "unit_system",
+    )
 
     def _on_probe_succeeded(
         self, sender, *, profile: DeviceProfile, warnings: list[str]
     ) -> None:
         """Step 4: the probe merged values into a working profile."""
-        # Merge probed machine_config fields into our working profile.
-        # Probe returns a full DeviceProfile; we overlay every
-        # non-None field of its machine_config onto our profile.
-        src = profile.machine_config
-        dst = self.profile.machine_config
-        for field_name in (
-            "driver_args",
-            "driver_config",
-            "axis_extents",
-            "origin",
-            "max_travel_speed",
-            "max_cut_speed",
-            "acceleration",
-            "single_axis_homing_enabled",
-            "home_on_start",
-            "heads",
-            "unit_system",
-        ):
-            value = getattr(src, field_name, None)
-            if value is not None:
-                setattr(dst, field_name, value)
+        self._merge_probe_specs(profile)
         for text in warnings:
             logger.info("Probing warning: %s", text)
+        self._adopt_profile_from_probe(profile)
+
+    def _adopt_profile_from_probe(self, probed: DeviceProfile) -> None:
+        """Adopts a curated profile when the probe's answers identify
+        the machine (discovery-originated probes only)."""
+        if self._source is not None:
+            return
+        device = self.aux_state.get("discovered")
+        if not isinstance(device, DiscoveredDevice):
+            return
+        device = dc_replace(device, probe_profile=probed)
+        try:
+            matched = get_context().device_profile_mgr.match_device(
+                self._probe_identity(device)
+            )
+        except Exception:
+            logger.exception("Profile matching failed")
+            return
+        if matched is None:
+            return
+        self._adopt_matched_profile(matched, device)
 
     # ----- camera workflow ----------------------------------------------
 

--- a/rayforge/ui_gtk/machine/wizard_pages/__init__.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/__init__.py
@@ -49,6 +49,9 @@ class WizardPage(Adw.Bin):
     # page advances only through its own explicit affordances (e.g.
     # Step 1, which fires source_selected on row activation).
     next_on_footer: bool = True
+    # Optional override for the footer "Next" button label (e.g.
+    # "Configure Manually" on the discover step).
+    next_label: str | None = None
 
     def __init__(self, wizard: "UnifiedWizard", **kwargs):
         super().__init__(**kwargs)

--- a/rayforge/ui_gtk/machine/wizard_pages/ai_lookup_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/ai_lookup_page.py
@@ -79,7 +79,7 @@ def _format_value(value: Any, kind: str) -> str:
 
 
 class AILookupPage(WizardPage):
-    step_number = 6
+    step_number = 7
     title = _("AI Spec Lookup")
     subtitle = _(
         "If your machine is a known commercial model, the AI can "

--- a/rayforge/ui_gtk/machine/wizard_pages/camera_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/camera_page.py
@@ -29,7 +29,7 @@ from . import WizardPage, _makePreferencesGroup
 
 
 class CameraPage(WizardPage):
-    step_number = 10
+    step_number = 11
     title = _("Cameras")
     subtitle = _(
         "Optional. Configure any cameras you want to use for "

--- a/rayforge/ui_gtk/machine/wizard_pages/connection_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/connection_page.py
@@ -1,9 +1,11 @@
-"""Step 3 — Connection parameters.
+"""Step 4 — Connection parameters.
 
 Always required: even after picking a known profile or importing a
 snapshot, the user must supply host-specific values like the USB
 device path, IP address, hostname, or OctoPrint API key. The page
 prefills any defaults the profile supplies and leaves the rest blank.
+(Device discovery happens up front on the wizard's first page; any
+parameters it produced are prefilled here.)
 
 Reuses :class:`~rayforge.ui_gtk.varset.varsetwidget.VarSetWidget` to
 render the driver's ``get_setup_vars()`` definition, mirroring the
@@ -11,6 +13,7 @@ pattern in the legacy ``config_wizard.py``.
 """
 
 from gettext import gettext as _
+from typing import TYPE_CHECKING, Any
 
 from gi.repository import Adw, Gtk
 
@@ -20,15 +23,18 @@ from ....machine.driver.driver import Driver
 from ...varset.varsetwidget import VarSetWidget
 from . import WizardPage, _makePreferencesGroup
 
+if TYPE_CHECKING:
+    from ..unified_wizard import UnifiedWizard
+
 
 class ConnectionPage(WizardPage):
-    step_number = 3
+    step_number = 4
     title = _("Connection")
     subtitle = _("Enter the connection parameters for your device.")
 
-    def __init__(self, wizard, **kwargs):
+    def __init__(self, wizard: "UnifiedWizard", **kwargs: Any) -> None:
         self._driver_cls: type[Driver] | None = None
-        self._required_keys: set = set()
+        self._required_keys: set[str] = set()
         super().__init__(wizard, **kwargs)
 
     def build_ui(self) -> None:
@@ -88,7 +94,7 @@ class ConnectionPage(WizardPage):
         self.connect_widget.populate(var_set)
         self._refresh_ready()
 
-    def _on_data_changed(self, sender, **kwargs) -> None:
+    def _on_data_changed(self, sender: Any, **kwargs: Any) -> None:
         self._refresh_ready()
 
     def _refresh_ready(self) -> None:
@@ -117,7 +123,7 @@ class ConnectionPage(WizardPage):
             self.wizard.show_error(_("Invalid input"), str(exc))
             return False
         # Drop empty-string / None values so we don't blur defaults.
-        cleaned: dict = {}
+        cleaned: dict[str, Any] = {}
         for key, value in values.items():
             if value in (None, ""):
                 continue

--- a/rayforge/ui_gtk/machine/wizard_pages/controller_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/controller_page.py
@@ -36,7 +36,7 @@ _EXPORT_ONLY_ICON = "document-save-symbolic"
 
 
 class ControllerPage(WizardPage):
-    step_number = 2
+    step_number = 3
     title = _("Choose Controller")
     subtitle = _("What kind of controller board does this machine use?")
 

--- a/rayforge/ui_gtk/machine/wizard_pages/discover_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/discover_page.py
@@ -1,0 +1,300 @@
+"""Step 1 — Automatic device discovery.
+
+Starts scanning for machines the moment the wizard opens — before
+the user has selected anything. Every driver that declares a
+``DISCOVERY`` recognizer participates (see
+:mod:`rayforge.machine.driver.discovery`); found devices are listed
+as rows the user can activate to adopt them.
+
+Discovery and data collection are fully automatic: as soon as a
+device is identified, its driver is asked to probe it (firmware
+build info, working area, speeds) and the row is updated with what
+the device reported — e.g. "Sculpfun iCube, 120×120 mm". The user
+never interacts with this page beyond picking a row.
+
+The page keeps polling while it is visible so devices plugged in
+later show up on their own. Ports of already-found devices are
+excluded from rescans: re-opening them would reset some boards
+(DTR toggle) and fight with an in-flight probe. The footer's Next
+button is relabeled "Configure Manually" and leads to the regular
+profile-first flow.
+"""
+
+import logging
+from dataclasses import replace
+from gettext import gettext as _
+from typing import TYPE_CHECKING, Any
+
+from blinker import Signal
+from gi.repository import Adw, GLib, Gtk
+
+from ....context import get_context
+from ....machine.device.profile import DeviceProfile
+from ....machine.driver import (
+    DiscoveredDevice,
+    find_all_devices,
+    get_driver_cls,
+)
+from ....machine.transport import SerialTransport
+from ....shared.tasker import task_mgr
+from ....shared.tasker.context import ExecutionContext
+from . import WizardPage, _makePreferencesGroup
+
+if TYPE_CHECKING:
+    from ..unified_wizard import UnifiedWizard
+
+logger = logging.getLogger(__name__)
+
+# Seconds between automatic re-scans while the page is visible.
+_RESCAN_INTERVAL_S = 5
+
+
+class _DeviceRow(Adw.ActionRow):
+    """A custom row to hold a reference to its discovered device."""
+
+    def __init__(self, device: DiscoveredDevice, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.device: DiscoveredDevice = device
+        # Rows are not obviously clickable; an explicit Select
+        # button states the action. The whole row stays activatable.
+        self.select_button = Gtk.Button(label=_("Select"))
+        self.select_button.set_valign(Gtk.Align.CENTER)
+        self.select_button.add_css_class("suggested-action")
+        self.select_button.connect("clicked", lambda *_: self.activate())
+        self.add_suffix(self.select_button)
+
+
+class DiscoverPage(WizardPage):
+    step_number = 1
+    title = _("Add a Machine")
+    subtitle = _(
+        "Connect your machine via USB — we will find it automatically."
+    )
+    next_label = _("Configure Manually")
+
+    # Sent when the user activates a discovered-device row. Payload
+    # ``device`` is the picked DiscoveredDevice, including any probe
+    # data collected by then.
+    device_selected = Signal()
+
+    def __init__(self, wizard: "UnifiedWizard", **kwargs: Any) -> None:
+        # Bumped on every scan start; stale completion callbacks are
+        # ignored by comparing against this.
+        self._scan_generation: int = 0
+        self._device_rows: dict[str, _DeviceRow] = {}
+        # Ports of found devices; excluded from rescans (see module
+        # docstring) and monitored for unplug.
+        self._held_ports: set[str] = set()
+        super().__init__(wizard, **kwargs)
+
+    def build_ui(self) -> None:
+        self.group = _makePreferencesGroup(
+            title=_("Detected Devices"),
+            description=_(
+                "Plug in and power on your machine. Devices found on "
+                "USB serial connections appear here automatically."
+            ),
+        )
+        self.content.append(self.group)
+
+        self.spinner = Gtk.Spinner()
+        self.status_label = Gtk.Label(label=_("Searching for devices…"))
+        self.status_label.add_css_class("dim-label")
+        self.status_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=6,
+            halign=Gtk.Align.CENTER,
+            margin_top=6,
+            margin_bottom=6,
+        )
+        self.status_box.append(self.spinner)
+        self.status_box.append(self.status_label)
+        self.content.append(self.status_box)
+
+        self.set_ready(True)
+
+    def enter(self, profile: DeviceProfile) -> None:
+        # (Re-)start discovery from scratch every time the page is
+        # shown; the generation bump invalidates stale callbacks.
+        self._start_scan()
+
+    def footer_buttons(self) -> list[Gtk.Button]:
+        return []
+
+    # ----- scanning --------------------------------------------------------
+
+    def _start_scan(self) -> None:
+        self._scan_generation += 1
+        generation = self._scan_generation
+        self._show_scanning()
+
+        async def _coroutine(exec_ctx: ExecutionContext) -> Any:
+            return await find_all_devices(exclude_ports=self._held_ports)
+
+        task_mgr.add_coroutine(
+            _coroutine,
+            key=f"wizard-device-discovery-{id(self.wizard)}",
+            when_done=lambda task: self._on_scan_done(task, generation),
+        )
+
+    def _on_scan_done(self, task: Any, generation: int) -> None:
+        # Marshal back to the GTK main thread before touching widgets.
+        def _update() -> None:
+            if generation != self._scan_generation or not self.get_mapped():
+                return
+            try:
+                devices = task.result()
+            except Exception:
+                logger.exception("Device discovery failed")
+                devices = []
+            if task.get_status() != "completed":
+                return
+            self._prune_unplugged_ports()
+            self._update_devices(devices or [])
+            GLib.timeout_add_seconds(_RESCAN_INTERVAL_S, self._on_rescan_timer)
+
+        task_mgr.schedule_on_main_thread(_update)
+
+    def _on_rescan_timer(self) -> bool:
+        """Periodic re-scan while the page is visible."""
+        if not self.get_mapped():
+            return False
+        self._start_scan()
+        return False
+
+    def _show_scanning(self) -> None:
+        self.status_label.set_text(_("Searching for devices…"))
+        self.spinner.start()
+        self.status_box.set_visible(True)
+
+    def _update_devices(self, devices: list[DiscoveredDevice]) -> None:
+        """Reconciles the visible rows with the scan results."""
+        keep: set[str] = set()
+        for device in devices:
+            keep.add(device.key)
+            port = device.params.get("port")
+            if isinstance(port, str):
+                self._held_ports.add(port)
+            existing = self._device_rows.get(device.key)
+            if existing is not None:
+                continue
+            row = _DeviceRow(
+                device=device,
+                title=device.label,
+                subtitle=_row_subtitle(device),
+                activatable=True,
+            )
+            row.connect("activated", self._on_row_activated)
+            self._device_rows[device.key] = row
+            self.group.add(row)
+            self._start_probe(device)
+
+        for key, row in list(self._device_rows.items()):
+            if key in keep:
+                continue
+            # Devices on held ports are excluded from rescans, so
+            # their absence from the results is expected; they are
+            # dropped by _prune_unplugged_ports instead.
+            port = row.device.params.get("port")
+            if isinstance(port, str) and port in self._held_ports:
+                continue
+            self._remove_row(key)
+
+        if self._device_rows:
+            self.spinner.stop()
+            self.status_box.set_visible(False)
+        else:
+            self.status_label.set_text(_("No devices detected yet"))
+            self.spinner.start()
+            self.status_box.set_visible(True)
+
+    def _remove_row(self, key: str) -> None:
+        row = self._device_rows.pop(key, None)
+        if row is not None:
+            self.group.remove(row)
+
+    def _prune_unplugged_ports(self) -> None:
+        """Drops rows whose port has vanished from the system."""
+        try:
+            present = {i.device for i in SerialTransport.list_port_info()}
+        except Exception:
+            logger.debug(
+                "Could not enumerate ports for pruning", exc_info=True
+            )
+            return
+        for key, row in list(self._device_rows.items()):
+            port = row.device.params.get("port")
+            if isinstance(port, str) and port not in present:
+                self._held_ports.discard(port)
+                self._remove_row(key)
+
+    # ----- probing ---------------------------------------------------------
+
+    def _start_probe(self, device: DiscoveredDevice) -> None:
+        """Asks the device itself for its specs, without interaction.
+
+        The row is already usable when the probe finishes; the probe
+        only enriches it (machine name, working area) and equips the
+        wizard to match a device profile automatically.
+        """
+        driver_cls = get_driver_cls(device.driver_name)
+        if driver_cls is None or not driver_cls.supports_probing:
+            return
+        context = get_context()
+        params = dict(device.params)
+
+        async def _coroutine(exec_ctx: ExecutionContext) -> Any:
+            return await driver_cls.probe(context, **params)
+
+        task_mgr.add_coroutine(
+            _coroutine,
+            key=f"wizard-device-probe-{device.key}",
+            when_done=lambda task: self._on_probe_done(task, device),
+        )
+
+    def _on_probe_done(self, task: Any, device: DiscoveredDevice) -> None:
+        def _update() -> None:
+            row = self._device_rows.get(device.key)
+            if row is None:
+                return
+            try:
+                profile, warnings = task.result()
+            except Exception:
+                logger.debug(
+                    "Probe of discovered device %s failed",
+                    device.key,
+                    exc_info=True,
+                )
+                return
+            for text in warnings:
+                logger.info("Probing warning: %s", text)
+            enriched = replace(device, probe_profile=profile)
+            row.device = enriched
+            name = enriched.probe_name
+            if name:
+                row.set_title(name)
+            row.set_subtitle(_row_subtitle(enriched))
+
+        task_mgr.schedule_on_main_thread(_update)
+
+    def _on_row_activated(self, row: _DeviceRow) -> None:
+        self.device_selected.send(self, device=row.device)
+
+    def _on_select_clicked(self, _button: Gtk.Button, row: _DeviceRow) -> None:
+        self._on_row_activated(row)
+
+
+def _row_subtitle(device: DiscoveredDevice) -> str:
+    """The two-line description under a device row."""
+    parts = [device.detail]
+    if device.probe_profile is not None:
+        extents = device.probe_profile.machine_config.axis_extents
+        if extents is not None:
+            width, height = extents
+            parts.append(_("{w}×{h} mm work area").format(w=width, h=height))
+    elif device.identity.banner:
+        parts.append(device.identity.banner)
+    return "\n".join(parts)
+
+
+__all__ = ["DiscoverPage"]

--- a/rayforge/ui_gtk/machine/wizard_pages/hardware_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/hardware_page.py
@@ -39,7 +39,7 @@ _DEFAULT_ACCELERATION = 1000.0
 
 
 class HardwarePage(WizardPage):
-    step_number = 7
+    step_number = 8
     title = _("Hardware")
     subtitle = _("Work area, origin, speeds and acceleration.")
 

--- a/rayforge/ui_gtk/machine/wizard_pages/head_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/head_page.py
@@ -37,7 +37,7 @@ def _is_spindle_head_dict(head: dict[str, Any] | None) -> bool:
 
 
 class HeadPage(WizardPage):
-    step_number = 8
+    step_number = 9
     title = _("Head")
     subtitle = _("What's attached to the gantry: a laser, a spindle, or both?")
 

--- a/rayforge/ui_gtk/machine/wizard_pages/probe_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/probe_page.py
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 
 
 class ProbePage(WizardPage):
-    step_number = 4
-    title = _("Discover Device")
+    step_number = 5
+    title = _("Probe Device")
     subtitle = _(
         "Connect to the device and read its configuration, "
         "or skip to enter the values manually."

--- a/rayforge/ui_gtk/machine/wizard_pages/profile_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/profile_page.py
@@ -6,11 +6,16 @@ Offers the user three entry points:
   searchable list. The chosen profile pre-fills driver + dims + head;
   Step 3 (Connection) is still required because profiles never carry
   host-specific values like the USB device path or OctoPrint API key.
-* **Other / unknown machine**: skip to Step 2 where the user picks the
-  controller class manually.
+* **Other / unknown machine**: skip to Step 2 where the user picks
+  the controller class manually.
 * **Import .lbdev / .zip**: pull a snapshot from disk. Same treatment
   as a known profile but Step 3 is also prefilled with any connection
   args saved in the snapshot.
+
+When a discovered device is pending (no profile matched it
+automatically), the list is pre-filtered to profiles of the same
+vendor and controller, since the collected identity says which
+machine family it belongs to. Searching always covers everything.
 """
 
 from gettext import gettext as _
@@ -20,6 +25,7 @@ from gi.repository import Adw, Gtk
 
 from ....context import get_context
 from ....machine.device.profile import DeviceProfile
+from ....machine.driver import DiscoveredDevice, normalize_tokens
 from ..profile_importer import open_profile_file
 from . import WizardPage, _makePreferencesGroup
 
@@ -33,8 +39,8 @@ class _ProfileRow(Adw.ActionRow):
 
 
 class ProfilePage(WizardPage):
-    step_number = 1
-    title = _("Add a Machine")
+    step_number = 2
+    title = _("Choose a Machine")
     subtitle = _("Pick a starting point for the new machine.")
     # The page advances only through explicit source selection (row
     # activation, Import, or Unlisted Device, so the wizard's
@@ -46,10 +52,22 @@ class ProfilePage(WizardPage):
     # the next page.
     def __init__(self, wizard, **kwargs):
         self._all_profiles: list[DeviceProfile] = []
+        self._suggested_profiles: list[DeviceProfile] = []
         self.source_selected = Signal()
         super().__init__(wizard, **kwargs)
 
     def build_ui(self) -> None:
+        self.hint_row = Adw.ActionRow(
+            title=_("A device was detected"),
+            subtitle=_(
+                "No profile matched it automatically. Pick the "
+                "matching profile below, or continue with "
+                "'Device Not Listed'."
+            ),
+        )
+        self.hint_row.set_visible(False)
+        self.content.append(self.hint_row)
+
         group = _makePreferencesGroup(
             title=_("Machine Templates"),
             description=_(
@@ -92,16 +110,48 @@ class ProfilePage(WizardPage):
         return [self.import_button, self.other_button]
 
     def enter(self, profile: DeviceProfile) -> None:
+        discovered = self.wizard.aux_state.get("discovered")
+        self.hint_row.set_visible(bool(discovered))
+        self._suggested_profiles = (
+            self._compute_suggestions(discovered)
+            if isinstance(discovered, DiscoveredDevice)
+            else []
+        )
         self._all_profiles = list(get_context().device_profile_mgr.get_all())
         self._filter_and_populate_list()
 
+    def _compute_suggestions(
+        self, discovered: DiscoveredDevice
+    ) -> list[DeviceProfile]:
+        """Profiles matching what the collected identity says about
+        the machine: same vendor tokens and same controller."""
+        name = discovered.probe_name
+        tokens = set(discovered.identity.tokens)
+        if name:
+            tokens |= normalize_tokens(name)
+        suggested = []
+        for pkg in get_context().device_profile_mgr.get_all():
+            vendor_tokens = normalize_tokens(pkg.meta.vendor or "")
+            if not vendor_tokens or not vendor_tokens <= tokens:
+                continue
+            if pkg.machine_config.driver != discovered.driver_name:
+                continue
+            suggested.append(pkg)
+        return suggested
+
     def _filter_and_populate_list(self) -> None:
         search_text = self.search_entry.get_text().lower()
+        # With a pending discovered device and no search active, the
+        # list shows only the relevant profiles; typing a search
+        # broadens it back to the full catalog.
+        pool = self._all_profiles
+        if self._suggested_profiles and not search_text:
+            pool = self._suggested_profiles
 
         while child := self.list_box.get_row_at_index(0):
             self.list_box.remove(child)
 
-        for pkg in self._all_profiles:
+        for pkg in pool:
             if (
                 search_text
                 and search_text not in pkg.name.lower()

--- a/rayforge/ui_gtk/machine/wizard_pages/provider_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/provider_page.py
@@ -21,7 +21,7 @@ _DEFAULT_BASE_URL = "https://api.openai.com/v1"
 
 
 class AIProviderPage(WizardPage):
-    step_number = 5
+    step_number = 6
     title = _("AI Provider")
     subtitle = _(
         "Configure an AI provider so the wizard can pre-fill "

--- a/rayforge/ui_gtk/machine/wizard_pages/review_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/review_page.py
@@ -101,7 +101,7 @@ def _prefill_name(profile: DeviceProfile) -> str:
 
 
 class ReviewPage(WizardPage):
-    step_number = 11
+    step_number = 12
     title = _("Review & Name")
     subtitle = _("Final name and sanity check before creating the machine.")
 

--- a/rayforge/ui_gtk/machine/wizard_pages/rotary_page.py
+++ b/rayforge/ui_gtk/machine/wizard_pages/rotary_page.py
@@ -40,7 +40,7 @@ _TYPE_ROLLERS = 1
 
 
 class RotaryPage(WizardPage):
-    step_number = 9
+    step_number = 10
     title = _("Rotary Module")
     subtitle = _(
         "Optional. Set up a rotary attachment now or skip this "

--- a/rayforge/ui_gtk/mainwindow.py
+++ b/rayforge/ui_gtk/mainwindow.py
@@ -56,6 +56,7 @@ from .machine.profile_review_dialog import (
     SchemaReviewDialog,
 )
 from .machine.settings_dialog import MachineSettingsDialog
+from .machine.unified_wizard import UnifiedWizard
 from .main_menu import MainMenu
 from .project_cmd import ProjectCmd
 from .settings.settings_dialog import SettingsWindow
@@ -152,6 +153,8 @@ class MainWindow(Adw.ApplicationWindow):
         self._surface_vis_overlay: VisibilityOverlay | None = None
         self._canvas3d_time_overlay: TimeEstimateOverlay | None = None
         self._is_syncing_3d = False
+        self._setup_wizard: UnifiedWizard | None = None
+        self._setup_wizard_completed = True
 
         # The ToastOverlay will wrap the main content box
         self.toast_overlay = Adw.ToastOverlay()
@@ -206,6 +209,16 @@ class MainWindow(Adw.ApplicationWindow):
         self.menubar = Gtk.PopoverMenuBar.new_from_model(self.menu_model)
         self.menubar.add_css_class("in-header-menubar")
         self.header_bar.pack_start(self.menubar)
+
+        # Persistent banner shown while the active machine is still the
+        # untouched placeholder created on first launch.
+        self.setup_banner = Adw.Banner()
+        self.setup_banner.set_title(_("Set up your machine to get started"))
+        self.setup_banner.set_button_label(_("Set Up Machine"))
+        self.setup_banner.connect(
+            "button-clicked", self._on_setup_banner_clicked
+        )
+        vbox.append(self.setup_banner)
 
         # Set up Recent Files manager
         self.recent_manager = Gtk.RecentManager.get_default()
@@ -557,6 +570,9 @@ class MainWindow(Adw.ApplicationWindow):
 
         # Initialize usage tracking based on saved consent
         config = get_context().config
+        consent_pending = not (
+            config.has_consented_tracking or config.has_declined_tracking
+        )
         if config.has_consented_tracking:
             get_usage_tracker().set_enabled(True)
             get_usage_tracker().track_page_view("/view/2d", "2D View")
@@ -565,6 +581,9 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             dialog = UsageConsentDialog(self)
             dialog.present()
+            # Avoid piling windows: open the first-run wizard only
+            # after the consent dialog has been answered.
+            dialog.connect("response", self._on_consent_responded)
 
         # Trigger the non-blocking check for addon updates
         self.update_cmd.check_for_updates_on_startup()
@@ -574,6 +593,93 @@ class MainWindow(Adw.ApplicationWindow):
 
         # Check configured machines against their source device profiles
         GLib.idle_add(self._check_profile_updates)
+
+        # On first launch, offer the machine setup wizard instead of
+        # silently keeping the auto-created placeholder machine. While
+        # the consent dialog is up, it chains the presentation so the
+        # two don't stack up.
+        if consent_pending:
+            return
+        GLib.idle_add(self._maybe_present_first_run_wizard)
+
+    def _on_consent_responded(self, dialog, response_id):
+        GLib.idle_add(self._maybe_present_first_run_wizard)
+
+    def _maybe_present_first_run_wizard(self) -> bool:
+        """
+        Presents the setup wizard once if no real machine has ever been
+        set up (only untouched placeholder machines exist).
+        """
+        context = get_context()
+        config = context.config
+        machines = list(context.machine_mgr.machines.values())
+        if config.setup_completed:
+            return GLib.SOURCE_REMOVE
+        if not all(machine.placeholder for machine in machines):
+            return GLib.SOURCE_REMOVE
+        logger.info("First launch detected; presenting setup wizard.")
+        self.present_setup_wizard()
+        return GLib.SOURCE_REMOVE
+
+    def present_setup_wizard(self):
+        """Opens the unified machine setup wizard."""
+        if self._setup_wizard is not None:
+            self._setup_wizard.present()
+            return
+        dialog = UnifiedWizard(transient_for=self)
+        self._setup_wizard = dialog
+        self._setup_wizard_completed = False
+        dialog.profile_created.connect(self._on_setup_wizard_profile_created)
+        dialog.connect("close-request", self._on_setup_wizard_closed)
+        dialog.present()
+
+    def _on_setup_wizard_closed(self, *args) -> bool:
+        """Handles the user cancelling the setup wizard.
+
+        Falls back to the placeholder machine and marks setup as
+        handled so the wizard is never forced on the user again.
+        """
+        self._setup_wizard = None
+        if self._setup_wizard_completed:
+            return False
+        self._setup_wizard_completed = True
+        get_context().config.set_setup_completed(True)
+        logger.info("Setup wizard cancelled; keeping placeholder machine.")
+        return False
+
+    def _on_setup_wizard_profile_created(
+        self,
+        sender,
+        *,
+        profile,
+        machine=None,
+    ):
+        """Activates the machine created by the wizard.
+
+        The placeholder machine is removed so it does not linger in
+        the machine list.
+        """
+        context = get_context()
+        if machine is None:
+            machine = profile.create_machine(context)
+        self._setup_wizard_completed = True
+        self._setup_wizard = None
+        context.config.set_setup_completed(True)
+
+        manager = context.machine_mgr
+        manager.set_active_machine(machine)
+        for placeholder in manager.get_placeholder_machines():
+            if placeholder.id != machine.id:
+                manager.remove_machine(placeholder.id)
+
+    def _on_setup_banner_clicked(self, banner):
+        self.present_setup_wizard()
+
+    def _update_setup_banner(self):
+        """Shows the banner only while a placeholder machine is active."""
+        config = get_context().config
+        show_banner = bool(config.machine and config.machine.placeholder)
+        self.setup_banner.set_revealed(show_banner)
 
     def _check_profile_updates(self) -> bool:
         """
@@ -1687,6 +1793,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._update_workflow_views()
         self._apply_right_panel_visibility()
         self._update_macros_menu()
+        self._update_setup_banner()
 
         # Check for any pending notifications from the new machine immediately
         if self._current_machine:

--- a/rayforge/ui_gtk/settings/machine_settings_page.py
+++ b/rayforge/ui_gtk/settings/machine_settings_page.py
@@ -212,19 +212,17 @@ class MachineSettingsPage(TrackedPreferencesPage):
         profile: DeviceProfile,
         machine: Machine | None = None,
     ):
-        """Creates a machine and opens its settings editor.
+        """Makes the new machine the active one.
 
         The UnifiedWizard hands back the live ``Machine`` it created
         via ``profile.create_machine(...)`` so we don't double-create.
+        The machine list rebuilds via the config.changed signal, so
+        the new machine shows up as active right away.
         """
         if machine is None:
             machine = profile.create_machine(get_context())
 
-        editor_dialog = MachineSettingsDialog(
-            machine=machine,
-            transient_for=self.get_ancestor(Gtk.Window),
-        )
-        editor_dialog.present()
+        get_context().machine_mgr.set_active_machine(machine)
 
     def _create_add_button(self) -> Gtk.Button:
         """Creates the add button with icon and label."""

--- a/rayforge/ui_gtk/varset/adapter/combo.py
+++ b/rayforge/ui_gtk/varset/adapter/combo.py
@@ -233,3 +233,19 @@ class SerialPortAdapter(ComboAdapter):
         if value_str and value_str in devices:
             selected = devices.index(value_str) + 1
         self._row.set_selected(selected)
+
+    def set_value(self, value: Any) -> None:
+        if value is None:
+            super().set_value(None)
+            return
+        value_str = str(value)
+        model = self._row.get_model()
+        strings: list[str | None] = []
+        if isinstance(model, Gtk.StringList):
+            strings = [model.get_string(i) for i in range(model.get_n_items())]
+        if value_str not in strings:
+            # Unknown port (e.g. just plugged in or not seen by the
+            # last scan): rebuild the list so it becomes selectable.
+            self._refresh(value_str)
+            return
+        super().set_value(value_str)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,39 @@
+"""Tests for the persistent Config class."""
+
+from rayforge.core.config import Config
+
+
+class TestSetupCompletedFlag:
+    def test_defaults_to_false(self):
+        config = Config()
+        assert config.setup_completed is False
+
+    def test_setter_emits_changed_once(self):
+        config = Config()
+        calls = []
+
+        def on_changed(sender, **kwargs):
+            calls.append(sender)
+
+        config.changed.connect(on_changed, weak=False)
+
+        config.set_setup_completed(True)
+        assert len(calls) == 1
+
+        # Setting the same value again must not re-emit.
+        config.set_setup_completed(True)
+        assert len(calls) == 1
+
+    def test_round_trip(self):
+        config = Config()
+        config.set_setup_completed(True)
+        data = config.to_dict()
+        assert data["setup_completed"] is True
+
+        restored = Config.from_dict(data, get_machine_by_id=lambda mid: None)
+        assert restored.setup_completed is True
+
+    def test_absent_key_falls_back_to_false(self):
+        """Older configs without the key must not crash on load."""
+        restored = Config.from_dict({}, get_machine_by_id=lambda mid: None)
+        assert restored.setup_completed is False

--- a/tests/machine/device/test_profile_matching.py
+++ b/tests/machine/device/test_profile_matching.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+from rayforge.machine.device.manager import DeviceProfileManager
+from rayforge.machine.driver.discovery import (
+    GENERIC_TOKENS,
+    DeviceIdentity,
+    normalize_tokens,
+)
+
+_PROFILE_YAML = """\
+api_version: 1
+device:
+  name: {name}
+  vendor: {vendor}
+machine:
+  driver: RuidaDriver
+"""
+
+
+def _make_profile(root: Path, dirname: str, name: str, vendor: str) -> Path:
+    profile_dir = root / dirname
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "device.yaml").write_text(
+        _PROFILE_YAML.format(name=name, vendor=vendor)
+    )
+    return profile_dir
+
+
+def _manager(tmp_path: Path) -> DeviceProfileManager:
+    mgr = DeviceProfileManager(source_dirs=[tmp_path])
+    mgr.discover()
+    return mgr
+
+
+def _identity_for(*texts: str) -> DeviceIdentity:
+    return DeviceIdentity(tokens=normalize_tokens(*texts))
+
+
+def test_unique_vendor_match(tmp_path):
+    _make_profile(tmp_path, "frob-one", "Frob One", "Frobnicate")
+    _make_profile(tmp_path, "other-two", "Other Two", "Gadgetco")
+    mgr = _manager(tmp_path)
+
+    identity = _identity_for("Frobnicate Laser Master", "CH340")
+    matched = mgr.match_device(identity)
+    assert matched is not None
+    assert matched.name == "Frob One"
+
+
+def test_ambiguous_same_vendor_returns_none(tmp_path):
+    _make_profile(tmp_path, "frob-one", "Frob One", "Frobnicate")
+    _make_profile(tmp_path, "frob-two", "Frob Two", "Frobnicate")
+    mgr = _manager(tmp_path)
+
+    identity = _identity_for("Frobnicate laser")
+    assert mgr.match_device(identity) is None
+
+
+def test_model_tokens_narrow_the_match(tmp_path):
+    _make_profile(tmp_path, "frob-one", "Frob One", "Frobnicate")
+    frob_pro = tmp_path / "frob-pro"
+    frob_pro.mkdir()
+    (frob_pro / "device.yaml").write_text(
+        _PROFILE_YAML.format(name="Frob Pro", vendor="Frobnicate").replace(
+            "machine:", "  model: Pro\nmachine:"
+        )
+    )
+    mgr = _manager(tmp_path)
+
+    # Model tokens present in the identity: the model-less profile
+    # matches on vendor alone, the "Pro" profile does not (its model
+    # token is missing), so the match is unambiguous.
+    identity = _identity_for("Frobnicate laser")
+    matched = mgr.match_device(identity)
+    assert matched is not None
+    assert matched.name == "Frob One"
+
+    # With the model token, the more specific "Pro" profile outranks
+    # the model-less one.
+    identity_pro = _identity_for("Frobnicate Pro laser")
+    matched_pro = mgr.match_device(identity_pro)
+    assert matched_pro is not None
+    assert matched_pro.name == "Frob Pro"
+
+
+def test_no_match_returns_none(tmp_path):
+    _make_profile(tmp_path, "frob-one", "Frob One", "Frobnicate")
+    mgr = _manager(tmp_path)
+
+    assert mgr.match_device(_identity_for("USB Serial CH340")) is None
+    assert mgr.match_device(DeviceIdentity()) is None
+
+
+def test_generic_vendor_is_ignored(tmp_path):
+    _make_profile(tmp_path, "generic", "Generic USB Serial", "USB Serial")
+    mgr = _manager(tmp_path)
+
+    identity = _identity_for("USB Serial CH340")
+    assert mgr.match_device(identity) is None
+    assert normalize_tokens("USB Serial") <= GENERIC_TOKENS
+
+
+def test_builtin_profiles_all_declare_vendor():
+    import rayforge
+
+    devices_dir = Path(rayforge.__file__).parent / "resources" / "devices"
+    assert devices_dir.is_dir()
+    mgr = DeviceProfileManager(source_dirs=[devices_dir])
+    mgr.discover()
+
+    profiles = mgr.get_all()
+    assert profiles, "expected built-in device profiles"
+    missing = [p.name for p in profiles if not (p.meta.vendor or "").strip()]
+    assert missing == []
+
+
+def test_machine_name_matches_builtin_profile():
+    """A device name announced by the firmware itself (Grbl's
+    [MSG:machine:...] line) drives matching against the built-in
+    profiles."""
+    import rayforge
+    from rayforge.machine.driver.discovery import build_identity
+
+    devices_dir = Path(rayforge.__file__).parent / "resources" / "devices"
+    mgr = DeviceProfileManager(source_dirs=[devices_dir])
+    mgr.discover()
+
+    identity = build_identity(
+        "grbl",
+        b"[VER:1.0.15,20240923:]\r\n[MSG:mechine:Sculpfun iCube]\r\n",
+        port_info=None,
+        device_name="Sculpfun iCube",
+    )
+    matched = mgr.match_device(identity)
+    assert matched is not None
+    assert matched.name == "Sculpfun iCube"

--- a/tests/machine/driver/grbl/test_grbl_util.py
+++ b/tests/machine/driver/grbl/test_grbl_util.py
@@ -10,7 +10,9 @@ from rayforge.machine.driver.grbl.grbl_util import (
     _recalculate_positions,
     _split_status_line,
     error_code_to_device_error,
+    extract_device_name_from_output,
     gcode_to_p_number,
+    is_grbl_output,
     is_report_in_inches,
     parse_grbl_parser_state,
     parse_opt_info,
@@ -776,3 +778,70 @@ class TestSplitRealtimeCommands:
 
     def test_empty_input(self):
         assert split_realtime_commands([]) == ([], [])
+
+
+class TestIsGrblOutput:
+    """The driver-owned matcher used for serial device discovery."""
+
+    def test_matches_banner(self):
+        assert is_grbl_output(b"Grbl 1.1f ['$' for help]\r\n")
+
+    def test_matches_grblhal(self):
+        assert is_grbl_output(b"GrblHAL 2.0a\r\n")
+
+    def test_matches_status_report(self):
+        assert is_grbl_output(b"<Idle|MPos:0.000,0.000,0.000|FS:0,0>")
+
+    def test_matches_accumulated_noise(self):
+        assert is_grbl_output(b"\r\n\x00garbage\r\nok\r\nGrbl 1.1f\r\n")
+
+    def test_rejects_other_firmware(self):
+        assert not is_grbl_output(b"start\r\necho:Marlin 2.1.2\r\n")
+        assert not is_grbl_output(b"Smoothie ok\r\n")
+        assert not is_grbl_output(b"hello world\r\n")
+        assert not is_grbl_output(b"")
+
+
+# Real-world capture from a Sculpfun iCube: a Grbl fork whose boot
+# output never mentions Grbl — only $I-style build-info lines.
+SCULPFUN_ICUBE_BANNER = (
+    b"[VER:1.0.15,20240923:]\r\n"
+    b"[OPT:VMP,31,511]\r\n"
+    b"[MSG:mechine:Sculpfun iCube]\r\n"
+    b"[MSG:Mode=BT]\r\n"
+    b"[BT_VER:8.1.2,FSC-BT836B]\r\n"
+    b"Connection status: CONNECTED \r\n"
+)
+
+
+class TestIsGrblOutputBuildInfo:
+    def test_matches_build_info_only_banner(self):
+        assert is_grbl_output(SCULPFUN_ICUBE_BANNER)
+
+    def test_matches_single_msg_line(self):
+        assert is_grbl_output(b"[MSG:Caution: Unlocked]\r\n")
+
+    def test_matches_ver_line(self):
+        assert is_grbl_output(b"[VER:1.1h.ORTUR:]\r\n")
+
+    def test_rejects_square_brackets_from_other_firmware(self):
+        # Marlin and friends echo with 'echo:', not '[...]'.
+        assert not is_grbl_output(b"echo:busy: processing\r\nok\r\n")
+
+
+class TestExtractDeviceNameFromOutput:
+    def test_extracts_machine_name_from_msg(self):
+        assert (
+            extract_device_name_from_output(SCULPFUN_ICUBE_BANNER)
+            == "Sculpfun iCube"
+        )
+
+    def test_falls_back_to_ver_build_name(self):
+        data = b"[VER:1.1h.ORTUR:]\r\n[OPT:V,15,128]\r\n"
+        assert extract_device_name_from_output(data) == "ORTUR"
+
+    def test_returns_none_for_stock_grbl(self):
+        assert (
+            extract_device_name_from_output(b"Grbl 1.1f ['$' for help]\r\n")
+            is None
+        )

--- a/tests/machine/driver/marlin/test_marlin_util.py
+++ b/tests/machine/driver/marlin/test_marlin_util.py
@@ -6,6 +6,7 @@ from rayforge.machine.driver.marlin.marlin_util import (
     gcode_to_p_number,
     is_boot_message,
     is_error_response,
+    is_marlin_output,
     is_ok_response,
     parse_error_message,
     parse_m114_position,
@@ -361,3 +362,24 @@ class TestExtractMarlinDeviceName:
 
     def test_no_info_returns_unknown(self):
         assert extract_marlin_device_name([]) == ("Unknown Marlin Device")
+
+
+class TestIsMarlinOutput:
+    """The driver-owned matcher used for serial device discovery."""
+
+    def test_matches_start_banner(self):
+        assert is_marlin_output(b"start\r\n")
+
+    def test_matches_echo_lines(self):
+        assert is_marlin_output(b"start\r\necho:Marlin initialized\r\n")
+
+    def test_matches_marlin_name(self):
+        assert is_marlin_output(b"Marlin 2.1.2\r\n")
+
+    def test_matches_accumulated_noise(self):
+        assert is_marlin_output(b"\r\n\x00garbage\r\nstart\r\n")
+
+    def test_rejects_other_firmware(self):
+        assert not is_marlin_output(b"Grbl 1.1f ['$' for help]\r\n")
+        assert not is_marlin_output(b"hello world\r\n")
+        assert not is_marlin_output(b"")

--- a/tests/machine/driver/test_discovery.py
+++ b/tests/machine/driver/test_discovery.py
@@ -1,0 +1,325 @@
+import asyncio
+from typing import ClassVar
+
+import pytest
+
+from rayforge.machine.driver.discovery import (
+    GENERIC_TOKENS,
+    DeviceIdentity,
+    DeviceRecognizer,
+    DiscoveredDevice,
+    build_identity,
+    extract_banner,
+    find_all_devices,
+    normalize_tokens,
+)
+from rayforge.machine.transport.serial import SerialPortInfo
+
+
+def _grbl_matcher(data: bytes) -> bool:
+    # Mirrors the real is_grbl_output(): banner or realtime status
+    # report. A bare "ok" ack must NOT match (Marlin acks alike).
+    return b"Grbl" in data or b"<Idle" in data
+
+
+def _marlin_matcher(data: bytes) -> bool:
+    return b"start" in data or b"echo:" in data
+
+
+class FakeGrblDriver:
+    DISCOVERY = DeviceRecognizer(
+        label=lambda: "GRBL device",
+        matches=_grbl_matcher,
+        firmware="grbl",
+    )
+
+
+class FakeMarlinDriver:
+    DISCOVERY = DeviceRecognizer(
+        label=lambda: "Marlin device",
+        matches=_marlin_matcher,
+        firmware="marlin",
+    )
+
+
+class FakeSerial:
+    """A fake pyserial.Serial for discovery tests."""
+
+    attempts: ClassVar[list[tuple[str, int]]] = []
+
+    def __init__(self, port=None, baudrate=9600, timeout=0, responses=None):
+        FakeSerial.attempts.append((str(port), int(baudrate)))
+        self.port = port
+        self.baudrate = baudrate
+        self._pending = bytearray((responses or {}).get(port, b""))
+
+    def read(self, size=1):
+        if not self._pending:
+            return b""
+        chunk = bytes(self._pending[:size])
+        del self._pending[:size]
+        return chunk
+
+    def write(self, data):
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class NudgeAnsweringSerial:
+    """
+    A device without a power-on banner that acks every nudge like
+    GRBL: ``ok`` for a newline, a status report for ``?``.
+    """
+
+    def __init__(self, port=None, baudrate=9600, timeout=0):
+        self._replies = iter([b"ok\r\n", b"<Idle|MPos:0.0,0.0,0.0>\r\n"])
+        self._pending = bytearray()
+
+    def read(self, size=1):
+        if not self._pending:
+            return b""
+        chunk = bytes(self._pending[:size])
+        del self._pending[:size]
+        return chunk
+
+    def write(self, data):
+        try:
+            self._pending.extend(next(self._replies))
+        except StopIteration:
+            pass
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def fast_timeouts(monkeypatch):
+    from rayforge.machine.transport import serial_scan
+
+    monkeypatch.setattr(serial_scan, "_BANNER_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_NUDGE_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_DRAIN_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_QUIET_GAP", 0.01)
+    monkeypatch.setattr(serial_scan, "_READ_CHUNK", 0.01)
+    FakeSerial.attempts.clear()
+
+
+def _patch_serial(monkeypatch, responses):
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.serial.Serial",
+        lambda **kw: FakeSerial(responses=responses, **kw),
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_scan_serves_all_drivers(monkeypatch):
+    """Adding discovery-capable drivers never multiplies port opens:
+    both recognizers evaluate a single scan."""
+    responses = {
+        "/dev/ttyUSB0": b"Grbl 1.1f ['$' for help]\r\n",
+        "/dev/ttyACM0": b"start\r\necho:Marlin initialized\r\n",
+    }
+    _patch_serial(monkeypatch, responses)
+    devices = await find_all_devices(
+        [FakeGrblDriver, FakeMarlinDriver],
+        ports=["/dev/ttyUSB0", "/dev/ttyACM0"],
+    )
+    by_driver = {d.driver_name: d for d in devices}
+    assert set(by_driver) == {"FakeGrblDriver", "FakeMarlinDriver"}
+
+    grbl = by_driver["FakeGrblDriver"]
+    assert grbl.params == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+    assert grbl.label == "GRBL device"
+    assert grbl.detail == "/dev/ttyUSB0 at 115200 baud"
+    assert grbl.identity.firmware == "grbl"
+    assert grbl.identity.banner == "Grbl 1.1f ['$' for help]"
+
+    marlin = by_driver["FakeMarlinDriver"]
+    assert marlin.params["port"] == "/dev/ttyACM0"
+    assert marlin.identity.firmware == "marlin"
+
+    assert sorted(FakeSerial.attempts) == [
+        ("/dev/ttyACM0", 115200),
+        ("/dev/ttyUSB0", 115200),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bannerless_grbl_is_recognized(monkeypatch):
+    """A GRBL device that never emits a boot banner (no DTR reset)
+    still identifies itself through its nudge responses alone."""
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.serial.Serial",
+        NudgeAnsweringSerial,
+    )
+    devices = await find_all_devices(
+        [FakeGrblDriver, FakeMarlinDriver], ports=["/dev/ttyUSB0"]
+    )
+    assert [d.driver_name for d in devices] == ["FakeGrblDriver"]
+    assert devices[0].identity.banner == "ok"
+
+
+# Real-world capture from a Sculpfun iCube: a Grbl fork whose boot
+# output never mentions Grbl — only $I-style build-info lines.
+SCULPFUN_ICUBE_BANNER = (
+    b"[VER:1.0.15,20240923:]\r\n"
+    b"[OPT:VMP,31,511]\r\n"
+    b"[MSG:mechine:Sculpfun iCube]\r\n"
+    b"[MSG:Mode=BT]\r\n"
+    b"[BT_VER:8.1.2,FSC-BT836B]\r\n"
+    b"Connection status: CONNECTED \r\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_sculpfun_banner_end_to_end(monkeypatch):
+    """The real GrblSerialDriver recognizer claims build-info-only
+    banners and extracts the machine name for identity/matching."""
+    from rayforge.machine.driver.grbl import GrblSerialDriver
+
+    _patch_serial(monkeypatch, {"/dev/ttyUSB0": SCULPFUN_ICUBE_BANNER})
+    devices = await find_all_devices(
+        [GrblSerialDriver], ports=["/dev/ttyUSB0"]
+    )
+    assert [d.driver_name for d in devices] == ["GrblSerialDriver"]
+    device = devices[0]
+    assert device.identity.firmware == "grbl"
+    assert device.identity.banner == "Sculpfun iCube"
+    assert "sculpfun" in device.identity.tokens
+    assert "icube" in device.identity.tokens
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_output_is_not_reported(monkeypatch):
+    _patch_serial(monkeypatch, {"/dev/ttyUSB0": b"SomeOtherFW v2\r\n"})
+    devices = await find_all_devices(
+        [FakeGrblDriver, FakeMarlinDriver], ports=["/dev/ttyUSB0"]
+    )
+    assert devices == []
+
+
+@pytest.mark.asyncio
+async def test_drivers_without_recognizer_are_ignored(monkeypatch):
+    _patch_serial(monkeypatch, {"/dev/ttyUSB0": b"Grbl 1.1f\r\n"})
+
+    class UndiscoverableDriver:
+        pass
+
+    devices = await find_all_devices(
+        [UndiscoverableDriver], ports=["/dev/ttyUSB0"]
+    )
+    assert devices == []
+    # No recognizer at all means no scan is even attempted.
+    assert FakeSerial.attempts == []
+
+
+@pytest.mark.asyncio
+async def test_broken_recognizer_does_not_break_discovery(monkeypatch):
+    _patch_serial(monkeypatch, {"/dev/ttyUSB0": b"Grbl 1.1f\r\n"})
+
+    def boom(data: bytes) -> bool:
+        raise OSError("boom")
+
+    class BrokenDriver:
+        DISCOVERY = DeviceRecognizer(
+            label=lambda: "Broken",
+            matches=boom,
+        )
+
+    devices = await find_all_devices(
+        [BrokenDriver, FakeGrblDriver], ports=["/dev/ttyUSB0"]
+    )
+    assert [d.driver_name for d in devices] == ["FakeGrblDriver"]
+
+
+@pytest.mark.asyncio
+async def test_scan_timeout_returns_empty(monkeypatch):
+    from rayforge.machine.driver import discovery
+
+    async def slow_scan(**kwargs):
+        await asyncio.sleep(1.0)
+        return []
+
+    monkeypatch.setattr(discovery, "scan_serial_ports", slow_scan)
+    monkeypatch.setattr(discovery, "_SCAN_TIMEOUT", 0.05)
+    devices = await find_all_devices([FakeGrblDriver], ports=["/dev/x"])
+    assert devices == []
+
+
+@pytest.mark.asyncio
+async def test_scan_failure_returns_empty(monkeypatch):
+    from rayforge.machine.driver import discovery
+
+    async def broken_scan(**kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(discovery, "scan_serial_ports", broken_scan)
+    devices = await find_all_devices([FakeGrblDriver], ports=["/dev/x"])
+    assert devices == []
+
+
+@pytest.mark.asyncio
+async def test_builtin_discovery_drivers():
+    from rayforge.machine.driver import (
+        GrblSerialDriver,
+        GrblTelnetDriver,
+        MarlinSerialDriver,
+        drivers,
+    )
+
+    discoverable = [d for d in drivers if d.DISCOVERY is not None]
+    assert {d.__name__ for d in discoverable} == {
+        "GrblSerialDriver",
+        "MarlinSerialDriver",
+    }
+    assert GrblTelnetDriver.DISCOVERY is None
+    assert GrblSerialDriver.DISCOVERY is not None
+    assert GrblSerialDriver.DISCOVERY.firmware == "grbl"
+    assert MarlinSerialDriver.DISCOVERY is not None
+    assert MarlinSerialDriver.DISCOVERY.firmware == "marlin"
+
+
+def test_extract_banner():
+    assert extract_banner(b"\r\nGrbl 1.1f\r\nok\r\n") == "Grbl 1.1f"
+    assert extract_banner(b"") is None
+    assert extract_banner(b"\n\n") is None
+
+
+def test_normalize_tokens():
+    tokens = normalize_tokens("Ortur Laser_Master", "CH340", None)
+    # Generic chip names stay in the token set; they are filtered at
+    # match time via GENERIC_TOKENS.
+    assert tokens == {"ortur", "laser", "master", "ch340"}
+    assert normalize_tokens(None, "") == frozenset()
+    assert "ch340" in GENERIC_TOKENS
+
+
+def test_build_identity():
+    info = SerialPortInfo("/dev/ttyUSB0", "USB Serial", vid=1, pid=2)
+    identity = build_identity("grbl", b"Grbl 1.1f\r\n", info)
+    assert identity.firmware == "grbl"
+    assert identity.banner == "Grbl 1.1f"
+    assert identity.usb_vid == 1
+    assert identity.usb_pid == 2
+    assert "usb" in identity.tokens
+    assert "serial" in identity.tokens
+
+
+def test_discovered_device_key():
+    device = DiscoveredDevice(
+        driver_name="GrblSerialDriver",
+        params={"port": "/dev/ttyUSB0", "baudrate": 115200},
+        label="GRBL device",
+        detail="/dev/ttyUSB0 at 115200 baud",
+    )
+    assert device.key == "GrblSerialDriver:/dev/ttyUSB0"
+    assert DeviceIdentity() == DeviceIdentity()

--- a/tests/machine/models/test_machine_manager.py
+++ b/tests/machine/models/test_machine_manager.py
@@ -61,6 +61,25 @@ class TestMachineManager:
         assert hasattr(manager, "machine_removed")
         assert hasattr(manager, "machine_updated")
 
+    def test_create_default_machine_marks_placeholder(
+        self, lite_context, tmp_path
+    ):
+        """Machines created by create_default_machine are placeholders."""
+        manager = MachineManager(tmp_path)
+        machine = manager.create_default_machine()
+
+        assert machine.placeholder is True
+        assert manager.get_placeholder_machines() == [machine]
+
+    def test_get_placeholder_machines_filters(self, lite_context, tmp_path):
+        """Only machines flagged as placeholder are returned."""
+        manager = MachineManager(tmp_path)
+        placeholder = manager.create_default_machine()
+        real = Machine(lite_context)
+        manager.add_machine(real)
+
+        assert manager.get_placeholder_machines() == [placeholder]
+
     def test_has_controller_does_not_lazily_create(
         self, lite_context, tmp_path
     ):

--- a/tests/machine/models/test_machine_model.py
+++ b/tests/machine/models/test_machine_model.py
@@ -432,6 +432,18 @@ class TestMachineModel:
         assert machine.work_margins == (50, 50, 50, 50)
         assert machine.soft_limits == (10, 10, 280, 380)
 
+    def test_placeholder_round_trip(self, lite_context):
+        """The placeholder flag survives serialization and defaults off."""
+        machine = Machine(lite_context)
+        assert machine.placeholder is False
+
+        data = machine.to_dict()
+        assert data["machine"]["placeholder"] is False
+
+        machine.placeholder = True
+        restored = Machine.from_dict(machine.to_dict(), context=lite_context)
+        assert restored.placeholder is True
+
     def test_from_dict_migrates_offsets_to_margins(self, lite_context):
         """Test that from_dict migrates old offsets to margins."""
         data = {

--- a/tests/machine/transport/test_serial_scan.py
+++ b/tests/machine/transport/test_serial_scan.py
@@ -1,0 +1,281 @@
+import asyncio
+import threading
+from typing import ClassVar
+
+import pytest
+import serial as pyserial
+
+from rayforge.machine.transport.serial import SerialPortInfo
+from rayforge.machine.transport.serial_scan import (
+    looks_like_device_output,
+    scan_serial_ports,
+)
+
+
+class FakeSerial:
+    """A fake pyserial.Serial for scanning tests."""
+
+    attempts: ClassVar[list[tuple[str, int]]] = []
+
+    def __init__(
+        self,
+        port=None,
+        baudrate=9600,
+        timeout=0,
+        responses=None,
+        busy=(),
+    ):
+        FakeSerial.attempts.append((str(port), int(baudrate)))
+        if port in busy:
+            raise pyserial.SerialException("Device or resource busy")
+        self.port = port
+        self.baudrate = baudrate
+        self._responses = responses or {}
+        response = self._responses.get(port, b"")
+        # A port may answer differently per baud rate.
+        if isinstance(response, dict):
+            response = response.get(int(baudrate), b"")
+        self._pending = bytearray(response)
+
+    def read(self, size=1):
+        if not self._pending:
+            return b""
+        chunk = bytes(self._pending[:size])
+        del self._pending[:size]
+        return chunk
+
+    def write(self, data):
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def fast_timeouts(monkeypatch):
+    from rayforge.machine.transport import serial_scan
+
+    monkeypatch.setattr(serial_scan, "_BANNER_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_NUDGE_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_DRAIN_TIMEOUT", 0.05)
+    monkeypatch.setattr(serial_scan, "_QUIET_GAP", 0.01)
+    monkeypatch.setattr(serial_scan, "_READ_CHUNK", 0.01)
+    FakeSerial.attempts.clear()
+
+
+def _patch_serial(monkeypatch, responses=None, busy=()):
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.serial.Serial",
+        lambda **kw: FakeSerial(responses=responses, busy=busy, **kw),
+    )
+
+
+def test_looks_like_device_output():
+    assert looks_like_device_output(b"Grbl 1.1f ['$' for help]\r\n")
+    assert looks_like_device_output(b"start\r\necho:busy: processing")
+    assert not looks_like_device_output(b"")
+    assert not looks_like_device_output(b"\x00\xff\x0f\xd3\xa1")
+    assert not looks_like_device_output(b"\n\n\r\n")
+
+
+@pytest.mark.asyncio
+async def test_scan_observes_responding_port(monkeypatch):
+    responses = {"/dev/ttyUSB0": b"Grbl 1.1f ['$' for help]\r\n"}
+    _patch_serial(monkeypatch, responses)
+    observations = await scan_serial_ports(ports=["/dev/ttyUSB0"])
+    assert len(observations) == 1
+    obs = observations[0]
+    assert obs.port == "/dev/ttyUSB0"
+    assert obs.baud_rate == 115200
+    assert obs.data == b"Grbl 1.1f ['$' for help]\r\n"
+
+
+@pytest.mark.asyncio
+async def test_scan_opens_port_once_per_scan(monkeypatch):
+    """A responding port is accepted at the first baud rate that
+    yields device-like output; later rates are not tried."""
+    responses = {"/dev/ttyUSB0": b"Grbl 1.1f\r\n"}
+    _patch_serial(monkeypatch, responses)
+    await scan_serial_ports(ports=["/dev/ttyUSB0"])
+    assert FakeSerial.attempts == [("/dev/ttyUSB0", 115200)]
+
+
+@pytest.mark.asyncio
+async def test_scan_tries_baud_rates_in_order(monkeypatch):
+    _patch_serial(monkeypatch, {})
+    await scan_serial_ports(ports=["/dev/ttyA"], baud_rates=[115200, 9600])
+    assert FakeSerial.attempts == [("/dev/ttyA", 115200), ("/dev/ttyA", 9600)]
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_port_with_only_garbage(monkeypatch):
+    """Framing garbage at one baud rate must not end the probe:
+    the scan moves on to the next rate."""
+    responses = {
+        "/dev/ttyA": {
+            115200: b"\x00\xff\x0f\xd3\xa1\x7f",
+            9600: b"Grbl 1.1f\r\n",
+        }
+    }
+    _patch_serial(monkeypatch, responses)
+    observations = await scan_serial_ports(
+        ports=["/dev/ttyA"], baud_rates=[115200, 9600]
+    )
+    assert [(o.port, o.baud_rate) for o in observations] == [
+        ("/dev/ttyA", 9600)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scan_collects_nudge_responses_for_silent_devices(
+    monkeypatch,
+):
+    """A device without a power-on banner is provoked into talking:
+    every nudge is answered, all responses are captured together
+    (a bare ``ok`` ack alone is not enough to identify firmware)."""
+
+    class NudgeDevice:
+        writes: ClassVar[list[bytes]] = []
+
+        def __init__(self, port=None, baudrate=9600, timeout=0):
+            self._replies = iter(
+                [b"ok\r\n", b"<Idle|MPos:0.000,0.000,0.000|FS:0,0>\r\n"]
+            )
+            self._pending = bytearray()
+
+        def read(self, size=1):
+            if not self._pending:
+                return b""
+            chunk = bytes(self._pending[:size])
+            del self._pending[:size]
+            return chunk
+
+        def write(self, data):
+            NudgeDevice.writes.append(bytes(data))
+            try:
+                self._pending.extend(next(self._replies))
+            except StopIteration:
+                pass
+            return len(data)
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.serial.Serial", NudgeDevice
+    )
+    NudgeDevice.writes.clear()
+
+    observations = await scan_serial_ports(ports=["/dev/ttyUSB0"])
+    assert NudgeDevice.writes == [b"\n", b"?"]
+    assert len(observations) == 1
+    assert observations[0].data == (
+        b"ok\r\n<Idle|MPos:0.000,0.000,0.000|FS:0,0>\r\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_busy_port(monkeypatch):
+    responses = {"/dev/ttyUSB1": b"Grbl 1.1f\r\n"}
+    _patch_serial(monkeypatch, responses, busy=("/dev/ttyUSB0",))
+    observations = await scan_serial_ports(
+        ports=["/dev/ttyUSB0", "/dev/ttyUSB1"], baud_rates=[115200]
+    )
+    assert [o.port for o in observations] == ["/dev/ttyUSB1"]
+
+
+@pytest.mark.asyncio
+async def test_scan_excludes_requested_ports(monkeypatch):
+    responses = {
+        "/dev/ttyUSB0": b"Grbl 1.1f\r\n",
+        "/dev/ttyUSB1": b"Grbl 1.1f\r\n",
+    }
+    _patch_serial(monkeypatch, responses)
+    observations = await scan_serial_ports(
+        ports=list(responses), exclude_ports={"/dev/ttyUSB0"}
+    )
+    assert [o.port for o in observations] == ["/dev/ttyUSB1"]
+    assert FakeSerial.attempts == [("/dev/ttyUSB1", 115200)]
+
+
+@pytest.mark.asyncio
+async def test_scan_uses_port_metadata(monkeypatch):
+    responses = {"/dev/ttyUSB0": b"Grbl 1.1f\r\n"}
+    _patch_serial(monkeypatch, responses)
+    port_info = [
+        SerialPortInfo(
+            device="/dev/ttyUSB0",
+            description="Ortur Laser Master",
+            manufacturer="Ortur",
+            vid=0x1A86,
+            pid=0x7523,
+        )
+    ]
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.SerialTransport"
+        ".list_port_info",
+        lambda: port_info,
+    )
+    observations = await scan_serial_ports(ports=["/dev/ttyUSB0"])
+    info = observations[0].info
+    assert info is not None
+    assert info.description == "Ortur Laser Master"
+    assert info.vid == 0x1A86
+    assert info.pid == 0x7523
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scans_serialize_on_port(monkeypatch):
+    """A second scan cannot open a port while another scan is still
+    probing it (pyserial opens exclusively)."""
+    opened = threading.Event()
+    release = threading.Event()
+
+    class BlockingSerial:
+        attempts: ClassVar[list[str]] = []
+
+        def __init__(self, port=None, baudrate=9600, timeout=0):
+            BlockingSerial.attempts.append(str(port))
+            self._first = len(BlockingSerial.attempts) == 1
+
+        def read(self, size=1):
+            if self._first:
+                opened.set()
+                release.wait(timeout=2.0)
+            return b""
+
+        def write(self, data):
+            return len(data)
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "rayforge.machine.transport.serial_scan.serial.Serial",
+        BlockingSerial,
+    )
+
+    loop = asyncio.get_running_loop()
+    scan1 = asyncio.create_task(
+        scan_serial_ports(ports=["/dev/ttyUSB0"], baud_rates=[115200])
+    )
+    await loop.run_in_executor(None, opened.wait, 2.0)
+
+    scan2 = asyncio.create_task(
+        scan_serial_ports(ports=["/dev/ttyUSB0"], baud_rates=[115200])
+    )
+    await asyncio.sleep(0.1)
+    assert BlockingSerial.attempts == ["/dev/ttyUSB0"]
+
+    release.set()
+    await asyncio.gather(scan1, scan2)
+    assert BlockingSerial.attempts == ["/dev/ttyUSB0", "/dev/ttyUSB0"]

--- a/tests/ui_gtk/machine/test_unified_wizard.py
+++ b/tests/ui_gtk/machine/test_unified_wizard.py
@@ -1,5 +1,6 @@
 """UI tests for the Unified Machine Configuration Wizard."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,19 +11,38 @@ from rayforge.machine.device.profile import (
     DeviceProfile,
     MachineConfig,
 )
+from rayforge.machine.driver.discovery import DeviceIdentity
+from rayforge.machine.driver.grbl import GrblSerialDriver
 from rayforge.machine.models.machine import Origin
 from rayforge.ui_gtk.machine.unified_wizard import UnifiedWizard
 from rayforge.ui_gtk.machine.wizard_pages.ai_lookup_page import AILookupPage
 from rayforge.ui_gtk.machine.wizard_pages.camera_page import CameraPage
 from rayforge.ui_gtk.machine.wizard_pages.connection_page import ConnectionPage
 from rayforge.ui_gtk.machine.wizard_pages.controller_page import ControllerPage
+from rayforge.ui_gtk.machine.wizard_pages.discover_page import DiscoverPage
 from rayforge.ui_gtk.machine.wizard_pages.probe_page import ProbePage
+from rayforge.ui_gtk.machine.wizard_pages.profile_page import ProfilePage
 from rayforge.ui_gtk.machine.wizard_pages.provider_page import AIProviderPage
 from rayforge.ui_gtk.machine.wizard_pages.review_page import ReviewPage
 
 _CAMERA_PATCH_TARGET = (
     "rayforge.ui_gtk.machine.wizard_pages.camera_page.get_sorted_by_id_paths"
 )
+
+
+@pytest.fixture(autouse=True)
+def _inert_device_discovery():
+    """Wizard construction opens the discover page, which would start
+    scanning real serial ports. Keep every test inert."""
+
+    async def _fake_find_all_devices(driver_classes=None, **kwargs):
+        return []
+
+    with patch(
+        "rayforge.ui_gtk.machine.wizard_pages.discover_page.find_all_devices",
+        _fake_find_all_devices,
+    ):
+        yield
 
 
 def _profile(driver=None):
@@ -42,9 +62,9 @@ def _make_wizard(ui_context_initializer):
 
 
 @pytest.mark.ui
-def test_wizard_starts_on_profile_page(ui_context_initializer):
+def test_wizard_starts_on_discover_page(ui_context_initializer):
     wizard = _make_wizard(ui_context_initializer)
-    assert wizard.stack.get_visible_child_name() == "profile"
+    assert wizard.stack.get_visible_child_name() == "discover"
 
 
 @pytest.mark.ui
@@ -60,6 +80,13 @@ def test_button_bar_lives_inside_main_box(ui_context_initializer):
 def test_footer_action_buttons_follow_page(ui_context_initializer):
     wizard = _make_wizard(ui_context_initializer)
 
+    discover_page = wizard._get_page("discover")
+    assert discover_page is not None
+    assert [b.get_label() for b in wizard._footer_action_buttons] == [
+        b.get_label() for b in discover_page.footer_buttons()
+    ]
+
+    wizard._navigate_to("profile")
     profile_page = wizard._get_page("profile")
     assert profile_page is not None
     assert [b.get_label() for b in wizard._footer_action_buttons] == [
@@ -99,6 +126,7 @@ def test_wizard_step_order_declared():
     from rayforge.ui_gtk.machine.unified_wizard import _STEP_ORDER
 
     assert _STEP_ORDER == [
+        "discover",
         "profile",
         "controller",
         "connect",
@@ -262,16 +290,17 @@ def test_clone_profile_preserves_all_config_fields(ui_context_initializer):
 
 
 @pytest.mark.ui
-def test_known_profile_skips_ai_hw_head_pages(ui_context_initializer):
-    """A picked profile carries trusted specs, so after Connection the
-    wizard skips probe, AI, hardware and head — landing on Rotary.
-    Imports are not fully reliable, so they keep hardware/head (but
-    still skip the AI pages)."""
+def test_known_profile_skips_to_review(ui_context_initializer):
+    """A picked profile carries trusted specs and optional hardware,
+    so after Connection the wizard skips probe, AI, hardware, head,
+    rotary and camera — landing on Review. Imports are not fully
+    reliable, so they keep hardware/head (but still skip the AI
+    pages)."""
     wizard = _make_wizard(ui_context_initializer)
     wizard._on_profile_source_selected(
         None, kind="profile", profile=_profile(driver="RuidaDriver")
     )
-    assert wizard._next_step_after("connect") == "rotary"
+    assert wizard._next_step_after("connect") == "review"
     assert {
         "controller",
         "probe",
@@ -279,6 +308,8 @@ def test_known_profile_skips_ai_hw_head_pages(ui_context_initializer):
         "ai_lookup",
         "hardware",
         "head",
+        "rotary",
+        "camera",
     } <= wizard._skipped_steps_set
 
 
@@ -345,10 +376,12 @@ def test_materialize_machine_emits_profile_created(ui_context_initializer):
 
 @pytest.mark.ui
 def test_profile_page_hides_next_button(ui_context_initializer):
-    """Step 1 advances only via explicit source selection, so the
-    generic Next button must not appear next to "Other / Unknown
-    Device…" — otherwise the two look like duplicate primary actions."""
+    """The profile step advances only via explicit source selection,
+    so the generic Next button must not appear next to "Other /
+    Unknown Device…" — otherwise the two look like duplicate primary
+    actions."""
     wizard = _make_wizard(ui_context_initializer)
+    wizard._navigate_to("profile")
     assert not wizard.next_btn.get_visible()
 
 
@@ -357,6 +390,7 @@ def test_back_visible_and_returns_to_profile_after_source(
     ui_context_initializer,
 ):
     wizard = _make_wizard(ui_context_initializer)
+    wizard._navigate_to("profile")
     wizard._on_profile_source_selected(
         None, kind="profile", profile=_profile()
     )
@@ -369,6 +403,7 @@ def test_back_visible_and_returns_to_profile_after_source(
 @pytest.mark.ui
 def test_back_visible_after_other_source(ui_context_initializer):
     wizard = _make_wizard(ui_context_initializer)
+    wizard._navigate_to("profile")
     wizard._on_profile_source_selected(None, kind="other", profile=None)
     assert wizard.stack.get_visible_child_name() == "controller"
     assert wizard.back_btn.get_visible()
@@ -444,8 +479,8 @@ def test_skip_button_only_on_optional_pages(ui_context_initializer):
         wizard._navigate_to(name)
         assert wizard.skip_btn.get_visible(), name
     for name in (
+        "discover",
         "profile",
-        "controller",
         "connect",
         "probe",
         "ai_lookup",
@@ -728,3 +763,488 @@ def test_ai_lookup_page_progress_bar_tracks_lookup(ui_context_initializer):
     assert page._progress_bar.get_visible()
     page._stop_pulse()
     assert not page._progress_bar.get_visible()
+
+
+def _discovered_device(**overrides):
+    from rayforge.machine.driver.discovery import DiscoveredDevice
+
+    defaults = {
+        "driver_name": "GrblSerialDriver",
+        "params": {"port": "/dev/ttyUSB0", "baudrate": 115200},
+        "label": "GRBL device",
+        "detail": "/dev/ttyUSB0 at 115200 baud",
+        "identity": DeviceIdentity(firmware="grbl", banner="Grbl 1.1f"),
+    }
+    defaults.update(overrides)
+    return DiscoveredDevice(**defaults)
+
+
+@pytest.mark.ui
+def test_discover_page_lists_devices(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    assert wizard.stack.get_visible_child_name() == "discover"
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    page._update_devices([])
+    assert page.status_label.get_text() == "No devices detected yet"
+    assert page.status_box.get_visible()
+
+    with patch.object(GrblSerialDriver, "supports_probing", False):
+        page._update_devices([_discovered_device()])
+    assert not page.status_box.get_visible()
+    assert list(page._device_rows) == ["GrblSerialDriver:/dev/ttyUSB0"]
+    row = page._device_rows["GrblSerialDriver:/dev/ttyUSB0"]
+    assert row.get_title() == "GRBL device"
+    subtitle = row.get_subtitle()
+    assert subtitle is not None
+    assert "/dev/ttyUSB0 at 115200 baud" in subtitle
+
+    # A held device is not rescanned, so its row survives empty scan
+    # results; only unplugging (port gone from the system) removes it.
+    page._update_devices([])
+    assert list(page._device_rows) == ["GrblSerialDriver:/dev/ttyUSB0"]
+
+
+@pytest.mark.ui
+def test_discover_page_select_button(ui_context_initializer):
+    """Every device row carries a Select button; clicking it picks
+    the device just like activating the row."""
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    with patch.object(GrblSerialDriver, "supports_probing", False):
+        page._update_devices([_discovered_device()])
+    row = page._device_rows["GrblSerialDriver:/dev/ttyUSB0"]
+    assert row.select_button.get_label() == "Select"
+
+    selected = {}
+    page.device_selected.connect(
+        lambda sender, **kw: selected.update(kw), weak=False
+    )
+    row.select_button.emit("clicked")
+    assert selected["device"].key == "GrblSerialDriver:/dev/ttyUSB0"
+
+
+@pytest.mark.ui
+def test_discover_page_next_is_configure_manually(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    assert wizard.stack.get_visible_child_name() == "discover"
+    assert wizard.next_btn.get_label() == "Configure Manually"
+    assert wizard.next_btn.get_visible()
+    assert wizard.next_btn.get_sensitive()
+
+
+@pytest.mark.ui
+def test_discover_configure_manually_goes_to_profile(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    wizard.next_btn.emit("clicked")
+    assert wizard.stack.get_visible_child_name() == "profile"
+
+
+@pytest.mark.ui
+def test_device_selected_with_match_skips_to_probe(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    matched = DeviceProfile(
+        meta=DeviceMeta(name="Frob One", vendor="Frobnicate"),
+        machine_config=MachineConfig(driver="GrblSerialDriver"),
+        dialect_config={},
+    )
+    device = _discovered_device()
+    # Keep the auto-started probe on the next step inert.
+    with (
+        patch("rayforge.ui_gtk.machine.wizard_pages.probe_page.task_mgr"),
+        patch.object(
+            type(ui_context_initializer.device_profile_mgr),
+            "match_device",
+            return_value=matched,
+        ),
+    ):
+        wizard._on_device_selected(page, device=device)
+
+    assert wizard.stack.get_visible_child_name() == "probe"
+    assert wizard.profile.name == "Frob One"
+    mc = wizard.profile.machine_config
+    assert mc.driver == "GrblSerialDriver"
+    assert mc.driver_args == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+    assert {"profile", "controller", "connect"} <= wizard._skipped_steps_set
+
+
+@pytest.mark.ui
+def test_probe_result_adopts_matched_profile(ui_context_initializer):
+    """The probe's build info names the device, so the wizard re-runs
+    profile matching: a unique match adopts the curated profile and
+    reroutes to the known-machine flow."""
+    wizard = _make_wizard(ui_context_initializer)
+    discover_page = wizard._get_page("discover")
+    assert isinstance(discover_page, DiscoverPage)
+
+    with patch("rayforge.ui_gtk.machine.wizard_pages.probe_page.task_mgr"):
+        wizard._on_device_selected(
+            discover_page, device=_discovered_device(identity=DeviceIdentity())
+        )
+    assert wizard.stack.get_visible_child_name() == "probe"
+    assert wizard._source is None
+
+    # The probe returns a profile built from $I/$$ answers.
+    probed = DeviceProfile(
+        meta=DeviceMeta(name="Frob One"),
+        machine_config=MachineConfig(
+            driver="GrblSerialDriver",
+            driver_args={"port": "/dev/ttyUSB0", "baudrate": 115200},
+            driver_config={"rx_buffer_size": 31},
+            axis_extents=(120.0, 120.0),
+        ),
+        dialect_config={},
+    )
+    curated = DeviceProfile(
+        meta=DeviceMeta(name="Frob One", vendor="Frobnicate"),
+        machine_config=MachineConfig(
+            driver="GrblSerialDriver",
+            axis_extents=(150.0, 150.0),
+        ),
+        dialect_config={},
+    )
+    with patch.object(
+        type(ui_context_initializer.device_profile_mgr),
+        "match_device",
+        return_value=curated,
+    ):
+        wizard._on_probe_succeeded(
+            None, profile=probed, warnings=["laser mode off"]
+        )
+
+    assert wizard._source is not None
+    assert wizard._source["kind"] == "profile"
+    assert wizard.profile.name == "Frob One"
+    mc = wizard.profile.machine_config
+    assert mc.driver_args == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+    # Live connection facts survive; curated specs are trusted over
+    # the probe's readings.
+    assert mc.driver_config == {"rx_buffer_size": 31}
+    assert mc.axis_extents == (150.0, 150.0)
+
+    # Known-machine flow: everything through camera is skipped; the
+    # profile is the source of truth for optional hardware too.
+    assert wizard._next_step_after("probe") == "review"
+    assert {
+        "ai_provider",
+        "ai_lookup",
+        "hardware",
+        "head",
+        "rotary",
+        "camera",
+    } <= wizard._skipped_steps_set
+
+
+@pytest.mark.ui
+def test_device_selected_without_match_probes_device(ui_context_initializer):
+    """No profile match, but a probe-capable driver: ask the device
+    itself instead of making the user pick from the catalog."""
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    # No tokens → no profile can match; the probe auto-starts on
+    # entry, so keep its task manager inert.
+    with patch("rayforge.ui_gtk.machine.wizard_pages.probe_page.task_mgr"):
+        wizard._on_device_selected(
+            page, device=_discovered_device(identity=DeviceIdentity())
+        )
+
+    assert wizard.stack.get_visible_child_name() == "probe"
+    mc = wizard.profile.machine_config
+    assert mc.driver == "GrblSerialDriver"
+    assert mc.driver_args == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+    assert wizard.aux_state.get("discovered") is not None
+    assert {"controller", "connect"} <= wizard._skipped_steps_set
+
+
+@pytest.mark.ui
+def test_device_selected_without_match_shows_profile(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    # A driver that cannot probe falls back to the profile picker.
+    with patch.object(GrblSerialDriver, "supports_probing", False):
+        wizard._on_device_selected(
+            page, device=_discovered_device(identity=DeviceIdentity())
+        )
+
+    assert wizard.stack.get_visible_child_name() == "profile"
+    mc = wizard.profile.machine_config
+    assert mc.driver == "GrblSerialDriver"
+    assert mc.driver_args == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+
+    profile_page = wizard._get_page("profile")
+    assert isinstance(profile_page, ProfilePage)
+    assert profile_page.hint_row.get_visible()
+
+    # Picking "Device Not Listed" keeps the discovered driver and
+    # collected data; with complete connection args the remaining
+    # known-data steps are skipped and the unknown-machine flow
+    # (AI lookup) begins.
+    wizard._on_profile_source_selected(
+        profile_page, kind="other", profile=None
+    )
+    assert wizard.stack.get_visible_child_name() == "ai_provider"
+    assert wizard.profile.machine_config.driver == "GrblSerialDriver"
+    assert wizard.profile.machine_config.driver_args == {
+        "port": "/dev/ttyUSB0",
+        "baudrate": 115200,
+    }
+
+
+def _probed_profile(name="Mystery CNC", **machine_overrides):
+    return DeviceProfile(
+        meta=DeviceMeta(name=name),
+        machine_config=MachineConfig(
+            driver="GrblSerialDriver", **machine_overrides
+        ),
+        dialect_config={},
+    )
+
+
+@pytest.mark.ui
+def test_device_selected_with_probe_data_and_match_completes_flow(
+    ui_context_initializer,
+):
+    """Probe data collected on the discover page + a unique profile
+    match: everything through the camera step is skipped and the
+    user lands directly on the review."""
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    probed = _probed_profile(
+        "Frob One",
+        driver_config={"rx_buffer_size": 31},
+        axis_extents=(120.0, 120.0),
+    )
+    curated = DeviceProfile(
+        meta=DeviceMeta(name="Frob One", vendor="Frobnicate"),
+        machine_config=MachineConfig(
+            driver="GrblSerialDriver", axis_extents=(150.0, 150.0)
+        ),
+        dialect_config={},
+    )
+    device = _discovered_device(
+        identity=DeviceIdentity(), probe_profile=probed
+    )
+    with patch.object(
+        type(ui_context_initializer.device_profile_mgr),
+        "match_device",
+        return_value=curated,
+    ):
+        wizard._on_device_selected(page, device=device)
+
+    assert wizard.stack.get_visible_child_name() == "review"
+    assert wizard.profile.name == "Frob One"
+    mc = wizard.profile.machine_config
+    # Live connection facts survive; curated specs are trusted.
+    assert mc.driver_args == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+    assert mc.driver_config == {"rx_buffer_size": 31}
+    assert mc.axis_extents == (150.0, 150.0)
+    assert {
+        "profile",
+        "controller",
+        "connect",
+        "probe",
+        "ai_provider",
+        "ai_lookup",
+        "hardware",
+        "head",
+        "rotary",
+        "camera",
+    } <= wizard._skipped_steps_set
+
+
+@pytest.mark.ui
+def test_device_selected_with_probe_data_without_match_filters_profiles(
+    ui_context_initializer,
+):
+    """Probe data without a match: the profile picker comes up (not
+    the probe page), the probed specs are already in place, and
+    picking a profile completes the known-machine flow."""
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    probed = _probed_profile(axis_extents=(120.0, 120.0))
+    device = _discovered_device(
+        identity=DeviceIdentity(), probe_profile=probed
+    )
+    wizard._on_device_selected(page, device=device)
+
+    assert wizard.stack.get_visible_child_name() == "profile"
+    assert {"controller", "connect", "probe"} <= wizard._skipped_steps_set
+    assert wizard.profile.machine_config.axis_extents == (120.0, 120.0)
+
+    profile_page = wizard._get_page("profile")
+    assert isinstance(profile_page, ProfilePage)
+
+    curated = DeviceProfile(
+        meta=DeviceMeta(name="Frob One", vendor="Frobnicate"),
+        machine_config=MachineConfig(
+            driver="GrblSerialDriver", axis_extents=(150.0, 150.0)
+        ),
+        dialect_config={},
+    )
+    wizard._on_profile_source_selected(
+        profile_page, kind="profile", profile=curated
+    )
+    assert wizard.stack.get_visible_child_name() == "review"
+    assert wizard.profile.machine_config.axis_extents == (150.0, 150.0)
+    assert wizard.profile.machine_config.driver_args == {
+        "port": "/dev/ttyUSB0",
+        "baudrate": 115200,
+    }
+
+
+@pytest.mark.ui
+def test_discover_page_probes_and_enriches_found_device(
+    ui_context_initializer,
+):
+    """A found device is probed automatically; the row then shows
+    the machine's own name and work area."""
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    device = _discovered_device()
+    with (
+        patch(
+            "rayforge.ui_gtk.machine.wizard_pages.discover_page.get_context",
+            return_value=ui_context_initializer,
+        ),
+        patch(
+            "rayforge.ui_gtk.machine.wizard_pages.discover_page.task_mgr"
+        ) as tm,
+    ):
+        page._update_devices([device])
+        assert tm.add_coroutine.called
+        assert page._held_ports == {"/dev/ttyUSB0"}
+
+        probed = _probed_profile("Sculpfun iCube", axis_extents=(120.0, 120.0))
+        task = MagicMock()
+        task.result.return_value = (probed, [])
+        tm.schedule_on_main_thread.side_effect = lambda fn: fn()
+        page._on_probe_done(task, device)
+
+    row = page._device_rows["GrblSerialDriver:/dev/ttyUSB0"]
+    assert row.get_title() == "Sculpfun iCube"
+    assert row.device.probe_profile is probed
+    subtitle = row.get_subtitle()
+    assert subtitle is not None
+    assert "/dev/ttyUSB0 at 115200 baud" in subtitle
+    assert "120" in subtitle
+
+    # The enriched device is what selection emits.
+    selected = {}
+    page.device_selected.connect(
+        lambda sender, **kw: selected.update(kw), weak=False
+    )
+    page._on_row_activated(row)
+    assert selected["device"].probe_profile is probed
+
+
+@pytest.mark.ui
+def test_discover_page_rescan_excludes_and_prunes(ui_context_initializer):
+    wizard = _make_wizard(ui_context_initializer)
+    page = wizard._get_page("discover")
+    assert isinstance(page, DiscoverPage)
+
+    with patch.object(GrblSerialDriver, "supports_probing", False):
+        page._update_devices([_discovered_device()])
+    assert page._held_ports == {"/dev/ttyUSB0"}
+
+    # Rescans keep away from ports whose devices are already held.
+    captured = {}
+
+    async def fake_find(driver_classes=None, exclude_ports=None, **kwargs):
+        captured["exclude_ports"] = set(exclude_ports or ())
+
+    with (
+        patch(
+            "rayforge.ui_gtk.machine.wizard_pages.discover_page"
+            ".find_all_devices",
+            fake_find,
+        ),
+        patch(
+            "rayforge.ui_gtk.machine.wizard_pages.discover_page.task_mgr"
+        ) as tm,
+    ):
+        page._start_scan()
+        coro = tm.add_coroutine.call_args.args[0]
+        asyncio.run(coro(None))
+    assert captured["exclude_ports"] == {"/dev/ttyUSB0"}
+
+    # A device that is unplugged is pruned and its port freed.
+    with patch(
+        "rayforge.ui_gtk.machine.wizard_pages.discover_page.SerialTransport"
+    ) as transport:
+        transport.list_port_info.return_value = []
+        page._prune_unplugged_ports()
+    assert page._device_rows == {}
+    assert page._held_ports == set()
+
+
+@pytest.mark.ui
+def test_profile_page_suggests_matching_vendor(ui_context_initializer):
+    """With a pending discovered device, the profile list narrows to
+    profiles of the same vendor and controller; searching broadens
+    it back to the full catalog."""
+    from rayforge.machine.driver import normalize_tokens
+
+    wizard = _make_wizard(ui_context_initializer)
+    profile_page = wizard._get_page("profile")
+    assert isinstance(profile_page, ProfilePage)
+
+    frob = DeviceProfile(
+        meta=DeviceMeta(name="Frob One", vendor="Frobnicate"),
+        machine_config=MachineConfig(driver="GrblSerialDriver"),
+        dialect_config={},
+    )
+    other = DeviceProfile(
+        meta=DeviceMeta(name="Gadget Two", vendor="Gadgetco"),
+        machine_config=MachineConfig(driver="GrblSerialDriver"),
+        dialect_config={},
+    )
+    device = _discovered_device(
+        identity=DeviceIdentity(tokens=normalize_tokens("Frobnicate laser"))
+    )
+    wizard.aux_state = {"discovered": device}
+
+    mgr = ui_context_initializer.device_profile_mgr
+    with (
+        patch(
+            "rayforge.ui_gtk.machine.wizard_pages.profile_page.get_context",
+            return_value=ui_context_initializer,
+        ),
+        patch.object(mgr, "get_all", return_value=[frob, other]),
+    ):
+        profile_page.enter(wizard.profile)
+        titles = _visible_profile_titles(profile_page)
+        assert titles == ["Frob One"]
+
+        # Searching broadens the list back to the full catalog.
+        # (search-changed is delay-debounced by GTK, so filter
+        # explicitly here.)
+        profile_page.search_entry.set_text("gadget")
+        profile_page._filter_and_populate_list()
+        titles = _visible_profile_titles(profile_page)
+        assert titles == ["Gadget Two"]
+
+
+def _visible_profile_titles(page: ProfilePage) -> list[str]:
+    titles = []
+    index = 0
+    while (row := page.list_box.get_row_at_index(index)) is not None:
+        titles.append(row.get_title())  # type: ignore[attr-defined]
+        index += 1
+    return titles

--- a/tests/ui_gtk/test_first_run_wizard.py
+++ b/tests/ui_gtk/test_first_run_wizard.py
@@ -1,0 +1,176 @@
+# flake8: noqa: E402
+import logging
+import os
+import sys
+import time
+
+import pytest
+
+# Platform-Specific Setup
+if sys.platform.startswith("linux"):
+    os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+    if not os.environ.get("DISPLAY"):
+        pytest.skip(
+            "DISPLAY not set on Linux, skipping UI tests. Run with xvfb-run.",
+            allow_module_level=True,
+        )
+
+
+# Gtk imports must happen AFTER the platform setup and display check.
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("Gdk", "4.0")
+from gi.repository import Adw, GLib
+
+from rayforge.ui_gtk.mainwindow import MainWindow
+
+logger = logging.getLogger(__name__)
+
+
+def process_events_for_duration(duration_sec: float):
+    """Processes all pending GTK events for a given duration."""
+    end_time = time.monotonic() + duration_sec
+    context = GLib.main_context_default()
+    while time.monotonic() < end_time:
+        while context.pending():
+            context.iteration(False)
+        time.sleep(0.01)
+
+
+@pytest.fixture
+def first_run_app_and_window(ui_context_initializer, request):
+    """Sets up an app/window in a fresh (first-run) configuration."""
+    from rayforge.ui_gtk import sim3d
+
+    sim3d.initialize()
+    assert sim3d.initialized, "Canvas3D failed to initialize"
+
+    context = ui_context_initializer
+    # Simulate a fresh install: a single untouched placeholder machine.
+    machine_mgr = context.machine_mgr
+    if not machine_mgr.machines:
+        machine_mgr.create_default_machine()
+
+    win = None
+
+    class TestApp(Adw.Application):
+        def do_activate(self):
+            nonlocal win
+            win = MainWindow(application=self)
+            win.set_default_size(1280, 800)
+            self.win = win
+
+    test_name = request.node.name.replace("_", "-")
+    app_id = f"org.rayforge.rayforge.test.{test_name}"
+    app = TestApp(application_id=app_id)
+    app.register(None)
+    app.activate()
+    process_events_for_duration(0.5)
+
+    assert hasattr(app, "win") and app.win is not None
+    win = app.win
+    win.present()
+    process_events_for_duration(0.5)
+
+    yield app, win
+
+    if win:
+        win.doc_editor.cleanup()
+        win.close()
+        app.quit()
+    process_events_for_duration(0.2)
+
+
+@pytest.fixture
+def setup_app_and_window(ui_context_initializer, request):
+    """Sets up an app/window whose setup is already completed."""
+    from rayforge.ui_gtk import sim3d
+
+    sim3d.initialize()
+    assert sim3d.initialized, "Canvas3D failed to initialize"
+
+    context = ui_context_initializer
+    context.machine_mgr.create_default_machine()
+    context.config.setup_completed = True
+
+    win = None
+
+    class TestApp(Adw.Application):
+        def do_activate(self):
+            nonlocal win
+            win = MainWindow(application=self)
+            win.set_default_size(1280, 800)
+            self.win = win
+
+    test_name = request.node.name.replace("_", "-")
+    app_id = f"org.rayforge.rayforge.test.{test_name}"
+    app = TestApp(application_id=app_id)
+    app.register(None)
+    app.activate()
+    process_events_for_duration(0.5)
+
+    assert hasattr(app, "win") and app.win is not None
+    win = app.win
+    win.present()
+    process_events_for_duration(0.5)
+
+    yield app, win
+
+    if win:
+        win.doc_editor.cleanup()
+        win.close()
+        app.quit()
+    process_events_for_duration(0.2)
+
+
+@pytest.mark.ui
+def test_first_launch_presents_wizard(first_run_app_and_window):
+    """On first launch the setup wizard opens automatically."""
+    _app, win = first_run_app_and_window
+    GLib.idle_add(win._maybe_present_first_run_wizard)
+    process_events_for_duration(0.5)
+
+    assert win._setup_wizard is not None
+    assert win._setup_wizard.get_visible()
+
+
+@pytest.mark.ui
+def test_first_launch_wizard_cancel_falls_back(first_run_app_and_window):
+    """Cancelling the wizard keeps the placeholder and sets the flag."""
+    _app, win = first_run_app_and_window
+    from rayforge.context import get_context
+
+    ctx = get_context()
+    config = ctx.config
+    placeholder_id = next(iter(ctx.machine_mgr.machines))
+
+    GLib.idle_add(win._maybe_present_first_run_wizard)
+    process_events_for_duration(0.5)
+    assert win._setup_wizard is not None
+
+    win._setup_wizard.close()
+    process_events_for_duration(0.5)
+
+    assert config.setup_completed is True
+    assert win._setup_wizard is None
+    # The placeholder machine is still there so the app stays usable.
+    assert placeholder_id in ctx.machine_mgr.machines
+
+
+@pytest.mark.ui
+def test_banner_shown_while_placeholder_active(setup_app_and_window):
+    """The banner is visible while the active machine is a placeholder."""
+    _app, win = setup_app_and_window
+    assert win.setup_banner.get_revealed() is True
+
+
+@pytest.mark.ui
+def test_banner_opens_wizard_manually(setup_app_and_window):
+    """The banner button opens the setup wizard."""
+    _app, win = setup_app_and_window
+    win.setup_banner.emit("button-clicked")
+    process_events_for_duration(0.3)
+
+    assert win._setup_wizard is not None


### PR DESCRIPTION
## Summary

This branch does two things that belong together:

### 1. Land PR #376 (auto-device-discovery) onto main

#376 was merged into the \`usb-first-port-selector\` branch but never landed on \`main\`. It adds the discovery-first flow to the machine configuration wizard: plugging in a machine and opening \"Add Machine\" is enough to get a fully configured device — no forms, no baud-rate guessing.

- **Scanning** (\`machine/transport/serial_scan.py\`): opens every serial port once per scan, probes candidate baud rates, captures banners/responses.
- **Evaluating** (\`machine/driver/discovery.py\`): drivers declare a \`DISCOVERY\` recognizer; \`find_all_devices()\` runs one scan for all drivers.
- **Wizard flow**: a Discover page scans while visible, lists found devices with a Select button, probes each automatically, matches against built-in device profiles, and skips steps whose data is already known.

Cherry-picked cleanly onto \`main\` (all three prerequisite commits — USB port selector + test fixes — are already on main under rewritten-history hashes).

### 2. First-run machine setup wizard (phase 3 of the frictionless-setup plan)

On first launch (only placeholder machines exist and setup was not yet completed), the main window presents the unified wizard automatically instead of silently keeping the auto-created placeholder. Because the discovery flow above is now in the wizard, first-run users get \"Detected GRBL on ttyUSB0\" immediately.

- Persisted \`Config.setup_completed\` flag gates the auto-wizard; existing users with real machines are unaffected.
- \`MachineManager.create_default_machine()\` marks the machine as \`placeholder\`; a persistent \"Set up your machine\" banner stays visible while a placeholder is active, with a button to re-open the wizard.
- Cancelling the wizard falls back to the placeholder (app stays usable) and sets the flag so it never nags again.
- Freshly created machines are stamped with the current schema version so they no longer trigger a spurious \"New Settings Available\" dialog on first run.
- The wizard opens only after the usage-consent dialog is answered, so windows don't pile up.

## Test plan

- New unit tests: \`tests/core/test_config.py\` (setup_completed persistence), \`tests/machine/models/test_machine_manager.py\` (placeholder marking/filtering), \`tests/machine/models/test_machine_model.py\` (placeholder serialization).
- New UI tests: \`tests/ui_gtk/test_first_run_wizard.py\` (auto-presentation, cancel fallback, banner visibility, banner button).
- Discovery tests from #376: \`test_serial_scan.py\`, \`test_discovery.py\`, \`test_profile_matching.py\`, extended \`test_unified_wizard.py\`.
- \`pixi run lint\` clean; full backend suite (6391 passed) and wizard UI tests (62 passed) green.
- Manual smoke test under xvfb with a fresh config dir: wizard opens on the Discover page, no \"New Settings Available\" dialog, no window pile-up.