### PR TITLE
fix: don't let generic binary MIME hijack file import

### DIFF
--- a/rayforge/doceditor/file_cmd.py
+++ b/rayforge/doceditor/file_cmd.py
@@ -124,12 +124,15 @@ class FileCmd:
     ) -> tuple[type[Importer] | None, set[ImporterFeature]]:
         """
         Finds the importer for a file and returns its class and feature set.
+
+        A generic MIME type carries no format information, so it never
+        shadows a match by file extension.
         """
         if not mime_type:
             mime_type, _ = mimetypes.guess_type(file_path)
 
         importer_cls = None
-        if mime_type:
+        if mime_type and mime_type != "application/octet-stream":
             importer_cls = importer_registry.get_by_mime_type(mime_type)
 
         if not importer_cls and file_path.suffix:

--- a/rayforge/image/ruida/importer.py
+++ b/rayforge/image/ruida/importer.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class RuidaImporter(Importer):
     label = "Ruida files"
-    mime_types = ("application/x-rd-file", "application/octet-stream")
+    mime_types = ("application/x-rd-file",)
     extensions = (".rd",)
     features: ClassVar[set[ImporterFeature]] = {ImporterFeature.DIRECT_VECTOR}
 

--- a/tests/doceditor/test_file_cmd.py
+++ b/tests/doceditor/test_file_cmd.py
@@ -32,6 +32,9 @@ from rayforge.image import (
     LayerInfo,
     ParsingResult,
 )
+from rayforge.image.dxf.importer import DxfImporter
+from rayforge.image.lightburn.importer import LightBurnImporter
+from rayforge.image.ruida.importer import RuidaImporter
 from rayforge.image.svg.renderer import SVG_RENDERER
 from rayforge.machine.models.coordspace import (
     AxisDirection,
@@ -842,6 +845,35 @@ class TestGetImporterInfo:
             )
             assert cls is None
             assert features == set()
+
+    def test_generic_mime_does_not_shadow_extension(self, file_cmd):
+        """
+        A .dxf file reported with the generic binary MIME type must be
+        routed by its extension, not by the generic match.
+
+        macOS reports files with unrecognized UTIs (e.g. .dxf, .lbrn2)
+        as application/octet-stream. If that MIME type won the lookup,
+        the file was handed to the RuidaImporter, which parsed the text
+        file as a binary Ruida job and produced garbage geometry.
+        """
+        cls, features = file_cmd.get_importer_info(
+            Path("part.dxf"), "application/octet-stream"
+        )
+        assert cls is DxfImporter
+        assert ImporterFeature.LAYER_SELECTION in features
+
+    def test_generic_mime_does_not_shadow_lightburn_extension(self, file_cmd):
+        cls, _ = file_cmd.get_importer_info(
+            Path("puzzle.lbrn2"), "application/octet-stream"
+        )
+        assert cls is LightBurnImporter
+
+    def test_ruida_resolves_by_extension_with_generic_mime(self, file_cmd):
+        cls, features = file_cmd.get_importer_info(
+            Path("job.rd"), "application/octet-stream"
+        )
+        assert cls is RuidaImporter
+        assert ImporterFeature.DIRECT_VECTOR in features
 
 
 class TestAnalyzeImportTarget:


### PR DESCRIPTION
Fixes #384

## Root cause

The DXF file in the issue never reached the `DxfImporter` — it was hijacked by the **Ruida importer**:

1. `RuidaImporter` registers the catch-all MIME type `application/octet-stream` (the type operating systems report for any file whose format they cannot identify).
2. On macOS, GIO resolves formats like `.dxf` and `.lbrn2` to exactly that generic type (no UTI → MIME mapping exists for them in the bundle's environment).
3. `FileCmd.get_importer_info()` consulted the MIME type **before** the file extension, so `application/octet-stream → RuidaImporter` won and the `.dxf` extension fallback was never reached.
4. The Ruida parser then read the text-based DXF as a binary Ruida job, producing deterministic garbage geometry.

### Evidence

The reporter's debug log shows the import result:

```
ItemAssembler: document_bounds=(0.0, -1241.1729999999998, 58.20799999999998, 1234.2079999999999)
ItemAssembler: item.crop_window=(...same...), layer_id=__default__
_fit_and_position_at_reference_origin: bbox=(0.00, -1241.17, 58.21, 1234.21), work_area=(0.00, 0.00, 400.00, 400.00)
⚠️ Imported item was larger than the work area and has been scaled down to fit.
```

Running `RuidaImporter` on the attached DXF file reproduces these values **float-for-float**:

```
document_bounds: (0.0, -1241.1729999999998, 58.20799999999998, 1234.2079999999999)
native_unit_to_mm: 1.0
layer: __default__
```

while the correct DXF parse yields `(-2.32, -4.58, 4.64, 9.17)` inches on layer `Layer 1` with 25.4 mm/unit — a 118×233 mm design that fits the 400 mm bed without any scaling. The `DxfRenderer: Rendering vector outlines...` line in the log is explained by `RuidaRenderer` subclassing `DxfRenderer`.

The second file (`puzzle-4mm.lbrn2`, a LightBurn project) fails identically for the same reason — this is not related to the DXF version or the generating editor. Every "unrecognizable" format was silently swallowed by the Ruida catch-all.

## Fix

- `FileCmd.get_importer_info()`: stop treating `application/octet-stream` as a positive match. It carries no format information and must never shadow a match by file extension.
- `RuidaImporter`: drop `application/octet-stream` from `mime_types`. `.rd` files keep resolving via the extension fallback.
- Regression tests pinning `.dxf`, `.lbrn2`, and `.rd` routing when the OS reports the generic binary type.

## Testing

- New tests in `tests/doceditor/test_file_cmd.py` fail on the unfixed code and pass with the fix.
- `tests/doceditor`, `tests/image`, `tests/core`: 1548 passed.
- ruff format/check, flake8, pyflakes, pyright clean on the changed files.