### PR TITLE
fix(grbl): display grblHAL bitmask settings instead of aborting read

### DIFF
--- a/rayforge/machine/driver/grbl/grbl_network.py
+++ b/rayforge/machine/driver/grbl/grbl_network.py
@@ -33,6 +33,7 @@ from .grbl_fingerprint import fingerprint_grbl_http
 from .grbl_probe import probe_grbl_device
 from .grbl_util import (
     CommandRequest,
+    apply_setting_to_varset,
     command_url,
     detect_unit_system_from_settings,
     eeprom_info_url,
@@ -760,7 +761,7 @@ class GrblNetworkDriver(Driver):
                 target_varset = key_to_varset_map.get(key)
                 if target_varset:
                     # Update the value in the correct VarSet
-                    target_varset[key] = value_str
+                    apply_setting_to_varset(target_varset, key, value_str)
                 else:
                     # This setting is not defined in our known VarSets
                     if unknown_vars.get(key) is None:

--- a/rayforge/machine/driver/grbl/grbl_serial.py
+++ b/rayforge/machine/driver/grbl/grbl_serial.py
@@ -49,6 +49,7 @@ from .grbl_probe import probe_grbl_device
 from .grbl_util import (
     CommandRequest,
     alarm_code_to_device_error,
+    apply_setting_to_varset,
     detect_unit_system_from_settings,
     error_code_to_device_error,
     extract_device_name_from_output,
@@ -1462,7 +1463,7 @@ class GrblSerialDriver(Driver):
                 target_varset = key_to_varset_map.get(key)
                 if target_varset:
                     # Update the value in the correct VarSet
-                    target_varset[key] = value_str
+                    apply_setting_to_varset(target_varset, key, value_str)
                 else:
                     # This setting is not defined in our known VarSets
                     unknown_vars.add(

--- a/rayforge/machine/driver/grbl/grbl_serial_simple.py
+++ b/rayforge/machine/driver/grbl/grbl_serial_simple.py
@@ -47,6 +47,7 @@ from ..driver import (
 from .grbl_probe import probe_grbl_device
 from .grbl_util import (
     alarm_code_to_device_error,
+    apply_setting_to_varset,
     detect_unit_system_from_settings,
     gcode_to_p_number,
     get_grbl_setting_varsets,
@@ -768,7 +769,7 @@ class GrblSerialSimpleDriver(Driver):
                 key, value_str = match.groups()
                 target_varset = key_to_varset_map.get(key)
                 if target_varset:
-                    target_varset[key] = value_str
+                    apply_setting_to_varset(target_varset, key, value_str)
                 else:
                     unknown_vars.add(
                         Var(

--- a/rayforge/machine/driver/grbl/grbl_util.py
+++ b/rayforge/machine/driver/grbl/grbl_util.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 from collections.abc import Callable
 from copy import copy, deepcopy
@@ -9,6 +10,8 @@ from typing import cast
 from ....core.varset import Var, VarSet
 from ....shared.units.system import UnitSystem, inches_to_mm
 from ..driver import DeviceError, DeviceState, DeviceStatus, Pos
+
+logger = logging.getLogger(__name__)
 
 # GRBL $13 setting key: "Report in inches" (boolean).
 GRBL_REPORT_INCHES_KEY = "13"
@@ -1137,14 +1140,14 @@ _STEPPER_CONFIG_VARS = [
     Var(
         key="4",
         label="$4",
-        var_type=bool,
-        description="Invert step enable pin, boolean",
+        var_type=int,
+        description="Invert step enable pins, mask",
     ),
     Var(
         key="5",
         label="$5",
-        var_type=bool,
-        description="Invert limit pins, boolean",
+        var_type=int,
+        description="Invert limit pins, mask",
     ),
     Var(
         key="6",
@@ -1411,3 +1414,27 @@ def get_grbl_setting_varsets() -> list["VarSet"]:
             ),
         ),
     ]
+
+
+def apply_setting_to_varset(varset: "VarSet", key: str, value_str: str):
+    """
+    Assigns a raw device value to the Var with *key* in *varset*.
+
+    If the value cannot be coerced to the Var's declared type (e.g. a
+    GrblHAL bitmask reported for a setting that classic Grbl defines
+    as a boolean), the Var is widened to a string type so the value
+    is still displayed instead of aborting the whole settings read.
+    """
+    var = varset[key]
+    try:
+        var.value = value_str
+    except (TypeError, ValueError) as e:
+        logger.warning(
+            "Setting $%s cannot be coerced to %s (%s); "
+            "displaying raw value instead.",
+            key,
+            var.var_type.__name__,
+            e,
+        )
+        var.var_type = str
+        var.value = value_str

--- a/tests/machine/driver/grbl/test_grbl_serial_driver.py
+++ b/tests/machine/driver/grbl/test_grbl_serial_driver.py
@@ -771,6 +771,40 @@ class TestGrblSerialDriver:
         assert unknown_varset["999"].value == "123"
 
     @pytest.mark.asyncio
+    async def test_read_settings_grblhal_mask_values(
+        self, connected_driver: GrblSerialDriver, mock_serial_transport
+    ):
+        """Regression test for #401: grblHAL reports $4/$5 as masks.
+
+        A mask value like 15 must be displayed instead of aborting
+        the whole settings read.
+        """
+        driver = connected_driver
+        settings_read_mock = MagicMock()
+        driver.settings_read.send = settings_read_mock
+
+        settings_response = b"$4=15\r\n$5=15\r\nok\r\n"
+        read_task = asyncio.create_task(driver.read_settings())
+
+        await asyncio.sleep(0.01)
+        mock_serial_transport.send.assert_called_with(b"$$\n")
+        driver.on_serial_data_received(
+            mock_serial_transport, settings_response
+        )
+        await read_task
+
+        settings_read_mock.assert_called_once()
+        settings = settings_read_mock.call_args.kwargs["settings"]
+
+        stepper_varset = next(
+            s
+            for s in settings
+            if "4" in s.keys()  # noqa: SIM118
+        )
+        assert stepper_varset["4"].value == 15
+        assert stepper_varset["5"].value == 15
+
+    @pytest.mark.asyncio
     async def test_set_wcs_offset(
         self, connected_driver: GrblSerialDriver, mock_serial_transport, mocker
     ):

--- a/tests/machine/driver/grbl/test_grbl_util.py
+++ b/tests/machine/driver/grbl/test_grbl_util.py
@@ -1,5 +1,6 @@
 import pytest
 
+from rayforge.core.varset import Var, VarSet
 from rayforge.machine.driver.driver import DeviceState, DeviceStatus
 from rayforge.machine.driver.grbl.grbl_util import (
     _parse_buffer_state,
@@ -9,9 +10,11 @@ from rayforge.machine.driver.grbl.grbl_util import (
     _parse_status_part,
     _recalculate_positions,
     _split_status_line,
+    apply_setting_to_varset,
     error_code_to_device_error,
     extract_device_name_from_output,
     gcode_to_p_number,
+    get_grbl_setting_varsets,
     is_grbl_output,
     is_report_in_inches,
     parse_grbl_parser_state,
@@ -858,3 +861,67 @@ class TestExtractDeviceNameFromOutput:
             == "Grbl 1.1f ['$' for help]"
         )
         assert extract_device_name_from_output(b"ok\r\nerror:1\r\n") is None
+
+
+class TestGrblHALMaskSettings:
+    """Regression tests for grblHAL bitmask settings (#401).
+
+    GrblHAL redefines $4 (step enable invert) and $5 (limit pins
+    invert) as per-axis masks, so values like 15 are legitimate.
+    Classic Grbl only reports 0/1, which coerce cleanly to int too.
+    """
+
+    def test_stepper_enable_var_is_int_mask(self):
+        varsets = get_grbl_setting_varsets()
+        var = next(v for vs in varsets for v in vs if v.key == "4")
+        assert var.var_type is int
+
+    def test_limit_pins_var_is_int_mask(self):
+        varsets = get_grbl_setting_varsets()
+        var = next(v for vs in varsets for v in vs if v.key == "5")
+        assert var.var_type is int
+
+    def test_mask_value_from_device_is_accepted(self):
+        varsets = get_grbl_setting_varsets()
+        stepper_varset = next(
+            vs
+            for vs in varsets
+            if "4" in vs.keys()  # noqa: SIM118
+        )
+        apply_setting_to_varset(stepper_varset, "4", "15")
+        assert stepper_varset["4"].value == 15
+        assert stepper_varset["4"].var_type is int
+
+    def test_boolean_value_still_coerces(self):
+        varsets = get_grbl_setting_varsets()
+        stepper_varset = next(
+            vs
+            for vs in varsets
+            if "4" in vs.keys()  # noqa: SIM118
+        )
+        apply_setting_to_varset(stepper_varset, "4", "1")
+        assert stepper_varset["4"].value == 1
+
+
+class TestApplySettingToVarset:
+    """Tests for the apply_setting_to_varset fallback behavior."""
+
+    def _make_varset(self, var_type) -> VarSet:
+        return VarSet(vars=[Var(key="42", label="$42", var_type=var_type)])
+
+    def test_assigns_coercible_value(self):
+        varset = self._make_varset(int)
+        apply_setting_to_varset(varset, "42", "7")
+        assert varset["42"].value == 7
+        assert varset["42"].var_type is int
+
+    def test_widens_to_str_on_incompatible_value(self):
+        varset = self._make_varset(bool)
+        apply_setting_to_varset(varset, "42", "15")
+        assert varset["42"].value == "15"
+        assert varset["42"].var_type is str
+
+    def test_raises_for_unknown_key(self):
+        varset = self._make_varset(int)
+        with pytest.raises(KeyError):
+            apply_setting_to_varset(varset, "99", "1")


### PR DESCRIPTION
## Summary

GrblHAL redefines `$4` (step enable invert) and `$5` (limit pins invert) as per-axis masks, so values like `15` (invert all 4 stepper enables) are legitimate. Rayforge declared these settings as booleans (classic Grbl semantics), so a settings read from a GrblHAL device raised:

```
TypeError: Value '15' for key '4' cannot be coerced to type bool
ERROR - Unhandled exception in managed task '(..., 'device-settings-read')
```

The exception aborted the entire `device-settings-read` task, so the device settings dialog never refreshed.

## Changes

- Model `$4` and `$5` as `int` masks instead of `bool`. Classic Grbl only reports 0/1, which coerce cleanly to int, and writing back preserves the mask instead of clobbering it with 0/1.
- Add `apply_setting_to_varset()` helper used by all three Grbl drivers (serial, serial-simple, network) when populating settings varsets. If a device value cannot be coerced to the declared type, the Var is widened to string so the raw value is displayed and a warning is logged, instead of killing the whole settings read.

Fixes #401

## Testing

- New regression test `test_read_settings_grblhal_mask_values` feeds a `$$` response with `$4=15` / `$5=15` through the real serial driver and asserts the values are displayed.
- New unit tests in `test_grbl_util.py` cover the mask vardefs and the coercion fallback.
- Ruff, flake8, pyflakes and pyright pass on the touched areas; all 249 grbl driver tests pass.