### PR TITLE
sim3d: add debug logging for canvas input gestures

### DIFF
--- a/rayforge/ui_gtk/sim3d/camera_controller.py
+++ b/rayforge/ui_gtk/sim3d/camera_controller.py
@@ -156,6 +156,13 @@ class CameraController:
 
     def _on_click_focus(self, gesture, n_press, x, y):
         """Grab keyboard focus so the canvas receives key events."""
+        logger.debug(
+            "Canvas3D click: button=%d, n_press=%d, pos=(%.2f, %.2f)",
+            gesture.get_current_button(),
+            n_press,
+            x,
+            y,
+        )
         self._widget.grab_focus()
 
     def _clear_drag_state(self):
@@ -188,6 +195,7 @@ class CameraController:
         gesture.set_state(Gtk.EventSequenceState.CLAIMED)
         state = gesture.get_current_event_state()
         is_shift = bool(state & Gdk.ModifierType.SHIFT_MASK)
+        logger.debug("Middle drag begin at (%.2f, %.2f)", x, y)
 
         if not is_shift and self.camera:
             # Orbit around the point on the object under the cursor,
@@ -205,6 +213,10 @@ class CameraController:
 
             self._last_orbit_pos = None
             self._is_orbiting = True
+            logger.debug(
+                "Middle drag orbits, pivot=%s",
+                self._rotation_pivot.tolist(),
+            )
         else:
             self._pan_anchor = self.get_world_coords_on_plane(x, y)
             self._pan_start_screen = x, y
@@ -212,9 +224,18 @@ class CameraController:
             self._is_orbiting = False
             if self._pan_anchor is not None:
                 self._pan_anchor = self._clamp_to_grid(self._pan_anchor)
+            anchor = (
+                self._pan_anchor.tolist()
+                if self._pan_anchor is not None
+                else None
+            )
+            logger.debug("Middle drag pans, anchor=%s", anchor)
 
     def on_drag_update(self, gesture, offset_x: float, offset_y: float):
         """Handles updates during a drag operation (panning or orbiting)."""
+        logger.debug(
+            "Middle drag update: offset=(%.2f, %.2f)", offset_x, offset_y
+        )
         if not self.camera:
             return
         camera = self.camera
@@ -440,6 +461,9 @@ class CameraController:
 
     def on_drag_end(self, gesture, offset_x, offset_y):
         """Handles the end of a drag operation."""
+        logger.debug(
+            "Middle drag end: offset=(%.2f, %.2f)", offset_x, offset_y
+        )
         self._clear_drag_state()
         self._request_render()
 
@@ -447,6 +471,7 @@ class CameraController:
         """
         Handles the start of a left-mouse-button drag for Z-axis rotation.
         """
+        logger.debug("Z-rotate drag begin at (%.2f, %.2f)", x, y)
         if not self.camera:
             return
         gesture.set_state(Gtk.EventSequenceState.CLAIMED)
@@ -483,6 +508,9 @@ class CameraController:
 
     def on_z_rotate_end(self, gesture, offset_x, offset_y):
         """Handles the end of a Z-axis rotation drag."""
+        logger.debug(
+            "Z-rotate drag end: offset=(%.2f, %.2f)", offset_x, offset_y
+        )
         self._clear_drag_state()
         self._request_render()
 
@@ -501,6 +529,7 @@ class CameraController:
         the camera is dollied and then translated so that the plane point
         under the cursor stays under the cursor.
         """
+        logger.debug("Scroll event: dx=%.2f, dy=%.2f", dx, dy)
         if not self.camera:
             return
 

--- a/rayforge/ui_gtk/sim3d/canvas3d.py
+++ b/rayforge/ui_gtk/sim3d/canvas3d.py
@@ -206,6 +206,10 @@ class Canvas3D(Gtk.GLArea):
         self._presenter.update_scene_from_doc()
 
     def _on_key_pressed(self, controller, keyval, keycode, state):
+        key_name = Gdk.keyval_name(keyval)
+        logger.debug(
+            "Canvas3D key pressed: key='%s', state=%s", key_name, state
+        )
         overlay = self._presenter.playback_overlay
         if keyval == Gdk.KEY_space and overlay:
             overlay.handle_space()


### PR DESCRIPTION
## Summary

Adds DEBUG-level logging to the 3D canvas input path, mirroring the existing coverage on the 2D `WorldSurface`, so that gesture problems can be diagnosed from user session logs (reopened #241).

**CameraController** (`camera_controller.py`):
- `_on_click_focus`: logs every button press reaching the 3D widget, including the button number — the key signal for detecting that events are not delivered at all
- `on_drag_begin`: logs start position and whether the drag orbits (with pivot) or pans (with anchor)
- `on_drag_update` / `on_drag_end`: logs drag offsets
- `on_z_rotate_begin` / `on_z_rotate_end`: logs left-button drag start/end
- `on_scroll`: logs scroll deltas

**Canvas3D** (`canvas3d.py`):
- `_on_key_pressed`: logs key name and modifier state, so it is visible whether e.g. Space even reaches the 3D view

All messages are DEBUG level and therefore only go to console (when `--loglevel DEBUG`) and the session log file; the in-app log view is unaffected.

## Test notes

- Only logging statements added; no control flow changes
- Verified compatibility with `tests/ui_gtk/sim3d/test_camera_controller.py` `_FakeGesture` stubs
- Lines compile and respect the 79-char limit

Fixes diagnostic half of #241 (logging only; Space+drag pan for 3D would be a separate feature)