### PR TITLE
fix(print-and-cut): tolerate 4-axis position reports

### DIFF
--- a/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
+++ b/rayforge/builtin_addons/rayforge-addon-print-and-cut/print_and_cut/wizard.py
@@ -538,10 +538,11 @@ class PrintAndCutWizard(PatchedDialogWindow):
             return
 
         pos = self._machine.get_current_position()
-        if pos is None:
+        if pos is None or len(pos) < 2:
             return
 
-        x_val, y_val, _z_val = pos
+        x_val = pos[0]
+        y_val = pos[1]
         if x_val is None or y_val is None:
             return
 
@@ -603,7 +604,10 @@ class PrintAndCutWizard(PatchedDialogWindow):
             return
         pos = self._machine.get_current_position()
         if pos:
-            x_val, y_val, _z_val = pos
+            if len(pos) < 2:
+                return
+            x_val = pos[0]
+            y_val = pos[1]
             if x_val is not None and y_val is not None:
                 self._laser_row.set_subtitle(f"X: {x_val:.2f}  Y: {y_val:.2f}")
 

--- a/tests/ui_gtk/test_print_and_cut_wizard.py
+++ b/tests/ui_gtk/test_print_and_cut_wizard.py
@@ -1,0 +1,116 @@
+"""Regression tests for Print & Cut wizard position handling (#394).
+
+``Machine.get_current_position()`` returns a variable-length ``Pos``
+tuple: 4-axis machines report an extra A-axis value, so the tuple has
+four entries. The wizard previously unpacked a fixed 3-tuple, which
+raised ``ValueError`` and crashed the wizard on such machines.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parents[2]
+_ADDON_ROOT = (
+    _REPO_ROOT / "rayforge" / "builtin_addons" / "rayforge-addon-print-and-cut"
+)
+
+# The addon directory name contains hyphens and is not importable the
+# normal way, so we mimic the addon manager's synthetic module setup
+# (see AddonManager._ensure_parent_modules).
+_ROOT_NS = "rayforge_addons"
+_ADDON_NS = f"{_ROOT_NS}.print_and_cut"
+_INNER_PKG = f"{_ADDON_NS}.print_and_cut"
+
+
+def _load_wizard_class():
+    if f"{_INNER_PKG}.wizard" in sys.modules:
+        return sys.modules[f"{_INNER_PKG}.wizard"].PrintAndCutWizard
+
+    root = types.ModuleType(_ROOT_NS)
+    root.__path__ = []
+    root.__package__ = _ROOT_NS
+    sys.modules[_ROOT_NS] = root
+
+    addon = types.ModuleType(_ADDON_NS)
+    addon.__path__ = [str(_ADDON_ROOT)]
+    addon.__package__ = _ADDON_NS
+    sys.modules[_ADDON_NS] = addon
+
+    init_path = _ADDON_ROOT / "print_and_cut" / "__init__.py"
+    spec = importlib.util.spec_from_file_location(_INNER_PKG, init_path)
+    pkg = importlib.util.module_from_spec(spec)
+    sys.modules[_INNER_PKG] = pkg
+    spec.loader.exec_module(pkg)
+
+    wizard_path = _ADDON_ROOT / "print_and_cut" / "wizard.py"
+    spec = importlib.util.spec_from_file_location(
+        f"{_INNER_PKG}.wizard", wizard_path
+    )
+    wizard_mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{_INNER_PKG}.wizard"] = wizard_mod
+    spec.loader.exec_module(wizard_mod)
+    return wizard_mod.PrintAndCutWizard
+
+
+PrintAndCutWizard = _load_wizard_class()
+
+
+@pytest.fixture
+def wizard_stub():
+    return MagicMock()
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "pos, expected",
+    [
+        ((1.0, 2.0, 0.0), "X: 1.00  Y: 2.00"),
+        ((1.0, 2.0, 0.0, 45.0), "X: 1.00  Y: 2.00"),
+    ],
+)
+def test_update_laser_position_with_extra_axis(wizard_stub, pos, expected):
+    wizard_stub._machine.get_current_position.return_value = pos
+
+    PrintAndCutWizard._update_laser_position(wizard_stub)
+
+    wizard_stub._laser_row.set_subtitle.assert_called_once_with(expected)
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "pos",
+    [
+        None,
+        (),
+        (None, None, None),
+        (1.0, None, 0.0, 45.0),
+    ],
+)
+def test_update_laser_position_ignores_invalid_positions(wizard_stub, pos):
+    wizard_stub._machine.get_current_position.return_value = pos
+
+    PrintAndCutWizard._update_laser_position(wizard_stub)
+
+    wizard_stub._laser_row.set_subtitle.assert_not_called()
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "pos",
+    [
+        (1.5, -2.5, 0.0),
+        (1.5, -2.5, 0.0, 45.0),
+    ],
+)
+def test_record_clicked_with_extra_axis(wizard_stub, pos):
+    wizard_stub._machine.get_current_position.return_value = pos
+
+    PrintAndCutWizard._on_record_clicked(wizard_stub, None, 0)
+
+    assert wizard_stub._physical_point1 == (1.5, -2.5)
+    wizard_stub._pos1_row.set_subtitle.assert_called_once_with("(1.50, -2.50)")

--- a/tests/ui_gtk/test_print_and_cut_wizard.py
+++ b/tests/ui_gtk/test_print_and_cut_wizard.py
@@ -27,9 +27,20 @@ _ADDON_NS = f"{_ROOT_NS}.print_and_cut"
 _INNER_PKG = f"{_ADDON_NS}.print_and_cut"
 
 
+def _load_module(name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_wizard_class():
-    if f"{_INNER_PKG}.wizard" in sys.modules:
-        return sys.modules[f"{_INNER_PKG}.wizard"].PrintAndCutWizard
+    wizard_mod = sys.modules.get(f"{_INNER_PKG}.wizard")
+    if wizard_mod is not None:
+        return wizard_mod.PrintAndCutWizard
 
     root = types.ModuleType(_ROOT_NS)
     root.__path__ = []
@@ -41,19 +52,10 @@ def _load_wizard_class():
     addon.__package__ = _ADDON_NS
     sys.modules[_ADDON_NS] = addon
 
-    init_path = _ADDON_ROOT / "print_and_cut" / "__init__.py"
-    spec = importlib.util.spec_from_file_location(_INNER_PKG, init_path)
-    pkg = importlib.util.module_from_spec(spec)
-    sys.modules[_INNER_PKG] = pkg
-    spec.loader.exec_module(pkg)
-
-    wizard_path = _ADDON_ROOT / "print_and_cut" / "wizard.py"
-    spec = importlib.util.spec_from_file_location(
-        f"{_INNER_PKG}.wizard", wizard_path
+    _load_module(_INNER_PKG, _ADDON_ROOT / "print_and_cut" / "__init__.py")
+    wizard_mod = _load_module(
+        f"{_INNER_PKG}.wizard", _ADDON_ROOT / "print_and_cut" / "wizard.py"
     )
-    wizard_mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"{_INNER_PKG}.wizard"] = wizard_mod
-    spec.loader.exec_module(wizard_mod)
     return wizard_mod.PrintAndCutWizard
 
 


### PR DESCRIPTION
## Summary

The Print & Cut wizard crashed on launch for 4-axis machines (e.g. X/Y/Z/A with a rotary) with:

    ValueError: too many values to unpack (expected 3)

at `_update_laser_position` (`wizard.py:606`).

`Machine.get_current_position()` returns a variable-length `Pos` tuple (`tuple[float | None, ...]`, driver.py:138). The GRBL parser keeps a 4th axis value when the firmware reports one (e.g. `<Idle|MPos:-300.000,-50.000,0.000,0.000|...>`), so `work_pos` has four entries on such machines. The wizard assumed a fixed 3-tuple in two places and hard-unpacked it.

## Changes

- `_update_laser_position`: read only X/Y via indexing with a length check instead of unpacking a 3-tuple
- `_on_record_clicked`: same fix (would have crashed identically when recording a point)
- Add regression tests (`tests/ui_gtk/test_print_and_cut_wizard.py`) covering 3- and 4-value positions, invalid positions, and point recording

Fixes #394

## Testing

- `pytest tests/ui_gtk/test_print_and_cut_wizard.py -m ui` under xvfb: 8 passed
- `pytest tests/machine/models/test_machine.py tests/machine/driver/grbl/test_grbl_util.py`: 338 passed
- ruff format/check, flake8, pyflakes clean (one pre-existing pyflakes warning in the sketcher addon on main)